### PR TITLE
Set purged=false on clone in CRUDHandler

### DIFF
--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -715,7 +715,9 @@ class CRUDHandler(ResourceHandler):
                 ctx.set_status(const.ResourceState.skipped)
 
             else:
-                current = resource.clone()
+                # current is clone, except for purged is set to false to prevent a bug that occurs often where the desired
+                # state defines purged=true but the read_resource fails to set it to false if the resource does exist
+                current = resource.clone(purged=False)
                 changes = {}
                 try:
                     self.read_resource(ctx, current)


### PR DESCRIPTION
Currently read_resource gets a clone of the desired state. If the
desired state requests purged=true, often a handler developer forgets to
manually set it to false. (because resourcepurged exception is most
often used)

This sets the default value for a clone to false for purged.