### PR TITLE
Issue/additonal compiler tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ build-result
 src/*/parser/parser.out
 src/*/parser/parsetab.py
 .env
+.eggs/*

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -44,7 +44,7 @@ class Context(object):
         self.queue = queue
         self.owner = owner
         self.result = result
-        self.compiler = queue.compiler
+        self.compiler = queue.get_compiler()
 
     def emit_expression(self, stmt):
         """
@@ -60,7 +60,7 @@ class Context(object):
 
     def get_type(self, name):
         try:
-            return self.queue.types[name]
+            return self.queue.get_types()[name]
         except KeyError:
             raise TypeNotFoundException(name, self.owner.namespace)
 

--- a/tests/data/lexer_reset/libs/lextest/model/_init.cf
+++ b/tests/data/lexer_reset/libs/lextest/model/_init.cf
@@ -1,0 +1,3 @@
+entity A:
+""" the A """
+end

--- a/tests/data/lexer_reset/libs/lextest/module.yml
+++ b/tests/data/lexer_reset/libs/lextest/module.yml
@@ -1,0 +1,4 @@
+author: Inmanta <code@inmanta.com>
+license: Apache 2.0
+name: lextest
+version: 0.1

--- a/tests/data/lexer_reset/main.cf
+++ b/tests/data/lexer_reset/main.cf
@@ -1,0 +1,3 @@
+import lextest
+
+"""

--- a/tests/data/lexer_reset/project.yml
+++ b/tests/data/lexer_reset/project.yml
@@ -1,0 +1,6 @@
+name: lexer_reset
+description: Model to test basic compiler functions
+modulepath: libs
+downloadpath: libs
+version: 1.0
+repo: "."

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -1090,6 +1090,16 @@ class TestIndexCompileCollision(CompilerBaseTest, unittest.TestCase):
             compiler.do_compile()
 
 
+class TestLexerReset(CompilerBaseTest, unittest.TestCase):
+
+    def __init__(self, methodName='runTest'):
+        unittest.TestCase.__init__(self, methodName)
+        CompilerBaseTest.__init__(self, "lexer_reset")
+
+    def test_compile(self):
+        compiler.do_compile()
+
+
 class TestIndexCompile(CompilerBaseTest, unittest.TestCase):
 
     def __init__(self, methodName='runTest'):

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -70,7 +70,7 @@ class AbstractSnippetTest(object):
         shutil.rmtree(cls.libs)
         shutil.rmtree(cls.env)
 
-    def setUpForSnippet(self, snippet):
+    def setUpForSnippet(self, snippet, autostd=True):
         # init project
         self.project_dir = tempfile.mkdtemp()
         os.symlink(self.__class__.env, os.path.join(self.project_dir, ".env"))
@@ -90,7 +90,7 @@ class AbstractSnippetTest(object):
         with open(os.path.join(self.project_dir, "main.cf"), "w") as x:
             x.write(snippet)
 
-        Project.set(Project(self.project_dir))
+        Project.set(Project(self.project_dir, autostd=autostd))
 
     def do_export(self):
         config.Config.load_config()
@@ -994,6 +994,61 @@ end
 """)
         (types, _) = compiler.do_compile()
         files = types["std::File"].get_all_instances()
+        assert len(files) == 1
+
+    def test_trackingbug(self):
+        self.setUpForSnippet("""
+entity A:
+    bool z = true
+end
+
+entity B:
+end
+
+entity C:
+end
+
+entity E:
+end
+
+A.b [0:] -- B.a [0:]
+A.b2 [0:] -- B.a2 [0:]
+A.e [0:] -- E.a [0:]
+
+C.a [0:] -- A.c [0:]
+
+implement E using std::none
+implement A using std::none
+
+
+
+implementation c for C:
+   E(a=self.a)
+end
+implement C using c
+
+implementation b for B:
+    C(a=self.a2)
+end
+
+implement B using b when std::count(self.a)>0
+
+entity D:
+end
+
+implementation d for D:
+    a = A()
+    b = B()
+    b.a = a
+    b.a2 = a
+end
+
+implement D using d
+
+D()
+""")
+        (types, _) = compiler.do_compile()
+        files = types["__config__::C"].get_all_instances()
         assert len(files) == 1
 
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -705,6 +705,16 @@ b=""
 """)
 
 
+def test_MLS():
+    parse_code("""
+entity MANO:
+    \"""
+        This entity provides mangement, orchestration and monitoring
+    \"""
+end
+""")
+
+
 def test_Bad():
     with pytest.raises(ParserException):
         parse_code("""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,6 +26,8 @@ def retry_limited(fun, timeout):
     start = time.time()
     while time.time() - start < timeout and not fun():
         yield sleep(0.1)
+    if not fun():
+        raise AssertionError("Bounded wait failed")
 
 
 UNKWN = object()


### PR DESCRIPTION
fixed delicate bug introduced by constructor tracking (assuming that QueueScheduler is mutable)
fixed bug where lexer was not properly reset  
added testing support for better diagnoses of transient test failures
