### PR TITLE
empty optionals 

### DIFF
--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -2034,7 +2034,8 @@ c1 = C(name="c1")
 b1.a = a1
 b1.a = c1.a
 """)
-    (_, scopes) = compiler.do_compile()
+    with pytest.raises(OptionalValueException):
+        (_, scopes) = compiler.do_compile()
 
 
 def test_608_opt_to_single(snippetcompiler):
@@ -2071,7 +2072,8 @@ c1 = C(name="c1")
 b1.a = a1
 b1.a = c1.a
 """)
-    (_, scopes) = compiler.do_compile()
+    with pytest.raises(OptionalValueException):
+        (_, scopes) = compiler.do_compile()
 
 
 def test_608_opt_to_single_2(snippetcompiler):

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -1997,3 +1997,193 @@ a="Net has tags {{ net1.tags }}"
     a = root.lookup("a").get_value()
 
     assert a == """Net has tags ['vlan']"""
+
+
+def test_608_opt_to_list(snippetcompiler):
+    snippetcompiler.setup_for_snippet("""
+implementation none for std::Entity:
+end
+
+entity A:
+    string name
+end
+
+entity B:
+    string name
+end
+
+B.a [1:] -- A
+
+entity C:
+    string name
+end
+
+C.a [0:1] -- A
+
+implement A using none
+implement B using none
+implement C using none
+
+a1 = A(name="a1")
+a2 = A(name="a2")
+
+b1 = B(name="b1")
+
+c1 = C(name="c1")
+
+b1.a = a1
+b1.a = c1.a
+""")
+    (_, scopes) = compiler.do_compile()
+
+
+def test_608_opt_to_single(snippetcompiler):
+    snippetcompiler.setup_for_snippet("""
+implementation none for std::Entity:
+end
+
+entity A:
+    string name
+end
+
+entity B:
+    string name
+end
+
+B.a [1] -- A
+
+entity C:
+    string name
+end
+
+C.a [0:1] -- A
+
+implement A using none
+implement B using none
+implement C using none
+
+a1 = A(name="a1")
+
+b1 = B(name="b1")
+
+c1 = C(name="c1")
+
+b1.a = a1
+b1.a = c1.a
+""")
+    (_, scopes) = compiler.do_compile()
+
+
+def test_608_opt_to_single_2(snippetcompiler):
+    snippetcompiler.setup_for_snippet("""
+implementation none for std::Entity:
+end
+
+entity A:
+    string name
+end
+
+entity B:
+    string name
+end
+
+B.a [1] -- A
+
+entity C:
+    string name
+end
+
+C.a [0:1] -- A
+
+implement A using none
+implement B using none
+implement C using none
+
+a1 = A(name="a1")
+
+b1 = B(name="b1")
+
+c1 = C(name="c1")
+
+b1.a = a1
+b1.a = c1.a
+
+c1.a = a1
+""")
+    (_, scopes) = compiler.do_compile()
+
+
+def test_608_list_to_list(snippetcompiler):
+    snippetcompiler.setup_for_snippet("""
+implementation none for std::Entity:
+end
+
+entity A:
+    string name
+end
+
+entity B:
+    string name
+end
+
+B.a [1:] -- A
+
+entity C:
+    string name
+end
+
+C.a [0:] -- A
+
+implement A using none
+implement B using none
+implement C using none
+
+a1 = A(name="a1")
+a2 = A(name="a2")
+
+b1 = B(name="b1")
+
+c1 = C(name="c1")
+
+b1.a = a1
+b1.a = c1.a
+""")
+    (_, scopes) = compiler.do_compile()
+
+
+def test_608_list_to_single(snippetcompiler):
+    snippetcompiler.setup_for_snippet("""
+implementation none for std::Entity:
+end
+
+entity A:
+    string name
+end
+
+entity B:
+    string name
+end
+
+B.a [1] -- A
+
+entity C:
+    string name
+end
+
+C.a [0:] -- A
+
+implement A using none
+implement B using none
+implement C using none
+
+a1 = A(name="a1")
+a2 = A(name="a2")
+
+b1 = B(name="b1")
+
+c1 = C(name="c1")
+
+b1.a = c1.a
+""")
+    with pytest.raises(AttributeException):
+        (_, scopes) = compiler.do_compile()


### PR DESCRIPTION
current situation:
[0:1] -- A  is in java terms Optional[A] (accessing it with no value is
an error, it has either one value or is invalid)
[:1] -- A is in java terms Set[A] (it may contain any number of values
including none)

we should decide:
1- do we retain the behavior of [0:1] as optional
2- do we need a construct that is 'list with one or 0 values' that can
always be assigned to lists, but only to single valued variables if it
has a value  (if we have such a construct, does it work the same on +=
and =)
3- do we need a construct that is 'list with one or 0 values' that can
always be assigned (i.e. no direct warning on usage of empty optional)

see #608 