### PR TITLE
Fix error message for wrong type in ctor

### DIFF
--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -116,7 +116,7 @@ class SetAttribute(AssignStatement):
         instance = self.instance.execute(requires, resolver, queue)
         var = instance.get_attribute(self.attribute_name)
         reqs = self.value.requires_emit_gradual(resolver, queue, var)
-        SetAttributeHelper(queue, resolver, var, reqs, self.value, self, instance)
+        SetAttributeHelper(queue, resolver, var, reqs, self.value, self, instance, self.attribute_name)
 
     def __str__(self) -> str:
         return "%s.%s = %s" % (str(self.instance), self.attribute_name, str(self.value))
@@ -131,17 +131,19 @@ class SetAttributeHelper(ExecutionUnit):
                  requires: typing.Dict[object, ResultVariable],
                  expression: ExpressionStatement,
                  stmt: Statement,
-                 instance: Instance) -> None:
+                 instance: Instance,
+                 attribute_name: str) -> None:
         ExecutionUnit.__init__(self, queue_scheduler, resolver, result, requires, expression)
         self.stmt = stmt
         self.instance = instance
+        self.attribute_name = attribute_name
 
     def execute(self) -> None:
         try:
             ExecutionUnit.execute(self)
         except RuntimeException as e:
             e.set_statement(self.stmt)
-            raise AttributeException(self.stmt, self.instance, self.stmt.attribute_name, e)
+            raise AttributeException(self.stmt, self.instance, self.attribute_name, e)
 
     def __str__(self) -> str:
         return str(self.stmt)

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -296,7 +296,7 @@ class Constructor(GeneratorStatement):
         for attributename, valueexpression in self._indirect_attributes.items():
             var = object_instance.get_attribute(attributename)
             reqs = valueexpression.requires_emit_gradual(resolver, queue, var)
-            SetAttributeHelper(queue, resolver, var, reqs, valueexpression, self, object_instance)
+            SetAttributeHelper(queue, resolver, var, reqs, valueexpression, self, object_instance, attributename)
 
         # add anonymous implementations
         if self.implemented:

--- a/tests/test_compiler_errors.py
+++ b/tests/test_compiler_errors.py
@@ -277,3 +277,41 @@ def test_index_undefined_attribute(snippetcompiler):
     """,
         "Attribute 'foo' referenced in index is not defined in entity std::Entity (reported in index "
         "std::Entity(foo, bar) ({dir}/main.cf:2))")
+
+
+def test_set_wrong_relation_type(snippetcompiler):
+    """
+        Test the error message when setting the wrong type on a relation in the two cases:
+        1) on an instance
+        2) in the constructor
+    """
+    snippetcompiler.setup_for_error(
+        """
+        entity Credentials:
+        end
+
+        Credentials.file [1] -- std::File
+
+        implement Credentials using std::none
+
+        creds = Credentials(file=creds)
+        """,
+        "Could not set attribute `file` on instance `__config__::Credentials (instantiated at {dir}/main.cf:9)` caused by "
+        "Invalid class type for __config__::Credentials (instantiated at {dir}/main.cf:9), should be std::File "
+        "(reported in Construct(Credentials) ({dir}/main.cf:9:34)) (reported in Construct(Credentials) ({dir}/main.cf:9))")
+
+    snippetcompiler.setup_for_error(
+        """
+        entity Credentials:
+        end
+
+        Credentials.file [1] -- std::File
+
+        implement Credentials using std::none
+
+        creds = Credentials()
+        creds.file = creds
+        """,
+        "Could not set attribute `file` on instance `__config__::Credentials (instantiated at {dir}/main.cf:9)` caused by "
+        "Invalid class type for __config__::Credentials (instantiated at {dir}/main.cf:9), should be std::File "
+        "(reported in creds.file = creds ({dir}/main.cf:10:22)) (reported in creds.file = creds ({dir}/main.cf:10))")


### PR DESCRIPTION
When a relation was assigned an instance of a wrong type inside the
constructor an error was caused during the generation of the error
message. This refactor handles the both cases + adds test cases

Fixes #557 