### PR TITLE
Add start to the index for the get_log query

### DIFF
--- a/src/inmanta/data.py
+++ b/src/inmanta/data.py
@@ -1024,7 +1024,8 @@ class ResourceAction(BaseDocument):
 
     __indexes__ = [
         dict(keys=[("environment", pymongo.ASCENDING), ("action_id", pymongo.ASCENDING)], unique=True),
-        dict(keys=[("environment", pymongo.ASCENDING), ("resource_version_ids", pymongo.ASCENDING), ("started", pymongo.DESCENDING)]),
+        dict(keys=[("environment", pymongo.ASCENDING), ("resource_version_ids", pymongo.ASCENDING),
+                   ("started", pymongo.DESCENDING)]),
     ]
 
     def __init__(self, from_mongo=False, **kwargs):

--- a/src/inmanta/data.py
+++ b/src/inmanta/data.py
@@ -1024,7 +1024,7 @@ class ResourceAction(BaseDocument):
 
     __indexes__ = [
         dict(keys=[("environment", pymongo.ASCENDING), ("action_id", pymongo.ASCENDING)], unique=True),
-        dict(keys=[("environment", pymongo.ASCENDING), ("resource_version_ids", pymongo.ASCENDING)]),
+        dict(keys=[("environment", pymongo.ASCENDING), ("resource_version_ids", pymongo.ASCENDING), ("started", pymongo.DESCENDING)]),
     ]
 
     def __init__(self, from_mongo=False, **kwargs):


### PR DESCRIPTION
The index allows mongo to stream the data instead of having to sort it
in memory.