### PR TITLE
Refactoring of the configuration framework to allow autogeneration of config docs 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ import sys, os
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig',
-              'sphinx.ext.viewcode', 'sphinxarg.ext']
+              'sphinx.ext.viewcode', 'sphinxarg.ext', 'inmanta.sphinxext']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,0 +1,4 @@
+.. show-options::
+
+	inmanta.server.config
+	inmanta.agent.config

--- a/integration/integration.py
+++ b/integration/integration.py
@@ -21,6 +21,7 @@ from datetime import timedelta
 import dateutil.parser
 from time import sleep
 from shutil import rmtree
+from inmanta.config import TransportConfig
 
 
 LOGGER = logging.getLogger(__name__)
@@ -71,6 +72,7 @@ log-dir=%s/logs
 [server]
 fact-expire = 600
 fact-renew = 200
+no-recompile = true
 auto-recompile-wait = 10
 server_address= %s
 """ % (path, path, host))
@@ -117,6 +119,7 @@ class Connection(object):
 
     def __init__(self, server, auth=False, ssl=False):
         self.server = server
+        TransportConfig("autotest")
         Config.set("autotest_rest_transport", "host", self.server)
         Config.set("autotest_rest_transport", "port", "8888")
         Config.set("compiler_rest_transport", "host", self.server)
@@ -254,8 +257,9 @@ class Environment(object):
     def get_endpoints(self):
         result = yield self.connection._client.list_params(self.envid)
         result = unwrap(result)
+        print(result)
         reports = {x["name"]: x["value"]
-                   for x in result["parameters"] if x["metadata"] is not None and "type" in x["metadata"] and x["metadata"]["type"] == "report"}
+                   for x in result["parameters"] if "metadata" in x and x["metadata"] is not None and "type" in x["metadata"] and x["metadata"]["type"] == "report"}
         return reports
 
     @gen.coroutine
@@ -342,8 +346,11 @@ class Project(object):
 
         if env.ssl:
             args += ["--ssl", "--ssl-ca-cert", "/etc/pki/tls/certs/server.crt"]
-
-        subprocess.check_output(args, cwd=self.target, env=os.environ.copy())
+        try:
+            subprocess.check_output(args, cwd=self.target, env=os.environ.copy())
+        except CalledProcessError as e:
+            print(e.output)
+            raise e
 
     def export(self, env, logfile):
         Config.set("config", "environment", env.envid)
@@ -367,6 +374,10 @@ class Project(object):
         if env.ssl:
             args += ["--ssl", "--ssl-ca-cert", "/etc/pki/tls/certs/server.crt"]
 
-        out = subprocess.check_output(args, cwd=self.target, env=os.environ.copy(), stderr=subprocess.STDOUT)
-        out = out.decode("utf-8")
-        return re.search(r'Committed resources with version ([0-9]+)', out).group(1)
+        try:
+            out = subprocess.check_output(args, cwd=self.target, env=os.environ.copy(), stderr=subprocess.STDOUT)
+            out = out.decode("utf-8")
+            return re.search(r'Committed resources with version ([0-9]+)', out).group(1)
+        except CalledProcessError as e:
+            print(e.output.decode("utf-8"))
+            raise e

--- a/src/inmanta/agent/__init__.py
+++ b/src/inmanta/agent/__init__.py
@@ -17,12 +17,4 @@
 """
 
 # flake8: noqa: F401
-                self.cache.open_version(version)
-                provider.set_cache(self.cache)
-
-            finally:
-                self.cache.close_version(version)
-
-
-
 from inmanta.agent.agent import Agent

--- a/src/inmanta/agent/__init__.py
+++ b/src/inmanta/agent/__init__.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 
-from inmanta.agent.agent import Agent
+# flake8: noqa: F401
                 self.cache.open_version(version)
                 provider.set_cache(self.cache)
 
@@ -25,3 +25,4 @@ from inmanta.agent.agent import Agent
 
 
 
+from inmanta.agent.agent import Agent

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -1,0 +1,660 @@
+"""
+    Copyright 2016 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+import base64
+from concurrent.futures.thread import ThreadPoolExecutor
+import datetime
+import hashlib
+import logging
+import os
+import random
+
+
+from tornado import gen
+from inmanta import env
+from inmanta import methods
+from inmanta import protocol
+from inmanta.agent.handler import Commander
+from inmanta.config import Config
+from inmanta.loader import CodeLoader
+from inmanta.protocol import Scheduler, AgentEndPoint
+from inmanta.resources import Resource, Id
+from tornado.concurrent import Future
+from inmanta.agent.cache import AgentCache
+from inmanta.agent import config as cfg
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ResourceActionResult(object):
+
+    def __init__(self, success, reload, cancel):
+        self.success = success
+        self.reload = reload
+        self.cancel = cancel
+
+    def __add__(self, other):
+        return ResourceActionResult(self.success and other.success,
+                                    self.reload or other.reload,
+                                    self.cancel or other.cancel)
+
+    def __str__(self, *args, **kwargs):
+        return "%r %r %r" % (self.success, self.reload, self.cancel)
+
+
+class ResourceAction(object):
+
+    def __init__(self, scheduler, resource):
+        self.scheduler = scheduler
+        self.resource = resource
+        self.future = Future()
+        self.running = False
+
+    def is_running(self):
+        return self.running
+
+    def is_done(self):
+        return self.future.done()
+
+    def cancel(self):
+        if not self.is_running() and not self.is_done():
+            LOGGER.info("Cancelled deploy of %s", self.resource)
+            self.future.set_result(ResourceActionResult(False, False, True))
+
+    @gen.coroutine
+    def __complete(self, success, reload, changes={}, status="", log_msg=""):
+        action = "deploy"
+        if status == "skipped" or status == "dry" or status == "deployed":
+            level = "INFO"
+        else:
+            level = "ERROR"
+
+        yield self.scheduler.agent._client.resource_updated(tid=self.scheduler._env_id,
+                                                            id=str(self.resource.id),
+                                                            level=level,
+                                                            action=action,
+                                                            status=status,
+                                                            message="%s: %s" % (status, log_msg),
+                                                            extra_data=changes)
+
+        self.future.set_result(ResourceActionResult(success, reload, False))
+        LOGGER.info("end run %s" % self.resource)
+        self.running = False
+
+    @gen.coroutine
+    def execute(self, dummy, generation, cache):
+        cache.open_version(self.resource.version)
+
+        self.dependencies = [generation[x.resource_str()] for x in self.resource.requires]
+        waiters = [x.future for x in self.dependencies]
+        waiters.append(dummy.future)
+        results = yield waiters
+
+        LOGGER.info("run %s" % self.resource)
+        self.running = True
+        if self.is_done():
+            # Action is cancelled
+            self.running = False
+            return
+
+        result = sum(results, ResourceActionResult(True, False, False))
+
+        if result.cancel:
+            return
+
+        if not result.success:
+            self.__complete(False, False, changes={}, status="skipped")
+        else:
+            resource = self.resource
+
+            LOGGER.debug("Start deploy of resource %s" % resource)
+            provider = None
+
+            try:
+                provider = Commander.get_provider(self.scheduler.agent, resource)
+                provider.set_cache(cache)
+            except Exception:
+                provider.close()
+                cache.close_version(self.resource.version)
+                LOGGER.exception("Unable to find a handler for %s" % resource.id)
+                return self.__complete(False, False, changes={}, status="unavailable")
+
+            results = yield self.scheduler.agent.thread_pool.submit(provider.execute, resource)
+
+            status = results["status"]
+            if status == "failed" or status == "skipped":
+                provider.close()
+                cache.close_version(self.resource.version)
+                return self.__complete(False, False,
+                                       changes=results["changes"],
+                                       status=results["status"],
+                                       log_msg=results["log_msg"])
+
+            if result.reload and provider.can_reload():
+                LOGGER.warning("Reloading %s because of updated dependencies" % resource.id)
+                yield self.scheduler.agent.thread_pool.submit(provider.do_reload, resource)
+
+            provider.close()
+            cache.close_version(self.resource.version)
+
+            reload = results["changed"] and hasattr(resource, "reload") and resource.reload
+            return self.__complete(True, reload=reload, changes=results["changes"],
+                                   status=results["status"], log_msg=results["log_msg"])
+
+            LOGGER.debug("Finished %s" % resource)
+
+    def __str__(self, *args, **kwargs):
+        if self.resource is None:
+            return "DUMMY"
+
+        status = ""
+        if self.is_done():
+            status = "Done"
+        elif self.is_running():
+            status = "Running"
+
+        return self.resource.id.resource_str() + status
+
+    def long_string(self):
+        return "%s awaits %s" % (self.resource.id.resource_str(), " ".join([str(aw) for aw in self.dependencies]))
+
+
+class ResourceScheduler(object):
+
+    def __init__(self, agent, env_id):
+        self.generation = {}
+        self._env_id = env_id
+        self.agent = agent
+
+    def reload(self, resources):
+        for ra in self.generation.values():
+            ra.cancel()
+        self.generation = {r.id.resource_str(): ResourceAction(self, r) for r in resources}
+        dummy = ResourceAction(self, None)
+        for r in self.generation.values():
+            r.execute(dummy, self.generation, self.agent.cache)
+        dummy.future.set_result(ResourceActionResult(True, False, False))
+
+    def dump(self):
+        print("Waiting:")
+        for r in self.generation.values():
+            print(r.long_string())
+        print("Ready to run:")
+        for r in self.queue:
+            print(r.long_string())
+
+
+class Agent(AgentEndPoint):
+    """
+        An agent to enact changes upon resources. This agent listens to the
+        message bus for changes.
+    """
+
+    def __init__(self, io_loop, hostname=None, agent_map=None, code_loader=True, env_id=None, poolsize=1):
+        super().__init__("agent", io_loop, cfg.heartbeat.get())
+
+        if agent_map is None:
+            agent_map = cfg.agent_map.get()
+
+        self.agent_map = agent_map
+        self._storage = self.check_storage()
+
+        self._last_update = 0
+
+        if env_id is None:
+            env_id = cfg.environment.get()
+            if env_id is None:
+                raise Exception("The agent requires an environment to be set.")
+        self.set_environment(env_id)
+        self._nq = ResourceScheduler(self, env_id)
+
+        if code_loader:
+            self._env = env.VirtualEnv(self._storage["env"])
+            self._env.use_virtual_env()
+            self._loader = CodeLoader(self._storage["code"])
+        else:
+            self._loader = None
+
+        if hostname is not None:
+            self.add_end_point_name(hostname)
+
+        else:
+            # load agent names from the config file
+            agent_names = cfg.agent_names.get()
+            if agent_names is not None:
+                names = [x.strip() for x in agent_names.split(",")]
+                for name in names:
+                    if "$" in name:
+                        name = name.replace("$node-name", self.node_name)
+
+                    self.add_end_point_name(name)
+
+        # do regular deploys
+        self._deploy_interval = cfg.agent_interval.get()
+        self._splay_interval = cfg.agent_splay.get()
+        self._splay_value = random.randint(0, self._splay_interval)
+
+        self.latest_version = 0
+        self.latest_code_version = 0
+
+        self._sched = Scheduler(io_loop=self._io_loop)
+        if self._splay_interval > 0 and cfg.agent_antisplay.get():
+            self._io_loop.add_callback(self.get_latest_version)
+        self._sched.add_action(self.get_latest_version, self._deploy_interval, self._splay_value)
+
+        self.thread_pool = ThreadPoolExecutor(poolsize)
+
+        self.cache = AgentCache()
+
+    def is_local(self, agent_name):
+        """
+            Check if the given agent name is a local or a remote agent
+        """
+        return self._client.node_name == agent_name or agent_name == "localhost"
+
+    @gen.coroutine
+    def get_latest_version(self):
+        """
+            Get the latest version of managed resources for all agents
+        """
+        for agent in self.end_point_names:
+            yield self.get_latest_version_for_agent(agent)
+
+    @gen.coroutine
+    def _ensure_code(self, environment, version, resourcetypes):
+        """
+            Ensure that the code for the given environment and version is loaded
+        """
+        if self._loader is not None:
+            for rt in resourcetypes:
+                result = yield self._client.get_code(environment, version, rt)
+
+                if result.code == 200:
+                    for key, source in result.result["sources"].items():
+                        try:
+                            LOGGER.debug("Installing handler %s for %s", rt, source[1])
+                            yield self._install(key, source)
+                            LOGGER.debug("Installed handler %s for %s", rt, source[1])
+                        except Exception:
+                            LOGGER.exception("Failed to install handler %s for %s", rt, source[1])
+
+    @gen.coroutine
+    def _install(self, key, source):
+        yield self.thread_pool.submit(self._env.install_from_list, source[3], True)
+        yield self.thread_pool.submit(self._loader.deploy_version, key, source)
+
+    @protocol.handle(methods.NodeMethod.trigger_agent)
+    @gen.coroutine
+    def trigger_update(self, tid, id):
+        """
+            Trigger an update
+        """
+        if id not in self.end_point_names:
+            return 200
+
+        LOGGER.info("Agent %s got a trigger to update in environment %s", id, tid)
+        future = self.get_latest_version_for_agent(id)
+        self.add_future(future)
+        return 200
+
+    @gen.coroutine
+    def get_latest_version_for_agent(self, agent):
+        """
+            Get the latest version for the given agent (this is also how we are notified)
+        """
+        if agent not in self.end_point_names:
+            return 200
+
+        LOGGER.debug("Getting latest resources for %s" % agent)
+        result = yield self._client.get_resources_for_agent(tid=self._env_id, agent=agent)
+        if result.code == 404:
+            LOGGER.info("No released configuration model version available for agent %s", agent)
+        elif result.code != 200:
+            LOGGER.warning("Got an error while pulling resources for agent %s", agent)
+
+        else:
+            restypes = set([res["id_fields"]["entity_type"] for res in result.result["resources"]])
+            resources = []
+            yield self._ensure_code(self._env_id, result.result["version"], restypes)
+            try:
+                for res in result.result["resources"]:
+                    data = res["fields"]
+                    data["id"] = res["id"]
+                    resource = Resource.deserialize(data)
+                    resources.append(resource)
+                    LOGGER.debug("Received update for %s", resource.id)
+            except TypeError as e:
+                LOGGER.error("Failed to receive update", e)
+
+            self._nq.reload(resources)
+
+    @protocol.handle(methods.AgentDryRun.do_dryrun)
+    @gen.coroutine
+    def run_dryrun(self, tid, id, agent, version):
+        """
+           Run a dryrun of the given version
+        """
+        if agent not in self.end_point_names:
+            return 200
+
+        LOGGER.info("Agent %s got a trigger to run dryrun %s for version %s in environment %s", agent, id, version, tid)
+        assert tid == self._env_id
+
+        result = yield self._client.get_resources_for_agent(tid=self._env_id, agent=agent, version=version)
+        if result.code == 404:
+            LOGGER.info("Version %s does not exist", version)
+            return 404
+
+        elif result.code != 200:
+            LOGGER.warning("Got an error while pulling resources for agent %s and version %s", agent, version)
+            return 500
+
+        restypes = set([res["id_fields"]["entity_type"] for res in result.result["resources"]])
+
+        yield self._ensure_code(self._env_id, version, restypes)  # TODO: handle different versions for dryrun and deploy!
+
+        self.cache.open_version(version)
+
+        for res in result.result["resources"]:
+            provider = None
+            try:
+                data = res["fields"]
+                data["id"] = res["id"]
+                resource = Resource.deserialize(data)
+                LOGGER.debug("Running dryrun for %s", resource.id)
+
+                try:
+                    provider = Commander.get_provider(self, resource)
+                    provider.set_cache(self.cache)
+                except Exception:
+                    LOGGER.exception("Unable to find a handler for %s" % resource.id)
+                    self._client.dryrun_update(tid=self._env_id, id=id, resource=res["id"],
+                                               changes={}, log_msg="No handler available")
+                    continue
+
+                results = yield self.thread_pool.submit(provider.execute, resource, dry_run=True)
+                yield self._client.dryrun_update(tid=self._env_id, id=id, resource=res["id"],
+                                                 changes=results["changes"], log_msg=results["log_msg"])
+
+            except TypeError:
+                LOGGER.exception("Unable to process resource for dryrun.")
+                return 500
+            finally:
+                if provider is not None:
+                    provider.close()
+
+        self.cache.close_version(version)
+
+        return 200
+
+    def get_agent_hostname(self, agent_name):
+        """
+            Convert the agent name to a hostname using the agent map
+        """
+        if agent_name in self.agent_map:
+            return self.agent_map[agent_name]
+
+        return agent_name
+
+    def check_storage(self):
+        """
+            Check if the server storage is configured and ready to use.
+        """
+
+        state_dir = cfg.state_dir.get()
+
+        if not os.path.exists(state_dir):
+            os.mkdir(state_dir)
+
+        agent_state_dir = os.path.join(state_dir, "agent")
+
+        if not os.path.exists(agent_state_dir):
+            os.mkdir(agent_state_dir)
+
+        dir_map = {"agent": agent_state_dir}
+
+        code_dir = os.path.join(agent_state_dir, "code")
+        dir_map["code"] = code_dir
+        if not os.path.exists(code_dir):
+            os.mkdir(code_dir)
+
+        env_dir = os.path.join(agent_state_dir, "env")
+        dir_map["env"] = env_dir
+        if not os.path.exists(env_dir):
+            os.mkdir(env_dir)
+
+        return dir_map
+
+    @protocol.handle(methods.AgentRestore.do_restore)
+    @gen.coroutine
+    def do_restore(self, tid, agent, restore_id, snapshot_id, resources):
+        """
+            Restore a snapshot
+        """
+        if agent not in self.end_point_names:
+            return 200
+
+        LOGGER.info("Start a restore %s", restore_id)
+
+        yield self._ensure_code(tid, resources[0][1]["id_fields"]["version"],
+                                [res[1]["id_fields"]["entity_type"] for res in resources])
+
+        version = resources[0][1]["id_fields"]["version"]
+        self.cache.open_version(version)
+
+        for restore, resource in resources:
+            start = datetime.datetime.now()
+            provider = None
+            try:
+                data = resource["fields"]
+                data["id"] = resource["id"]
+                resource_obj = Resource.deserialize(data)
+                provider = Commander.get_provider(self, resource_obj)
+                provider.set_cache(self.cache)
+
+                if not hasattr(resource_obj, "allow_restore") or not resource_obj.allow_restore:
+                    yield self._client.update_restore(tid=tid, id=restore_id, resource_id=str(resource_obj.id),
+                                                      start=start, stop=datetime.datetime.now(), success=False, error=False,
+                                                      msg="Resource %s does not allow restore" % resource["id"])
+                    continue
+
+                try:
+                    yield self.thread_pool.submit(provider.restore, resource_obj, restore["content_hash"])
+                    yield self._client.update_restore(tid=tid, id=restore_id,
+                                                      resource_id=str(resource_obj.id), success=True, error=False,
+                                                      start=start, stop=datetime.datetime.now(), msg="")
+                except NotImplementedError:
+                    yield self._client.update_restore(tid=tid, id=restore_id,
+                                                      resource_id=str(resource_obj.id), success=False, error=False,
+                                                      start=start, stop=datetime.datetime.now(),
+                                                      msg="The handler for resource "
+                                                      "%s does not support restores" % resource["id"])
+
+            except Exception:
+                LOGGER.exception("Unable to find a handler for %s", resource["id"])
+                yield self._client.update_restore(tid=tid, id=restore_id, resource_id=resource_obj.id.resource_str(),
+                                                  success=False, error=False, start=start, stop=datetime.datetime.now(),
+                                                  msg="Unable to find a handler to restore a snapshot of resource %s" %
+                                                  resource["id"])
+            finally:
+                if provider is not None:
+                    provider.close()
+        self.cache.close_version(version)
+
+        return 200
+
+    @protocol.handle(methods.AgentSnapshot.do_snapshot)
+    @gen.coroutine
+    def do_snapshot(self, tid, agent, snapshot_id, resources):
+        """
+            Create a snapshot of stateful resources managed by this agent
+        """
+        if agent not in self.end_point_names:
+            return 200
+
+        LOGGER.info("Start snapshot %s", snapshot_id)
+
+        yield self._ensure_code(tid, resources[0]["id_fields"]["version"],
+                                [res["id_fields"]["entity_type"] for res in resources])
+
+        version = resources[0]["id_fields"]["version"]
+        self.cache.open_version(version)
+
+        for resource in resources:
+            start = datetime.datetime.now()
+            provider = None
+            try:
+                data = resource["fields"]
+                data["id"] = resource["id"]
+                resource_obj = Resource.deserialize(data)
+                provider = Commander.get_provider(self, resource_obj)
+                provider.set_cache(self.cache)
+
+                if not hasattr(resource_obj, "allow_snapshot") or not resource_obj.allow_snapshot:
+                    yield self._client.update_snapshot(tid=tid, id=snapshot_id,
+                                                       resource_id=resource_obj.id.resource_str(), snapshot_data="",
+                                                       start=start, stop=datetime.datetime.now(), size=0,
+                                                       success=False, error=False,
+                                                       msg="Resource %s does not allow snapshots" % resource["id"])
+                    continue
+
+                try:
+                    result = yield self.thread_pool.submit(provider.snapshot, resource_obj)
+                    if result is not None:
+                        sha1sum = hashlib.sha1()
+                        sha1sum.update(result)
+                        content_id = sha1sum.hexdigest()
+                        yield self._client.upload_file(id=content_id, content=base64.b64encode(result).decode("ascii"))
+
+                        yield self._client.update_snapshot(tid=tid, id=snapshot_id,
+                                                           resource_id=resource_obj.id.resource_str(),
+                                                           snapshot_data=content_id, start=start, stop=datetime.datetime.now(),
+                                                           size=len(result), success=True, error=False,
+                                                           msg="")
+                    else:
+                        raise Exception("Snapshot returned no data")
+
+                except NotImplementedError:
+                    yield self._client.update_snapshot(tid=tid, id=snapshot_id, error=False,
+                                                       resource_id=resource_obj.id.resource_str(), snapshot_data="",
+                                                       start=start, stop=datetime.datetime.now(), size=0, success=False,
+                                                       msg="The handler for resource "
+                                                       "%s does not support snapshots" % resource["id"])
+                except Exception:
+                    LOGGER.exception("An exception occurred while creating the snapshot of %s", resource["id"])
+                    yield self._client.update_snapshot(tid=tid, id=snapshot_id, snapshot_data="",
+                                                       resource_id=resource_obj.id.resource_str(), error=True,
+                                                       start=start, stop=datetime.datetime.now(), size=0, success=False,
+                                                       msg="The handler for resource "
+                                                       "%s does not support snapshots" % resource["id"])
+
+            except Exception:
+                LOGGER.exception("Unable to find a handler for %s", resource["id"])
+                yield self._client.update_snapshot(tid=tid, id=snapshot_id, snapshot_data="",
+                                                   resource_id=resource_obj.id.resource_str(), error=False,
+                                                   start=start, stop=datetime.datetime.now(), size=0, success=False,
+                                                   msg="Unable to find a handler for %s" % resource["id"])
+            finally:
+                if provider is not None:
+                    provider.close()
+
+        self.cache.close_version(version)
+        return 200
+
+    def status(self, operation, body):
+        if "id" not in body:
+            return 500
+
+        if operation is None:
+            id = Id.parse_id(body["id"])
+            resource = id.get_instance()
+
+            if resource is None:
+                return 500
+
+            version = id.get_version()
+            self.cache.open_version(version)
+
+            try:
+                provider = Commander.get_provider(self, resource)
+                provider.set_cache(self.cache)
+            except Exception:
+                LOGGER.exception("Unable to find a handler for %s" % resource)
+                return 500
+
+            try:
+                result = yield self.thread_pool.submit(provider.check_resource, resource)
+                return 200, result
+            except Exception:
+                LOGGER.exception("Unable to check status of %s" % resource)
+                return 500
+
+            self.cache.close_version(version)
+
+        else:
+            return 501
+
+    @protocol.handle(methods.AgentParameterMethod.get_parameter)
+    @gen.coroutine
+    def get_facts(self, tid, agent, resource):
+        if agent not in self.end_point_names:
+            return 200
+
+        provider = None
+        try:
+            data = resource["fields"]
+            data["id"] = resource["id"]
+            resource_obj = Resource.deserialize(data)
+
+            version = resource_obj.version
+            self.cache.open_version(version)
+
+            provider = Commander.get_provider(self, resource_obj)
+            provider.set_cache(self.cache)
+
+            try:
+                result = yield self.thread_pool.submit(provider.check_facts, resource_obj)
+                parameters = [{"id": name, "value": value, "resource_id": resource_obj.id.resource_str(), "source": "fact"}
+                              for name, value in result.items()]
+                yield self._client.set_parameters(tid=tid, parameters=parameters)
+
+            except Exception:
+                LOGGER.exception("Unable to retrieve fact")
+
+        except Exception:
+            LOGGER.exception("Unable to find a handler for %s", resource["id"])
+            return 500
+        finally:
+            if provider is not None:
+                provider.close()
+            self.cache.close_version(version)
+        return 200
+
+    def queue(self, operation, body):
+        """
+            Return the current items in the queue
+        """
+        return 200, {"queue": ["%s" % (x.id) for x in self._nq.generation.values()]}
+
+    def info(self, operation, body):
+        """
+            Return statistics about this agent
+        """
+        return 200, {"threads": [x.name for x in enumerate()],
+                     "queue length": self._queue.size(),
+                     "queue ready length": self._queue.ready_size()}

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -30,7 +30,6 @@ from inmanta import env
 from inmanta import methods
 from inmanta import protocol
 from inmanta.agent.handler import Commander
-from inmanta.config import Config
 from inmanta.loader import CodeLoader
 from inmanta.protocol import Scheduler, AgentEndPoint
 from inmanta.resources import Resource, Id

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -21,6 +21,7 @@ import logging
 
 LOGGER = logging.getLogger(__name__)
 
+# flake8: noqa: H904
 
 python_binary = \
     Option("config", "python_binary", "python",

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -18,7 +18,6 @@
 
 from inmanta.config import *
 import logging
-from inmanta.protocol import TransportConfig
 
 LOGGER = logging.getLogger(__name__)
 
@@ -64,7 +63,7 @@ agent_antisplay = \
 
 heartbeat = \
     Option("config", "heartbeat-interval", 10,
-           "Interval between subsequent heartbeats towards the server, lower number reduces load in the server", is_int)
+           "Interval between subsequent heartbeats towards the server, lower number reduces load in the server", is_time)
 
 
 ##############################

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -18,6 +18,7 @@
 
 from inmanta.config import *
 import logging
+from inmanta.protocol import TransportConfig
 
 LOGGER = logging.getLogger(__name__)
 
@@ -52,7 +53,7 @@ agent_splay = \
     Option("config", "agent-splay", 600,
                      """The splaytime added to the runinterval.
 Set this to 0 to disable splaytime.
-     
+
 At startup the agent will choose a random number between 0 and "agent_splay.
 It will wait this number of second before performing the first deploy.
 Each subsequent deploy will start agent-interval seconds after the previous one.""", is_time)
@@ -60,6 +61,10 @@ Each subsequent deploy will start agent-interval seconds after the previous one.
 agent_antisplay = \
     Option("config", "agent-run-at-start", False,
            "run the agent at startup, even if a splay time is set", is_bool)
+
+heartbeat = \
+    Option("config", "heartbeat-interval", 10,
+           "Interval between subsequent heartbeats towards the server, lower number reduces load in the server", is_int)
 
 
 ##############################

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -1,0 +1,68 @@
+"""
+    Copyright 2016 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+from inmanta.config import *
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+python_binary = \
+    Option("config", "python_binary", "python",
+           "Python binary used to run the remote agent")
+
+agent_map = \
+    Option("config", "agent-map", None,
+           """mapping between agent names and host names.
+    If an agent is autostarted, its hostname is looked up in this map.
+    If it is not found, the agent name is used as hostname.
+    If the hostname is not localhost or :inmanta.config:option:`config.node-name`, ssh is used to start the agent on the appropriate machine
+    
+    example: iaas_openstack=localhost,vm1=192.16.13.2""", is_map)
+
+environment = \
+    Option("config", "environment", None,
+           "The environment this agent or compile belongs to", is_uuid_opt)
+
+agent_names = \
+    Option("config", "agent-names", "$node-name",
+           "Names of the agents this instance should deploy configuration for", is_str)
+
+agent_interval = \
+    Option("config", "agent-interval", 600, """The run interval of the agent.
+Every run-interval seconds, the agent will check the current state of its resources against to desired state model""", is_time)
+
+agent_splay = \
+    Option("config", "agent-splay", 600,
+                     """The splaytime added to the runinterval.
+Set this to 0 to disable splaytime.
+     
+At startup the agent will choose a random number between 0 and "agent_splay.
+It will wait this number of second before performing the first deploy.
+Each subsequent deploy will start agent-interval seconds after the previous one.""", is_time)
+
+agent_antisplay = \
+    Option("config", "agent-run-at-start", False,
+           "run the agent at startup, even if a splay time is set", is_bool)
+
+
+##############################
+# agent_rest_transport
+##############################
+
+agent_transport = TransportConfig("agent")

--- a/src/inmanta/agent/io/remote.py
+++ b/src/inmanta/agent/io/remote.py
@@ -19,18 +19,19 @@
 from execnet import multi, gateway_bootstrap
 from . import local
 from inmanta import resources
-from inmanta import config
+from inmanta.agent import config as cfg
 
 
 class RemoteIO(object):
     """
         This class provides handler IO methods
     """
+
     def is_remote(self):
         return True
 
     def __init__(self, host):
-        python_path = config.Config.get("config", "python_binary", "python")
+        python_path = cfg.python_binary.get()
         try:
             self._gw = multi.makegateway("ssh=root@%s//python=%s" % (host, python_path))
         except (gateway_bootstrap.HostNotFound, BrokenPipeError) as e:

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -97,7 +97,7 @@ def compile_project(options):
         Config.set("compiler_rest_transport", "ssl", "true")
 
     if options.ca_cert is not None:
-        Config.set("compiler_rest_transport", "ssl_ca_cert_file", options.ca_cert)
+        Config.set("compiler_rest_transport", "ssl-ca-cert-file", options.ca_cert)
 
     if options.profile:
         import cProfile
@@ -165,7 +165,7 @@ def export(options):
         Config.set("compiler_rest_transport", "ssl", "true")
 
     if options.ca_cert is not None:
-        Config.set("compiler_rest_transport", "ssl_ca_cert_file", options.ca_cert)
+        Config.set("compiler_rest_transport", "ssl-ca-cert-file", options.ca_cert)
 
     from inmanta.export import Exporter
 

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -28,6 +28,7 @@ from inmanta.config import Config
 from inmanta.module import ModuleTool
 from tornado.ioloop import IOLoop
 from inmanta import protocol
+from inmanta.export import cfg_env
 
 LOGGER = logging.getLogger()
 
@@ -185,7 +186,7 @@ def export(options):
     if options.deploy:
         conn = protocol.Client("compiler")
         LOGGER.info("Triggering deploy for version %d" % version)
-        tid = Config.get("config", "environment", None)
+        tid = cfg_env.get()
         IOLoop.current().run_sync(lambda: conn.release_version(tid, version, True), 60)
 
 

--- a/src/inmanta/ast/statements/call.py
+++ b/src/inmanta/ast/statements/call.py
@@ -111,7 +111,6 @@ class FunctionUnit(Waiter):
         except RuntimeException as e:
             e.set_statement(self.function)
             raise e
-        
 
     def __repr__(self):
         return repr(self.function)

--- a/src/inmanta/ast/statements/call.py
+++ b/src/inmanta/ast/statements/call.py
@@ -104,13 +104,14 @@ class FunctionUnit(Waiter):
         requires = {k: v.get_value() for (k, v) in self.requires.items()}
         try:
             self.function.resume(requires, self.resolver, self.queue_scheduler, self.result)
+            self.done = True
         except UnsetException as e:
             LOGGER.debug("Unset value in python code in plugin %s." % self.function.function)
             self.await(e.get_result_variable())
         except RuntimeException as e:
             e.set_statement(self.function)
             raise e
-        self.done = True
+        
 
     def __repr__(self):
         return repr(self.function)

--- a/src/inmanta/client.py
+++ b/src/inmanta/client.py
@@ -27,7 +27,7 @@ from inmanta import protocol
 from cliff.lister import Lister
 from cliff.show import ShowOne
 from cliff.command import Command
-from inmanta.config import Config
+from inmanta.config import Config, cmdline_rest_transport
 from blessings import Terminal
 from tornado.ioloop import IOLoop
 
@@ -51,9 +51,9 @@ class InmantaCommand(Command):
         Config.load_config()
 
         parser.add_argument("--host", dest="host", help="The server hostname to connect to (default: localhost)",
-                            default=Config.get("cmdline_rest_transport", "host", "localhost"))
+                            default=cmdline_rest_transport.host.get())
         parser.add_argument("--port", dest="port", help="The server port to connect to (default: 8888)",
-                            default=int(Config.get("cmdline_rest_transport", "port", 8888)), type=int)
+                            default=cmdline_rest_transport.port.get(), type=int)
         parser = self.parser_config(parser)
         return parser
 
@@ -68,8 +68,8 @@ class InmantaCommand(Command):
             Do a request and return the response
         """
         type(self).log.debug("Calling method %s on server %s:%s with arguments %s" %
-                             (method_name, Config.get("cmdline_rest_transport", "host"),
-                              Config.get("cmdline_rest_transport", "port"), arguments))
+                             (method_name, cmdline_rest_transport.host.get(),
+                              cmdline_rest_transport.port.get(), arguments))
 
         if not hasattr(self._client, method_name):
             raise Exception("API call %s is not available." % method_name)

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -18,10 +18,20 @@
 
 from configparser import ConfigParser, Interpolation
 import os
+import logging
+from _collections import defaultdict
+import uuid
+
+LOGGER = logging.getLogger(__name__)
 
 
 class Config(object):
     __instance = None
+    __config_definition = defaultdict(lambda: {})
+
+    @classmethod
+    def get_config_options(cls):
+        return cls.__config_definition
 
     @classmethod
     def load_config(cls, config_file=None):
@@ -51,17 +61,23 @@ class Config(object):
         """
             Get the entire compiler or get a value directly
         """
+        opt = cls.validate_option_request(section, name, default_value)
+
         cfg = cls._get_instance()
         if section is None:
             return cfg
 
-        return cfg.get(section, name, fallback=default_value)
+        val = cfg.get(section, name, fallback=default_value)
+        if not opt:
+            return val
+        return opt.validate(val)
 
     @classmethod
     def getboolean(cls, section, name, default_value=None):
         """
             Return a boolean from the configuration
         """
+        cls.validate_option_request(section, name, default_value)
         return cls._get_instance().getboolean(section, name, fallback=default_value)
 
     @classmethod
@@ -72,3 +88,160 @@ class Config(object):
         if section not in cls._get_instance():
             cls._get_instance().add_section(section)
         cls._get_instance().set(section, name, value)
+
+    @classmethod
+    def register_option(cls, option):
+        cls.__config_definition[option.section][option.name] = option
+
+    @classmethod
+    def validate_option_request(cls, section, name, default_value):
+        if section not in cls.__config_definition:
+            LOGGER.warn("Config section %s not defined" % (section))
+            #raise Exception("Config section %s not defined" % (section))
+            return
+        if name not in cls.__config_definition[section]:
+            LOGGER.warn("Config name %s not defined in section %s" % (name, section))
+            #raise Exception("Config name %s not defined in section %s" % (name, section))
+            return
+        opt = cls.__config_definition[section][name]
+        if not opt.get_default_value() == default_value:
+            LOGGER.warn("Inconsistent default value for option %s.%s: defined as %s, got %s" %
+                        (section, name, opt.default, default_value))
+
+        return opt
+
+
+def is_int(value):
+    """int"""
+    return int(value)
+
+
+def is_time(value):
+    """time"""
+    return int(value)
+
+
+def is_bool(value):
+    """bool"""
+    return Config._get_instance()._convert_to_boolean(value)
+
+
+def is_list(value):
+    """list"""
+    return value.split(",")
+
+
+def is_map(map_in):
+    """map"""
+    map_out = {}
+    if map_in is not None:
+        mappings = map_in.split(",")
+
+        for mapping in mappings:
+            parts = mapping.strip().split("=")
+            if len(parts) == 2:
+                key = parts[0].strip()
+                value = parts[1].strip()
+                if key != "" and value != "":
+                    map_out[key] = value
+
+    return map_out
+
+
+def is_str(value):
+    """str"""
+    return str(value)
+
+
+def is_str_opt(value):
+    """optional str"""
+    if value is None:
+        return None
+    return str(value)
+
+
+def is_uuid_opt(value):
+    """optional uuid"""
+    if value is None:
+        return None
+    return uuid.UUID(value)
+
+
+class Option(object):
+
+    def __init__(self, section, name, default, documentation, validator=is_str):
+        self.section = section
+        self.name = name
+        self.validator = validator
+        self.documentation = documentation
+        self.default = default
+        Config.register_option(self)
+
+    def get(self):
+        cfg = Config._get_instance()
+        out = cfg.get(self.section, self.name,  fallback=str(self.get_default_value()))
+        return self.validate(out)
+
+    def get_type(self):
+        if callable(self.validator):
+            return self.validator.__doc__
+        return None
+
+    def get_default_desc(self):
+        defa = self.default
+        if callable(defa):
+            return "$%s" % defa.__doc__
+        else:
+            return defa
+
+    def validate(self, value):
+        return self.validator(value)
+
+    def get_default_value(self):
+        defa = self.default
+        if callable(defa):
+            return defa()
+        else:
+            return defa
+
+#############################
+# Config
+#############################
+
+state_dir = \
+    Option("config", "state_dir", "/var/lib/inmanta",
+           "The directory where the server stores its state")
+
+log_dir = \
+    Option("config", "log_dir", "/var/log/inmanta",
+           "The directory where the server stores log file. Currently this is only for the output of embedded agents.")
+
+heartbeat = \
+    Option("config", "heartbeat-interval", 10,
+           "Interval between subsequent heartbeats towards the server, lower number reduces load in the server", is_int)
+
+
+def get_default_nodename():
+    """ socket.gethostname() """
+    import socket
+    return socket.gethostname()
+
+nodename = \
+    Option("config", "node-name", get_default_nodename, "Force the hostname of this machine to a specific value", is_str)
+
+###############################
+# Transport Config
+###############################
+
+
+class TransportConfig(object):
+
+    def __init__(self, name):
+        self.prefix = "%s_rest_transport" % name
+        self.host = Option(self.prefix, "host", "localhost", "IP address or hostname of the server", is_str)
+        self.port = Option(self.prefix, "port", 8888, "Server port", is_int)
+        self.ssl = Option(self.prefix, "ssl", False, "Connect using SSL?", is_bool)
+        self.ssl_ca_cert_file = Option(
+            self.prefix, "ssl_ca_cert_file", None, "CA cert file used to validate the server certificate against", is_str_opt)
+
+TransportConfig("compiler")

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -168,6 +168,23 @@ def is_uuid_opt(value):
 
 
 class Option(object):
+    """
+    Defines an option and exposes it for use
+
+    All config option should be define prior to use
+    For the document generator to work properly, they should be defined at the module level.
+
+    :param section: section in the config file
+    :param name: name of the option
+    :param default: default value for this option
+        the default value is either a value or a function.
+        If it is a value, `str(default)` will be used a default value.
+        If it is a function, its doc string will be used to represent the value in documentation.
+        and its return value as the actual default value
+    :param documentation: the documentation for this option
+    :param validator: a function responsible for turning the string representation of the option into the correct type. 
+        Its docstring is used as representation for the type of the option.
+    """
 
     def __init__(self, section, name, default, documentation, validator=is_str):
         self.section = section
@@ -206,6 +223,8 @@ class Option(object):
 
 #############################
 # Config
+#
+# Global config options are defined here
 #############################
 # flake8: noqa: H904
 state_dir = \
@@ -216,10 +235,6 @@ log_dir = \
     Option("config", "log_dir", "/var/log/inmanta",
            "The directory where the server stores log file. Currently this is only for the output of embedded agents.")
 
-heartbeat = \
-    Option("config", "heartbeat-interval", 10,
-           "Interval between subsequent heartbeats towards the server, lower number reduces load in the server", is_int)
-
 
 def get_default_nodename():
     """ socket.gethostname() """
@@ -228,25 +243,3 @@ def get_default_nodename():
 
 nodename = \
     Option("config", "node-name", get_default_nodename, "Force the hostname of this machine to a specific value", is_str)
-
-###############################
-# Transport Config
-###############################
-
-
-class TransportConfig(object):
-
-    def __init__(self, name):
-        self.prefix = "%s_rest_transport" % name
-        self.host = Option(self.prefix, "host", "localhost", "IP address or hostname of the server", is_str)
-        self.port = Option(self.prefix, "port", 8888, "Server port", is_int)
-        self.ssl = Option(self.prefix, "ssl", False, "Connect using SSL?", is_bool)
-        self.ssl_ca_cert_file = Option(
-            self.prefix, "ssl_ca_cert_file", None, "CA cert file used to validate the server certificate against", is_str_opt)
-        self.password = Option(
-            self.prefix, "password", None, "Password used to connect to the server", is_str_opt)
-        self.username = Option(
-            self.prefix, "username", None, "Username used to connect to the server", is_str_opt)
-
-TransportConfig("compiler")
-TransportConfig("client")

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -25,6 +25,10 @@ import uuid
 LOGGER = logging.getLogger(__name__)
 
 
+def _normalize_name(name: str):
+    return name.replace("_", "-")
+
+
 class Config(object):
     __instance = None
     __config_definition = defaultdict(lambda: {})
@@ -64,6 +68,7 @@ class Config(object):
         cfg = cls._get_instance()
         if section is None:
             return cfg
+        name = _normalize_name(name)
 
         opt = cls.validate_option_request(section, name, default_value)
 
@@ -85,6 +90,8 @@ class Config(object):
         """
             Override a value
         """
+        name = _normalize_name(name)
+
         if section not in cls._get_instance():
             cls._get_instance().add_section(section)
         cls._get_instance().set(section, name, value)
@@ -182,13 +189,13 @@ class Option(object):
         If it is a function, its doc string will be used to represent the value in documentation.
         and its return value as the actual default value
     :param documentation: the documentation for this option
-    :param validator: a function responsible for turning the string representation of the option into the correct type. 
+    :param validator: a function responsible for turning the string representation of the option into the correct type.
         Its docstring is used as representation for the type of the option.
     """
 
     def __init__(self, section, name, default, documentation, validator=is_str):
         self.section = section
-        self.name = name
+        self.name = _normalize_name(name)
         self.validator = validator
         self.documentation = documentation
         self.default = default

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -61,11 +61,11 @@ class Config(object):
         """
             Get the entire compiler or get a value directly
         """
-        opt = cls.validate_option_request(section, name, default_value)
-
         cfg = cls._get_instance()
         if section is None:
             return cfg
+
+        opt = cls.validate_option_request(section, name, default_value)
 
         val = cfg.get(section, name, fallback=default_value)
         if not opt:
@@ -207,7 +207,7 @@ class Option(object):
 #############################
 # Config
 #############################
-
+# flake8: noqa: H904
 state_dir = \
     Option("config", "state_dir", "/var/lib/inmanta",
            "The directory where the server stores its state")
@@ -243,5 +243,10 @@ class TransportConfig(object):
         self.ssl = Option(self.prefix, "ssl", False, "Connect using SSL?", is_bool)
         self.ssl_ca_cert_file = Option(
             self.prefix, "ssl_ca_cert_file", None, "CA cert file used to validate the server certificate against", is_str_opt)
+        self.password = Option(
+            self.prefix, "password", None, "Password used to connect to the server", is_str_opt)
+        self.username = Option(
+            self.prefix, "username", None, "Username used to connect to the server", is_str_opt)
 
 TransportConfig("compiler")
+TransportConfig("client")

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -285,3 +285,4 @@ class TransportConfig(object):
 
 TransportConfig("compiler")
 TransportConfig("client")
+cmdline_rest_transport = TransportConfig("cmdline_rest_transport")

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -30,7 +30,7 @@ from inmanta import protocol
 from inmanta.agent.handler import Commander
 from inmanta.execute.util import Unknown
 from inmanta.resources import resource, Resource, to_id
-from inmanta.config import Config
+from inmanta.config import Config, Option, is_uuid_opt, is_list, is_str
 from inmanta.execute.proxy import DynamicProxy
 from inmanta.ast import RuntimeException
 from tornado.ioloop import IOLoop
@@ -39,6 +39,10 @@ from tornado import gen
 LOGGER = logging.getLogger(__name__)
 
 unknown_parameters = []
+
+cfg_env = Option("config", "environment", None, "The environment this model is associated with", is_uuid_opt)
+cfg_export = Option("config", "export", "", "The list of exporters to use", is_list)
+cfg_unknown_handler = Option("unknown_handler", "default", "prune-agent", "default method to handle unknown values ", is_str)
 
 
 class Exporter(object):
@@ -115,7 +119,7 @@ class Exporter(object):
             Run any additional export plug-ins
         """
         export = []
-        for pl in Config.get("config", "export", "").split(","):
+        for pl in cfg_export.get():
             export.append(pl.strip())
 
         for name in export:
@@ -163,7 +167,7 @@ class Exporter(object):
         """
             Determine the unknown handling policy for the given agent
         """
-        default_policy = Config.get("unknown_handler", "default", "prune-agent")
+        default_policy = cfg_unknown_handler.get()
 
         if "unknown_handler" not in Config._get_instance():
             return default_policy
@@ -349,7 +353,7 @@ class Exporter(object):
         """
             Commit the entire list of resource to the configurations server.
         """
-        tid = Config.get("config", "environment", None)
+        tid = cfg_env.get()
         if tid is None:
             LOGGER.error("The environment for this model should be set!")
             return

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -353,11 +353,6 @@ class Exporter(object):
         if tid is None:
             LOGGER.error("The environment for this model should be set!")
             return
-        try:
-            uuid.UUID(tid)
-        except ValueError:
-            LOGGER.exception("Invalid uuid configured for this environment.")
-            return
 
         self.deploy_code(tid, version)
 

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -24,7 +24,6 @@ import os
 import time
 import glob
 import base64
-import uuid
 
 from inmanta import protocol
 from inmanta.agent.handler import Commander

--- a/src/inmanta/protocol.py
+++ b/src/inmanta/protocol.py
@@ -670,13 +670,10 @@ class RESTTransport(Transport):
             Load the configuration for the client
         """
         LOGGER.debug("Getting config in section %s", self.id)
-        port = 8888
-        if self.id in Config.get() and "port" in Config.get()[self.id]:
-            port = int(Config.get()[self.id]["port"])
 
-        host = "localhost"
-        if self.id in Config.get() and "host" in Config.get()[self.id]:
-            host = Config.get()[self.id]["host"]
+        port = Config.get(self.id, "port", 8888)
+
+        host = Config.get(self.id, "host", "localhost")
 
         if Config.getboolean(self.id, "ssl", False):
             protocol = "https"

--- a/src/inmanta/protocol.py
+++ b/src/inmanta/protocol.py
@@ -32,7 +32,7 @@ from collections import defaultdict
 import tornado.web
 from tornado import gen, queues, locks
 from inmanta import methods
-from inmanta.config import Config
+from inmanta.config import Config, Option, is_str, is_int, is_str_opt, is_bool
 from tornado.httpserver import HTTPServer
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient, HTTPError
 from tornado.ioloop import IOLoop
@@ -1354,3 +1354,28 @@ class ReturnClient(Client, metaclass=ClientMeta):
             return Result(code=500, result="")
 
         return Result(code=return_value["code"], result=return_value["result"])
+
+###############################
+# Transport Config
+###############################
+
+
+class TransportConfig(object):
+    """
+        A class to register the config options for Client classes
+    """
+
+    def __init__(self, name):
+        self.prefix = "%s_rest_transport" % name
+        self.host = Option(self.prefix, "host", "localhost", "IP address or hostname of the server", is_str)
+        self.port = Option(self.prefix, "port", 8888, "Server port", is_int)
+        self.ssl = Option(self.prefix, "ssl", False, "Connect using SSL?", is_bool)
+        self.ssl_ca_cert_file = Option(
+            self.prefix, "ssl_ca_cert_file", None, "CA cert file used to validate the server certificate against", is_str_opt)
+        self.password = Option(
+            self.prefix, "password", None, "Password used to connect to the server", is_str_opt)
+        self.username = Option(
+            self.prefix, "username", None, "Username used to connect to the server", is_str_opt)
+
+TransportConfig("compiler")
+TransportConfig("client")

--- a/src/inmanta/protocol.py
+++ b/src/inmanta/protocol.py
@@ -1010,6 +1010,8 @@ class Environment(object):
         self._agents.add(agent)
 
     def put_call(self, agent, call_spec):
+        import inmanta.server.config
+
         future = tornado.concurrent.Future()
         if agent in self._agent_node_map:
             LOGGER.debug("Putting call %s %s for agent %s in queue", call_spec["method"], call_spec["url"], agent)
@@ -1019,7 +1021,7 @@ class Environment(object):
             call_spec["agent"] = agent
             q.put(call_spec)
 
-            _set_timeout(self._io_loop, self._replies, call_spec["reply_id"], future, int(Config.get("config", "timeout", 2)),
+            _set_timeout(self._io_loop, self._replies, call_spec["reply_id"], future, inmanta.server.config.timeout.get(),
                          "Call %s %s for agent %s timed out." % (call_spec["method"], call_spec["url"], agent))
             self._replies[call_spec["reply_id"]] = future
         else:
@@ -1354,28 +1356,3 @@ class ReturnClient(Client, metaclass=ClientMeta):
             return Result(code=500, result="")
 
         return Result(code=return_value["code"], result=return_value["result"])
-
-###############################
-# Transport Config
-###############################
-
-
-class TransportConfig(object):
-    """
-        A class to register the config options for Client classes
-    """
-
-    def __init__(self, name):
-        self.prefix = "%s_rest_transport" % name
-        self.host = Option(self.prefix, "host", "localhost", "IP address or hostname of the server", is_str)
-        self.port = Option(self.prefix, "port", 8888, "Server port", is_int)
-        self.ssl = Option(self.prefix, "ssl", False, "Connect using SSL?", is_bool)
-        self.ssl_ca_cert_file = Option(
-            self.prefix, "ssl_ca_cert_file", None, "CA cert file used to validate the server certificate against", is_str_opt)
-        self.password = Option(
-            self.prefix, "password", None, "Password used to connect to the server", is_str_opt)
-        self.username = Option(
-            self.prefix, "username", None, "Username used to connect to the server", is_str_opt)
-
-TransportConfig("compiler")
-TransportConfig("client")

--- a/src/inmanta/protocol.py
+++ b/src/inmanta/protocol.py
@@ -32,7 +32,7 @@ from collections import defaultdict
 import tornado.web
 from tornado import gen, queues, locks
 from inmanta import methods
-from inmanta.config import Config, Option, is_str, is_int, is_str_opt, is_bool
+from inmanta.config import Config
 from tornado.httpserver import HTTPServer
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient, HTTPError
 from tornado.ioloop import IOLoop

--- a/src/inmanta/server/__init__.py
+++ b/src/inmanta/server/__init__.py
@@ -16,4 +16,6 @@
     Contact: code@inmanta.com
 """
 
+# flake8: noqa: F401
+
 from inmanta.server.server import Server

--- a/src/inmanta/server/__init__.py
+++ b/src/inmanta/server/__init__.py
@@ -16,12 +16,4 @@
     Contact: code@inmanta.com
 """
 
-from inmanta.agent.agent import Agent
-                self.cache.open_version(version)
-                provider.set_cache(self.cache)
-
-            finally:
-                self.cache.close_version(version)
-
-
-
+from inmanta.server.server import Server

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -1,0 +1,149 @@
+"""
+    Copyright 2016 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+from inmanta.config import Option, is_int, is_bool, is_time, is_list, is_str_opt
+from inmanta.config import state_dir, log_dir
+import logging
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+#############################
+# Database
+#############################
+
+db_host = \
+    Option("database", "host", "localhost",
+           "Hostname or IP of the mongo server")
+db_port = \
+    Option("database", "port", 27017,
+           "The port of the mongo server", is_int)
+db_name = \
+    Option("database", "name", "inmanta",
+           "The name of the database on the mongo server")
+
+#############################
+# server_rest_transport
+#############################
+
+transport_port = \
+    Option("server_rest_transport", "port", 8888,
+           "The port on which the server listens for connections")
+
+
+#############################
+# server
+#############################
+
+server_username = \
+    Option("server", "username", None,
+           "Username required to connect to this server. Leave blank to disable auth", is_str_opt)
+
+server_password = \
+    Option("server", "password", None,
+           "Password required to connect to this server. Leave blank to disable auth", is_str_opt)
+
+server_ssl_key = \
+    Option("server", "ssl_key_file", None,
+           "Server private key to use for this server Leave blank to disable SSl", is_str_opt)
+
+server_ssl_cert = \
+    Option("server", "ssl_cert_file", None,
+           "SSL certificate file for the server key. Leave blank to disable SSL", is_str_opt)
+
+
+server_fact_expire = \
+    Option("server", "fact-expire", 3600,
+           "After how many seconds will discovered facts/parameters expire", is_time)
+
+# server_ssl_key  = \
+#     Option("server", "fact-expire", 3600,
+#            "After how many seconds will discovered facts/parameters expire", is_time)
+#
+# ssl_cert_file
+
+
+def default_fact_renew():
+    """ server.fact-expire/3 """
+    return str(int(server_fact_expire.get() / 3))
+
+
+def validate_fact_renew(value):
+    """ time; < server.fact-expire """
+    out = int(value)
+    if not out < server_fact_expire.get():
+        LOGGER.warn("can not set fact_renew to %d, must be smaller than fact-expire (%d), using %d instead" %
+                    (out, server_fact_expire.get(), default_fact_renew()))
+        out = default_fact_renew()
+    return out
+
+server_fact_renew = \
+    Option("server", "fact-renew", default_fact_renew,
+           """After how many seconds will discovered facts/parameters be renewed?
+This value needs to be lower than fact-expire""", validate_fact_renew)
+
+server_fact_resource_block = \
+    Option("server", "fact-resource-block", 60,
+           "Minimal time between subsequent requests for the same fact", is_time)
+
+server_autrecompile_wait = \
+    Option("server", "auto-recompile-wait ", 10,
+           """The number of seconds to wait before the server may attempt to do a new recompile.
+           Recompiles are triggered after facts updates for example.""", is_time)
+
+server_purge_version_interval = \
+    Option("server", "purge-versions-interval", 3600,
+           """The number of seconds between version purging,
+see :inmanta.config:option:`server.available-versions-to-keep`""", is_time)
+
+server_version_to_keep = \
+    Option("server", "available-versions-to-keep", 2,
+           """On boot and at regular intervals the server will purge versions that have not been deployed.
+This is the number of most recent undeployed versions to keep available.""", is_int)
+
+server_autostart = \
+    Option("server", "autostart-on-start", True,
+           "Automatically start agents when the server starts instead of only just in time.", is_list)
+
+server_agent_autostart = \
+    Option("server", "agent_autostart", "iaas_*",
+           """Which agents can the server start itself?
+Setting this value to * will match all agents.
+These agents are started when a dryrun or a deploy is requested.""")
+
+server_address = \
+    Option("server", "server_address", "localhost",
+           """The public ip address of the server.
+This is required for example to inject the inmanta agent in virtual machines at boot time.""")
+
+server_wait_after_param = \
+    Option("server", "wait-after-param", 5,
+           """Time to wait before recompile after new paramters have been received""", is_time)
+
+#############################
+# Dashboard
+#############################
+
+dash_enable = \
+    Option("dashboard", "enabled", False,
+           "Determines whether the server should host the dashboard or not", is_bool)
+
+dash_path = \
+    Option("dashboard", "path", None,
+           "The path on the local file system where the dashboard can be found")

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -23,6 +23,7 @@ import logging
 
 LOGGER = logging.getLogger(__name__)
 
+# flake8: noqa: H904
 
 #############################
 # Database

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -118,15 +118,15 @@ server_version_to_keep = \
            """On boot and at regular intervals the server will purge versions that have not been deployed.
 This is the number of most recent undeployed versions to keep available.""", is_int)
 
-server_autostart = \
+server_autostart_on_start = \
     Option("server", "autostart-on-start", True,
-           "Automatically start agents when the server starts instead of only just in time.", is_list)
+           "Automatically start agents when the server starts instead of only just in time.", is_bool)
 
 server_agent_autostart = \
-    Option("server", "agent_autostart", "iaas_*",
+    Option("server", "agent-autostart", "iaas_*",
            """Which agents can the server start itself?
 Setting this value to * will match all agents.
-These agents are started when a dryrun or a deploy is requested.""")
+These agents are started when a dryrun or a deploy is requested.""", is_list)
 
 server_address = \
     Option("server", "server_address", "localhost",
@@ -136,6 +136,10 @@ This is required for example to inject the inmanta agent in virtual machines at 
 server_wait_after_param = \
     Option("server", "wait-after-param", 5,
            """Time to wait before recompile after new paramters have been received""", is_time)
+
+server_no_recompile = \
+    Option("server", "no-recompile", False,
+           """Prevent all server side compiles""", is_bool)
 
 #############################
 # Dashboard
@@ -148,3 +152,7 @@ dash_enable = \
 dash_path = \
     Option("dashboard", "path", None,
            "The path on the local file system where the dashboard can be found")
+
+timeout = \
+    Option("config", "timout", 2,
+           "Timeout for agent calls from server to agent", is_time)

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -91,7 +91,7 @@ class Server(protocol.ServerEndpoint):
 
         self._requires_agents = {}
 
-        if opt.server_autostart.get():
+        if opt.server_autostart_on_start.get():
             future = self.start_agents()
             self.add_future(future)
 
@@ -1005,7 +1005,7 @@ class Server(protocol.ServerEndpoint):
         return 200
 
     def _agent_matches(self, agent_name):
-        agent_globs = [x.strip() for x in opt.server_autostart.get()]
+        agent_globs = [x.strip() for x in opt.server_agent_autostart.get()]
 
         for agent_glob in agent_globs:
             if glob.fnmatch.fnmatchcase(agent_name, agent_glob):
@@ -1078,6 +1078,7 @@ agent-names = %(agents)s
 environment=%(env_id)s
 agent-map=%(agent_map)s
 python_binary=%(python_binary)s
+agent-splay=0
 
 [agent_rest_transport]
 port=%(port)s
@@ -1539,6 +1540,9 @@ ssl_ca_cert_file=%s
         """
             Recompile an environment in a different thread and taking wait time into account.
         """
+        if opt.server_no_recompile.get():
+            LOGGER.info("Skipping compile due to no-recompile=True")
+            return
         last_recompile = self._recompiles[environment_id]
         wait_time = opt.server_autrecompile_wait.get()
         if last_recompile is self:

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -43,8 +43,10 @@ from inmanta import methods
 from inmanta import protocol
 from inmanta.agent.io.remote import RemoteIO
 from inmanta.ast import type
-from inmanta.config import Config
 from inmanta.resources import Id, HostNotFoundException
+
+from inmanta.server import config as opt
+
 
 LOGGER = logging.getLogger(__name__)
 LOCK = locks.Lock()
@@ -65,24 +67,24 @@ class Server(protocol.ServerEndpoint):
 
         self._db = None
         if database_host is None:
-            database_host = Config.get("database", "host", "localhost")
+            database_host = opt.db_host.get()
 
         if database_port is None:
-            database_port = Config.get("database", "port", 27017)
+            database_port = opt.db_port.get()
 
-        self._db = connect(Config.get("database", "name", "inmanta"), host=database_host, port=database_port)
-        LOGGER.info("Connected to mongodb database %s on %s:%d", Config.get("database", "name", "inmanta"),
+        self._db = connect(opt.db_name.get(), host=database_host, port=database_port)
+        LOGGER.info("Connected to mongodb database %s on %s:%d", opt.db_name.get(),
                     database_host, database_port)
 
-        self._fact_expire = int(Config.get("server", "fact-expire", 3600))
-        self._fact_renew = int(Config.get("server", "fact-renew", self._fact_expire / 3))
-        self._fact_resource_block = int(Config.get("server", "fact-resource_block", 60))
+        self._fact_expire = opt.server_fact_expire.get()
+        self._fact_renew = opt.server_fact_renew.get()
+        self._fact_resource_block = opt.server_fact_resource_block.get()
         self._fact_resource_block_set = {}
 
         self.add_end_point_name(self.node_name)
 
         self.schedule(self.renew_expired_facts, self._fact_renew)
-        self.schedule(self._purge_versions, int(Config.get("server", "purge-versions-interval", 3600)))
+        self.schedule(self._purge_versions, opt.server_purge_version_interval.get())
 
         self._io_loop.add_callback(self._purge_versions)
 
@@ -90,7 +92,7 @@ class Server(protocol.ServerEndpoint):
 
         self._requires_agents = {}
 
-        if Config.getboolean("server", "autostart-on-start", True):
+        if opt.server_autostart.get():
             future = self.start_agents()
             self.add_future(future)
 
@@ -101,10 +103,10 @@ class Server(protocol.ServerEndpoint):
         """
             If configured, set up tornado to serve the dashboard
         """
-        if not Config.getboolean("dashboard", "enabled", False):
+        if not opt.dash_enable.get():
             return
 
-        dashboard_path = Config.get("dashboard", "path")
+        dashboard_path = opt.dash_path.get()
         if dashboard_path is None:
             LOGGER.warning("The dashboard is enabled in the configuration but its path is not configured.")
             return
@@ -141,7 +143,7 @@ class Server(protocol.ServerEndpoint):
         envs = yield data.Environment.objects.find_all()  # @UndefinedVariable
         for env_item in envs:
             # get available versions
-            n_versions = int(Config.get("server", "available-versions-to-keep", 2))
+            n_versions = opt.server_version_to_keep.get()
             versions = yield data.ConfigurationModel.objects.filter(released=False,  # @UndefinedVariable
                                                                     environment=env_item).find_all()  # @UndefinedVariable
             if len(versions) > n_versions:
@@ -157,10 +159,7 @@ class Server(protocol.ServerEndpoint):
         """
             Check if the server storage is configured and ready to use.
         """
-        if "config" not in Config.get() or "state-dir" not in Config.get()["config"]:
-            raise Exception("The Inmanta server requires a state directory to be configured")
-
-        state_dir = Config.get()["config"]["state-dir"]
+        state_dir = opt.state_dir.get()
 
         if not os.path.exists(state_dir):
             os.mkdir(state_dir)
@@ -187,7 +186,7 @@ class Server(protocol.ServerEndpoint):
         if not os.path.exists(env_agent_dir):
             os.mkdir(env_agent_dir)
 
-        log_dir = Config.get("config", "log-dir", "/var/log/inmanta")
+        log_dir = opt.log_dir.get()
         if not os.path.isdir(log_dir):
             os.mkdir(log_dir)
         dir_map["logs"] = log_dir
@@ -363,7 +362,7 @@ class Server(protocol.ServerEndpoint):
 
         result = yield self._update_param(env, id, value, source, resource_id, metadata)
         if result:
-            self._async_recompile(tid, False, int(Config.get("server", "wait-after-param", 5)))
+            self._async_recompile(tid, False, opt.server_wait_after_param.get())
 
         if resource_id is None:
             resource_id = ""
@@ -393,7 +392,7 @@ class Server(protocol.ServerEndpoint):
                 recompile = True
 
         if recompile:
-            self._async_recompile(tid, False, int(Config.get("server", "wait-after-param", 5)))
+            self._async_recompile(tid, False, opt.server_wait_after_param.get())
 
         return 200
 
@@ -537,7 +536,7 @@ class Server(protocol.ServerEndpoint):
         new_record = yield data.FormRecord.get_uuid(id)
         record_dict = yield new_record.to_dict()
 
-        self._async_recompile(tid, False, int(Config.get("server", "wait-after-param", 5)))
+        self._async_recompile(tid, False, opt.server_wait_after_param.get())
         return 200, {"record": record_dict}
 
     @protocol.handle(methods.FormRecords.create_record)
@@ -568,7 +567,7 @@ class Server(protocol.ServerEndpoint):
                     LOGGER.warning("Field %s in form %s has an invalid type." % (k, form_type))
 
         yield record.save()
-        self._async_recompile(tid, False, int(Config.get("server", "wait-after-param", 5)))
+        self._async_recompile(tid, False, opt.server_wait_after_param.get())
 
         # need to query this again, to_dict with load_references only works on retrieved document and not on newly created
         record = yield data.FormRecord.get_uuid(record_id)
@@ -1007,7 +1006,7 @@ class Server(protocol.ServerEndpoint):
         return 200
 
     def _agent_matches(self, agent_name):
-        agent_globs = [x.strip() for x in Config.get("server", "agent_autostart", "iaas_*").split(",")]
+        agent_globs = [x.strip() for x in opt.server_autostart.get()]
 
         for agent_glob in agent_globs:
             if glob.fnmatch.fnmatchcase(agent_name, agent_glob):
@@ -1041,6 +1040,8 @@ class Server(protocol.ServerEndpoint):
         """
             Ensure that the agent is running if required
         """
+        import inmanta.agent.config
+
         if self._agent_matches(agent_name):
             with (yield LOCK.acquire()):
                 LOGGER.info("%s matches agents managed by server, ensuring it is started.", agent_name)
@@ -1067,7 +1068,7 @@ class Server(protocol.ServerEndpoint):
                     except HostNotFoundException:
                         agent_map[agent] = "localhost"
 
-                port = Config.get("server_rest_transport", "port", "8888")
+                port = opt.transport_port.get()
 
                 # generate config file
                 config = """[config]
@@ -1083,12 +1084,12 @@ python_binary=%(python_binary)s
 port=%(port)s
 host=localhost
 """ % {"agents": agent_names, "env_id": environment_id, "port": port,
-                    "python_binary": Config.get("config", "python_binary", "python"),
+                    "python_binary": inmanta.agent.config.python_binary.get(),
                     "agent_map": ",".join(["%s=%s" % (k, v) for k, v in agent_map.items()]),
-                    "statedir": Config.get("config", "state-dir", "/var/lib/inmanta")}
+                    "statedir": opt.state_dir.get()}
 
-                user = Config.get("server", "username", None)
-                passwd = Config.get("server", "password", None)
+                user = opt.server_username.get()
+                passwd = opt.server_password.get()
 
                 if user is not None and passwd is not None:
                     config += """
@@ -1096,8 +1097,8 @@ username=%s
 password=%s
 """ % (user, passwd)
 
-                ssl_cert = Config.get("server", "ssl_key_file", None)
-                ssl_ca = Config.get("server", "ssl_cert_file", None)
+                ssl_cert = opt.server_ssl_key.get()
+                ssl_ca = opt.server_ssl_cert.get()
                 if ssl_ca is not None and ssl_cert is not None:
                     config += """
 ssl=True
@@ -1540,7 +1541,7 @@ ssl_ca_cert_file=%s
             Recompile an environment in a different thread and taking wait time into account.
         """
         last_recompile = self._recompiles[environment_id]
-        wait_time = int(Config.get("server", "auto-recompile-wait", 600))
+        wait_time = opt.server_autrecompile_wait.get()
         if last_recompile is self:
             LOGGER.info("Already recompiling")
             return
@@ -1640,11 +1641,11 @@ ssl_ca_cert_file=%s
                 stages.append(result)
 
             LOGGER.info("Recompiling configuration model")
-            server_address = Config.get("server", "server_address", "localhost")
+            server_address = opt.server_address.get()
             result = yield self._run_compile_stage("Recompiling configuration model",
                                                    inmanta_path + ["-vvv", "export", "-e", str(environment_id),
                                                                    "--server_address", server_address, "--server_port",
-                                                                   Config.get("server_rest_transport", "port", "8888")],
+                                                                   opt.transport_port.get()],
                                                    project_dir, env=os.environ.copy())
             stages.append(result)
         finally:

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -44,7 +44,6 @@ from inmanta import protocol
 from inmanta.agent.io.remote import RemoteIO
 from inmanta.ast import type
 from inmanta.resources import Id, HostNotFoundException
-
 from inmanta.server import config as opt
 
 

--- a/src/inmanta/sphinxext.py
+++ b/src/inmanta/sphinxext.py
@@ -1,0 +1,337 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# based on oslo_config.sphinxext
+# http://docs.openstack.org/developer/oslo.config/sphinxext.html
+
+from docutils import nodes
+from docutils.parsers import rst
+from docutils.parsers.rst import directives
+
+from docutils.statemachine import ViewList
+from sphinx import addnodes
+from sphinx.directives import ObjectDescription
+from sphinx.domains import Domain
+from sphinx.domains import ObjType
+from sphinx.roles import XRefRole
+from sphinx.util.nodes import make_refnode
+from sphinx.util.nodes import nested_parse_with_titles
+
+from inmanta.config import Config
+import importlib
+
+
+def _list_table(headers, data, title='', columns=None):
+    """Build a list-table directive.
+
+    :param add: Function to add one row to output.
+    :param headers: List of header values.
+    :param data: Iterable of row data, yielding lists or tuples with rows.
+    """
+    yield '.. list-table:: %s' % title
+    yield '   :header-rows: 1'
+    if columns:
+        yield '   :widths: %s' % (','.join(str(c) for c in columns))
+    yield ''
+    yield '   - * %s' % headers[0]
+    for h in headers[1:]:
+        yield '     * %s' % h
+    for row in data:
+        yield '   - * %s' % row[0]
+        for r in row[1:]:
+            yield '     * %s' % r
+    yield ''
+
+
+def _indent(text, n=2):
+    padding = ' ' * n
+    return '\n'.join(padding + l for l in text.splitlines())
+
+
+def _make_anchor_target(group_name, option_name):
+    # We need to ensure this is unique across entire documentation
+    # http://www.sphinx-doc.org/en/stable/markup/inline.html#ref-role
+    target = '%s.%s' % (group_name,
+                        option_name.lower())
+    return target
+
+
+def _format_group(app, group_name, opt_list):
+    group_name = group_name or 'DEFAULT'
+    app.info('[inmanta.config] %s' % (group_name))
+
+    yield '.. inmanta.config:group:: %s' % group_name
+    yield ''
+
+    for opt in sorted(opt_list.values(), key=lambda x: x.name):
+        yield '.. inmanta.config:option:: %s' % opt.name
+        yield ''
+
+        type = opt.get_type()
+        if type:
+            yield _indent(':Type: %s' % type)
+        default = opt.get_default_desc()
+        if default:
+            default = '``' + str(default).strip() + '``'
+            yield _indent(':Default: %s' % default)
+#         if getattr(opt.type, 'min', None) is not None:
+#             yield _indent(':Minimum Value: %s' % opt.type.min)
+#         if getattr(opt.type, 'max', None) is not None:
+#             yield _indent(':Maximum Value: %s' % opt.type.max)
+#         if getattr(opt.type, 'choices', None):
+#             choices_text = ', '.join([_get_choice_text(choice)
+#                                       for choice in opt.type.choices])
+#             yield _indent(':Valid Values: %s' % choices_text)
+
+        yield ''
+
+        try:
+            help_text = opt.documentation % {'default': 'the value above'}
+        except (TypeError, KeyError):
+            # There is no mention of the default in the help string,
+            # or the string had some unknown key
+            help_text = opt.documentation
+        if help_text:
+            yield _indent(help_text)
+            yield ''
+
+#         if opt.deprecated_opts:
+#             for line in _list_table(
+#                     ['Group', 'Name'],
+#                     ((d.group or 'DEFAULT',
+#                       d.name or opt.dest or 'UNSET')
+#                      for d in opt.deprecated_opts),
+#                     title='Deprecated Variations'):
+#                 yield _indent(line)
+#         if opt.deprecated_for_removal:
+#             yield _indent('.. warning::')
+#             yield _indent('   This option is deprecated for removal.')
+#             yield _indent('   Its value may be silently ignored ')
+#             yield _indent('   in the future.')
+#             yield ''
+#             if opt.deprecated_reason:
+#                 yield _indent('   :Reason: ' + opt.deprecated_reason)
+#             yield ''
+
+        yield ''
+
+
+def _format_option_help(app):
+    """Generate a series of lines of restructuredtext.
+
+    Format the option help as restructuredtext and return it as a list
+    of lines.
+    """
+
+    opts = Config.get_config_options()
+
+    for section, opt_list in sorted(opts.items(), key=lambda x: x[0]):
+        lines = _format_group(
+            app=app,
+            group_name=section,
+            opt_list=opt_list
+        )
+        for line in lines:
+            yield line
+
+
+class ShowOptionsDirective(rst.Directive):
+
+    option_spec = {
+        'split-namespaces': directives.flag,
+        'config-file': directives.unchanged,
+    }
+
+    has_content = True
+
+    def run(self):
+        env = self.state.document.settings.env
+        app = env.app
+
+        namespaces = [
+            c.strip()
+            for c in self.content
+            if c.strip()
+        ]
+        for namespace in namespaces:
+            importlib.import_module(namespace)
+
+        result = ViewList()
+        source_name = '<' + __name__ + '>'
+        for line in _format_option_help(app):
+            result.append(line, source_name)
+
+        node = nodes.section()
+        node.document = self.state.document
+        nested_parse_with_titles(self.state, result, node)
+
+        return node.children
+
+
+class ConfigGroupXRefRole(XRefRole):
+    "Handles :inmanta.config:group: roles pointing to configuration groups."
+
+    def __init__(self):
+        super(ConfigGroupXRefRole, self).__init__(
+            warn_dangling=True,
+        )
+
+    def process_link(self, env, refnode, has_explicit_title, title, target):
+        # The anchor for the group link is the group name.
+        return target, target
+
+
+class ConfigOptXRefRole(XRefRole):
+    "Handles :inmanta.config:option: roles pointing to configuration options."
+
+    def __init__(self):
+        super(ConfigOptXRefRole, self).__init__(
+            warn_dangling=True,
+        )
+
+    def process_link(self, env, refnode, has_explicit_title, title, target):
+        if not has_explicit_title:
+            title = target
+        if '.' in target:
+            group, opt_name = target.split('.')
+        else:
+            group = 'DEFAULT'
+            opt_name = target
+        anchor = _make_anchor_target(group, opt_name)
+        return title, anchor
+
+
+class ConfigGroup(rst.Directive):
+
+    has_content = True
+
+    option_spec = {
+        'namespace': directives.unchanged,
+    }
+
+    def run(self):
+        env = self.state.document.settings.env
+        app = env.app
+
+        group_name = ' '.join(self.content)
+
+        cached_groups = env.domaindata['inmanta.config']['groups']
+
+        # Store the current group for use later in option directives
+        env.temp_data['inmanta.config:group'] = group_name
+        app.info('inmanta.config group %r' % group_name)
+
+        # Store the location where this group is being defined
+        # for use when resolving cross-references later.
+        # FIXME: This should take the source namespace into account, too
+        cached_groups[group_name] = env.docname
+
+        result = ViewList()
+        source_name = '<' + __name__ + '>'
+
+        def _add(text):
+            "Append some text to the output result view to be parsed."
+            result.append(text, source_name)
+
+        title = group_name
+
+        _add(title)
+        _add('-' * len(title))
+        node = nodes.section()
+        node.document = self.state.document
+        nested_parse_with_titles(self.state, result, node)
+
+        first_child = node.children[0]
+
+        # Compute the normalized target and set the node to have that
+        # as an id
+        target_name = group_name
+        first_child['ids'].append(target_name)
+
+        indexnode = addnodes.index(entries=[])
+        return [indexnode] + node.children
+
+
+class ConfigOption(ObjectDescription):
+    "Description of a configuration option (.. option)."
+
+    def handle_signature(self, sig, signode):
+        """Transform an option description into RST nodes."""
+        optname = sig
+        self.env.app.info('inmanta.config option %s' % optname)
+        # Insert a node into the output showing the option name
+        signode += addnodes.desc_name(optname, optname)
+        signode['allnames'] = [optname]
+        return optname
+
+    def add_target_and_index(self, firstname, sig, signode):
+        cached_options = self.env.domaindata['inmanta.config']['options']
+        # Look up the current group name from the processing context
+        currgroup = self.env.temp_data.get('inmanta.config:group')
+        # Compute the normalized target name for the option and give
+        # that to the node as an id
+        target_name = _make_anchor_target(currgroup, sig)
+        signode['ids'].append(target_name)
+        self.state.document.note_explicit_target(signode)
+        # Store the location of the option definition for later use in
+        # resolving cross-references
+        # FIXME: This should take the source namespace into account, too
+        cached_options[target_name] = self.env.docname
+
+
+class ConfigDomain(Domain):
+    """inmanta.config domain."""
+    name = 'inmanta.config'
+    label = 'inmanta.config'
+    object_types = {
+        'configoption': ObjType('configuration option', 'option'),
+    }
+    directives = {
+        'group': ConfigGroup,
+        'option': ConfigOption,
+    }
+    roles = {
+        'option': ConfigOptXRefRole(),
+        'group': ConfigGroupXRefRole(),
+    }
+    initial_data = {
+        'options': {},
+        'groups': {},
+    }
+
+    def resolve_xref(self, env, fromdocname, builder,
+                     typ, target, node, contnode):
+        if typ == 'option':
+            group_name, option_name = target.split('.', 1)
+            return make_refnode(
+                builder,
+                fromdocname,
+                env.domaindata['inmanta.config']['options'][target],
+                target,
+                contnode,
+                option_name,
+            )
+        if typ == 'group':
+            return make_refnode(
+                builder,
+                fromdocname,
+                env.domaindata['inmanta.config']['groups'][target],
+                target,
+                contnode,
+                target,
+            )
+        return None
+
+
+def setup(app):
+    app.add_directive('show-options', ShowOptionsDirective)
+    app.add_domain(ConfigDomain)

--- a/src/inmanta/sphinxext.py
+++ b/src/inmanta/sphinxext.py
@@ -13,10 +13,11 @@
 # based on oslo_config.sphinxext
 # http://docs.openstack.org/developer/oslo.config/sphinxext.html
 
+import importlib
+
 from docutils import nodes
 from docutils.parsers import rst
 from docutils.parsers.rst import directives
-
 from docutils.statemachine import ViewList
 from sphinx import addnodes
 from sphinx.directives import ObjectDescription
@@ -25,9 +26,7 @@ from sphinx.domains import ObjType
 from sphinx.roles import XRefRole
 from sphinx.util.nodes import make_refnode
 from sphinx.util.nodes import nested_parse_with_titles
-
 from inmanta.config import Config
-import importlib
 
 
 def _list_table(headers, data, title='', columns=None):

--- a/tests/test_2way_protocol.py
+++ b/tests/test_2way_protocol.py
@@ -22,9 +22,10 @@ import uuid
 
 import colorlog
 from inmanta import methods
-from inmanta.config import Config, TransportConfig
+from inmanta.config import Config
 from tornado import gen
 from tornado.ioloop import IOLoop
+from inmanta.protocol import TransportConfig
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_2way_protocol.py
+++ b/tests/test_2way_protocol.py
@@ -22,7 +22,7 @@ import uuid
 
 import colorlog
 from inmanta import methods
-from inmanta.config import Config
+from inmanta.config import Config, TransportConfig
 from tornado import gen
 from tornado.ioloop import IOLoop
 
@@ -46,6 +46,7 @@ from inmanta import protocol  # NOQA
 
 
 class Server(protocol.ServerEndpoint):
+
     @protocol.handle(StatusMethod.get_status)
     @gen.coroutine
     def get_status(self, tid):
@@ -60,6 +61,7 @@ class Server(protocol.ServerEndpoint):
 
 
 class Agent(protocol.AgentEndPoint):
+
     @protocol.handle(StatusMethod.get_agent_status)
     @gen.coroutine
     def get_agent_status(self, id):
@@ -91,6 +93,10 @@ def test_2way_protocol(logs=False):
         logging.root.handlers = []
         logging.root.addHandler(stream)
         logging.root.setLevel(logging.DEBUG)
+
+    # set config defaults
+    TransportConfig("server")
+    TransportConfig("agent")
 
     io_loop = IOLoop.current()
     Config.load_config()

--- a/tests/test_2way_protocol.py
+++ b/tests/test_2way_protocol.py
@@ -25,7 +25,7 @@ from inmanta import methods
 from inmanta.config import Config
 from tornado import gen
 from tornado.ioloop import IOLoop
-from inmanta.protocol import TransportConfig
+from inmanta.config import TransportConfig
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_server_agent.py
+++ b/tests/test_server_agent.py
@@ -200,7 +200,7 @@ class testAgentServer(ServerTest):
         result = yield self.client.create_environment(project_id=project_id, name="dev")
         env_id = result.result["environment"]["id"]
 
-        self.agent = agent.Agent(self.io_loop, hostname="node1", env_id=env_id, agent_map="agent1=localhost",
+        self.agent = agent.Agent(self.io_loop, hostname="node1", env_id=env_id, agent_map={"agent1": "localhost"},
                                  code_loader=False)
         self.agent.add_end_point_name("agent1")
         self.agent.start()
@@ -306,7 +306,7 @@ class testAgentServer(ServerTest):
         result = yield self.client.create_environment(project_id=project_id, name="dev")
         env_id = result.result["environment"]["id"]
 
-        self.agent = agent.Agent(self.io_loop, hostname="node1", env_id=env_id, agent_map="agent1=localhost",
+        self.agent = agent.Agent(self.io_loop, hostname="node1", env_id=env_id, agent_map={"agent1": "localhost"},
                                  code_loader=False)
         self.agent.add_end_point_name("agent1")
         self.agent.start()
@@ -396,7 +396,7 @@ class testAgentServer(ServerTest):
         result = yield self.client.create_environment(project_id=project_id, name="dev")
         env_id = result.result["environment"]["id"]
 
-        self.agent = agent.Agent(self.io_loop, hostname="node1", env_id=env_id, agent_map="agent1=localhost",
+        self.agent = agent.Agent(self.io_loop, hostname="node1", env_id=env_id, agent_map={"agent1": "localhost"},
                                  code_loader=False)
         self.agent.add_end_point_name("agent1")
         self.agent.start()
@@ -463,7 +463,7 @@ class testAgentServer(ServerTest):
         result = yield self.client.create_environment(project_id=project_id, name="dev")
         env_id = result.result["environment"]["id"]
 
-        self.agent = agent.Agent(self.io_loop, hostname="node1", env_id=env_id, agent_map="agent1=localhost",
+        self.agent = agent.Agent(self.io_loop, hostname="node1", env_id=env_id, agent_map={"agent1": "localhost"},
                                  code_loader=False)
         self.agent.add_end_point_name("agent1")
         self.agent.start()
@@ -518,7 +518,7 @@ class testAgentServer(ServerTest):
         result = yield self.client.create_environment(project_id=project_id, name="dev")
         env_id = result.result["environment"]["id"]
 
-        self.agent = agent.Agent(self.io_loop, hostname="node1", env_id=env_id, agent_map="agent1=localhost",
+        self.agent = agent.Agent(self.io_loop, hostname="node1", env_id=env_id, agent_map={"agent1": "localhost"},
                                  code_loader=False, poolsize=10)
         self.agent.add_end_point_name("agent1")
         self.agent.start()
@@ -597,7 +597,7 @@ class testAgentServer(ServerTest):
         assert states['test::Resource[agent1,key=key4],v=%d' % version] == "skipped"
         assert states['test::Resource[agent1,key=key5],v=%d' % version] == "skipped"
 
-    @gen_test(timeout=10000)
+    @gen_test
     def test_wait(self):
         """
             Test results for a cancel
@@ -608,7 +608,7 @@ class testAgentServer(ServerTest):
         result = yield self.client.create_environment(project_id=project_id, name="dev")
         env_id = result.result["environment"]["id"]
 
-        self.agent = agent.Agent(self.io_loop, hostname="node1", env_id=env_id, agent_map="agent1=localhost",
+        self.agent = agent.Agent(self.io_loop, hostname="node1", env_id=env_id, agent_map={"agent1": "localhost"},
                                  code_loader=False, poolsize=10)
         self.agent.add_end_point_name("agent1")
         self.agent.start()


### PR DESCRIPTION
Config is now expected to be defined prior to use. 

To define a config option

`cfg_env = Option("config", "environment", None, "The environment this model is associated with", is_uuid_opt)`

to get the option

`cfg_env.get()`

Major changes:
 - config options are returned as the type given in the definition, not longer as strings
 - '-' and '_' are equivalent in config options
 - server is moved from a file to a directory

fixes #156 