### PR TITLE
Raise an exception when duplicate resources are exported

### DIFF
--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -490,6 +490,12 @@ class Id(object):
 
         return self.resource_str()
 
+    def __hash__(self):
+        return hash(str(self))
+
+    def __eq__(self, other):
+        return str(self) == str(other) and type(self) == type(other)
+
     def resource_str(self):
         return "%(type)s[%(agent)s,%(attribute)s=%(value)s]" % {
             "type": self._entity_type,

--- a/tests/data/modules/test/model/_init.cf
+++ b/tests/data/modules/test/model/_init.cf
@@ -1,0 +1,7 @@
+entity Resource extends std::PurgeableResource, std::State:
+    string agent="internal"
+    string key
+    string value
+end
+
+implement Resource using std::none

--- a/tests/data/modules/test/module.yml
+++ b/tests/data/modules/test/module.yml
@@ -1,0 +1,3 @@
+name: test
+version: 0.1
+license: ASL


### PR DESCRIPTION
This check raises an compiler exception when a resource id is not unique