### PR TITLE
Add an unknown state to the server

### DIFF
--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -501,7 +501,8 @@ class AgentInstance(object):
                         if const.ResourceState[res["status"]] in const.UNDEPLOYABLE_STATES:
                             ctx.exception("Skipping %(resource_id)s because in undeployable state %(status)s",
                                           resource_id=res["id"], status=res["status"])
-                            yield self.get_client().dryrun_update(tid=self._env_id, id=dry_run_id, resource=res["id"], changes={})
+                            yield self.get_client().dryrun_update(tid=self._env_id, id=dry_run_id, resource=res["id"],
+                                                                  changes={})
                             continue
 
                         data = res["attributes"]
@@ -515,7 +516,8 @@ class AgentInstance(object):
                         except Exception as e:
                             ctx.exception("Unable to find a handler for %(resource_id)s (exception: %(exception)s",
                                           resource_id=str(resource.id), exception=str(e))
-                            yield self.get_client().dryrun_update(tid=self._env_id, id=dry_run_id, resource=res["id"], changes={})
+                            yield self.get_client().dryrun_update(tid=self._env_id, id=dry_run_id, resource=res["id"],
+                                                                  changes={})
                         else:
                             yield self.thread_pool.submit(provider.execute, ctx, resource, dry_run=True)
                             yield self.get_client().dryrun_update(tid=self._env_id, id=dry_run_id, resource=res["id"],

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -76,6 +76,7 @@ class ResourceAction(object):
         self.status = None
         self.change = None
         self.changes = None
+        self.undeployable = None
 
     def is_running(self):
         return self.running
@@ -167,6 +168,10 @@ class ResourceAction(object):
                 ctx.set_status(const.ResourceState.skipped)
                 success = False
                 send_event = False
+            elif self.undeployable is not None:
+                ctx.set_status(self.undeployable)
+                success = False
+                send_event = False
             else:
                 if result.receive_events:
                     received_events = {x.resource_id: dict(status=x.status, change=x.change,
@@ -203,9 +208,9 @@ class ResourceAction(object):
 
         status = ""
         if self.is_done():
-            status = "Done"
+            status = " Done"
         elif self.is_running():
-            status = "Running"
+            status = " Running"
 
         return self.resource.id.resource_str() + status
 
@@ -282,7 +287,7 @@ class ResourceScheduler(object):
         self.ratelimiter = ratelimiter
         self.version = 0
 
-    def reload(self, resources):
+    def reload(self, resources, undeployable={}):
         version = resources[0].id.get_version
 
         self.version = version
@@ -292,6 +297,11 @@ class ResourceScheduler(object):
 
         gid = uuid.uuid4()
         self.generation = {r.id.resource_str(): ResourceAction(self, r, gid) for r in resources}
+
+        for key, res in self.generation.items():
+            vid = str(res.resource.id)
+            if vid in undeployable:
+                self.generation[key].undeployable = undeployable[vid]
 
         cross_agent_dependencies = [q for r in resources for q in r.requires if q.get_agent_name() != self.name]
         for cad in cross_agent_dependencies:
@@ -440,7 +450,12 @@ class AgentInstance(object):
                 resources = []
                 yield self.process._ensure_code(self._env_id, result.result["version"], restypes)
                 try:
+                    undeployable = {}
                     for res in result.result["resources"]:
+                        state = const.ResourceState[res["status"]]
+                        if state in const.UNDEPLOYABLE_STATES:
+                            undeployable[res["id"]] = state
+
                         data = res["attributes"]
                         data["id"] = res["id"]
                         resource = Resource.deserialize(data)
@@ -450,7 +465,7 @@ class AgentInstance(object):
                     LOGGER.error("Failed to receive update", e)
 
                 if len(resources) > 0:
-                    self._nq.reload(resources)
+                    self._nq.reload(resources, undeployable)
 
     @gen.coroutine
     def dryrun(self, dry_run_id, version):
@@ -471,7 +486,6 @@ class AgentInstance(object):
                     return
 
                 resources = result.result["resources"]
-
                 restypes = set([res["resource_type"] for res in resources])
 
                 # TODO: handle different versions for dryrun and deploy!
@@ -484,6 +498,12 @@ class AgentInstance(object):
                     started = datetime.datetime.now()
                     provider = None
                     try:
+                        if const.ResourceState[res["status"]] in const.UNDEPLOYABLE_STATES:
+                            ctx.exception("Skipping %(resource_id)s because in undeployable state %(status)s",
+                                          resource_id=res["id"], status=res["status"])
+                            yield self.get_client().dryrun_update(tid=self._env_id, id=dry_run_id, resource=res["id"], changes={})
+                            continue
+
                         data = res["attributes"]
                         data["id"] = res["id"]
                         resource = Resource.deserialize(data)
@@ -495,7 +515,7 @@ class AgentInstance(object):
                         except Exception as e:
                             ctx.exception("Unable to find a handler for %(resource_id)s (exception: %(exception)s",
                                           resource_id=str(resource.id), exception=str(e))
-                            self._client.dryrun_update(tid=self._env_id, id=dry_run_id, resource=res["id"], changes={})
+                            yield self.get_client().dryrun_update(tid=self._env_id, id=dry_run_id, resource=res["id"], changes={})
                         else:
                             yield self.thread_pool.submit(provider.execute, ctx, resource, dry_run=True)
                             yield self.get_client().dryrun_update(tid=self._env_id, id=dry_run_id, resource=res["id"],
@@ -671,6 +691,10 @@ class AgentInstance(object):
 
                 version = resource_obj.id.version
                 try:
+                    if const.ResourceState[resource["status"]] in const.UNDEPLOYABLE_STATES:
+                        LOGGER.exception("Skipping %s because in undeployable state %s", resource["id"], resource["status"])
+                        return 200
+
                     self._cache.open_version(version)
                     provider = handler.Commander.get_provider(self._cache, self, resource_obj)
                     provider.set_cache(self._cache)

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -28,6 +28,11 @@ class ResourceState(Enum):
     queued = 6
     available = 7
     cancelled = 8  # When a new version is pushed, in progress deploys are cancelled
+    unknown = 9  # The state of this resource is unknown at this moment in the orchestration process
+
+
+UNDEPLOYABLE_STATES = [ResourceState.unknown]
+UKNOWN_STRING = "<<unknown>>"
 
 
 class Change(Enum):

--- a/src/inmanta/methods.py
+++ b/src/inmanta/methods.py
@@ -471,13 +471,15 @@ class VersionMethod(Method):
         """
 
     @protocol(operation="PUT", arg_options=ENV_OPTS, client_types=["compiler"])
-    def put_version(self, tid: uuid.UUID, version: int, resources: list, unknowns: list=None, version_info: dict=None):
+    def put_version(self, tid: uuid.UUID, version: int, resources: list, resource_state: dict={}, unknowns: list=None,
+                    version_info: dict=None):
         """
             Store a new version of the configuration model
 
             :param tid: The id of the environment
             :param version: The version of the configuration model
             :param resources: A list of all resources in the configuration model (deployable)
+            :param resource_state: A dictionary with the initial const.ResourceState per resource id
             :param unknowns: A list of unknown parameters that caused the model to be incomplete
             :param version_info: Module version information
         """

--- a/src/inmanta/protocol.py
+++ b/src/inmanta/protocol.py
@@ -30,7 +30,7 @@ import enum
 
 import tornado.web
 from tornado import gen, queues
-from inmanta import methods, config, const
+from inmanta import methods, config, const, execute
 from tornado.httpserver import HTTPServer
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient, HTTPError
 from tornado.ioloop import IOLoop
@@ -222,6 +222,9 @@ def custom_json_encoder(o):
     if isinstance(o, Exception):
         # Logs can push exceptions through RPC. Return a string representation.
         return str(o)
+
+    if isinstance(o, execute.util.Unknown):
+        return const.UKNOWN_STRING
 
     LOGGER.error("Unable to serialize %s", o)
     raise TypeError(repr(o) + " is not JSON serializable")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,7 +278,7 @@ class SnippetCompilationTest(object):
 
         Project.set(Project(self.project_dir, autostd=autostd))
 
-    def do_export(self, deploy=False):
+    def do_export(self, deploy=False, include_status=False):
         templfile = mktemp("json", "dump", self.project_dir)
 
         from inmanta.export import Exporter
@@ -294,7 +294,7 @@ class SnippetCompilationTest(object):
         options.ssl = False
 
         export = Exporter(options=options)
-        return export.run(types, scopes)
+        return export.run(types, scopes, include_status=include_status)
 
     def setup_for_error(self, snippet, shouldbe):
         self.setup_for_snippet(snippet)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -239,8 +239,8 @@ Test.bar [1] foo,bar Foo.tests [5:10]
     assert rel.right[2] == (1, 1)
     assert statements[0].requires is None
     assert len(rel.annotations) == 2
-    assert rel.annotations[0] == "foo"
-    assert rel.annotations[1] == "bar"
+    assert rel.annotations[0].name == "foo"
+    assert rel.annotations[1].name == "bar"
 
 
 def test_new_relation_unidir():
@@ -290,8 +290,8 @@ Test.bar [1] foo,bar Foo
     assert rel.right[2] == (1, 1)
     assert statements[0].requires is None
     assert len(rel.annotations) == 2
-    assert rel.annotations[0] == "foo"
-    assert rel.annotations[1] == "bar"
+    assert rel.annotations[0].name == "foo"
+    assert rel.annotations[1].name == "bar"
 
 
 def test_implementation():

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -239,8 +239,8 @@ Test.bar [1] foo,bar Foo.tests [5:10]
     assert rel.right[2] == (1, 1)
     assert statements[0].requires is None
     assert len(rel.annotations) == 2
-    assert rel.annotations[0].name == "foo"
-    assert rel.annotations[1].name == "bar"
+    assert rel.annotations[0] == "foo"
+    assert rel.annotations[1] == "bar"
 
 
 def test_new_relation_unidir():
@@ -290,8 +290,8 @@ Test.bar [1] foo,bar Foo
     assert rel.right[2] == (1, 1)
     assert statements[0].requires is None
     assert len(rel.annotations) == 2
-    assert rel.annotations[0].name == "foo"
-    assert rel.annotations[1].name == "bar"
+    assert rel.annotations[0] == "foo"
+    assert rel.annotations[1] == "bar"
 
 
 def test_implementation():

--- a/tests/test_server_agent.py
+++ b/tests/test_server_agent.py
@@ -280,7 +280,7 @@ def test_dryrun_and_deploy(io_loop, server, client, resource_container):
                   'allow_restore': True,
                   'allow_snapshot': True,
                   }
-                ]
+                 ]
 
     status = {'test::Resource[agent1,key=key4]': const.ResourceState.unknown}
     result = yield client.put_version(tid=env_id, version=version, resources=resources, resource_state=status,


### PR DESCRIPTION
Previously all unknown handling was done in the server. This resulted in
strange reporting as the number of managed resource could go up and
down. Now, an additional resource state "unknown" is introduced. This
state is handled similar to skipped during deploys.