### PR TITLE
Add pytest plugins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+PyJWT==1.6.4
 click==7.0
 colorlog==3.1.4
 cryptography==2.3.1
@@ -6,11 +7,13 @@ inmanta-sphinx==0.8
 motor==2.0.0
 netifaces==0.10.7
 ply==3.11
-PyJWT==1.6.4
 pymongo==3.7.2
 pytest-cover==3.0.0
+pytest-instafail
 pytest-randomly==1.2.3
+pytest-sugar
 pytest-tornado==0.5.0
+pytest-xdist
 pytest==3.10.0
 python-dateutil==2.7.5
 pyyaml==3.13

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,9 @@ deps=
     pytest-tornado
     pytest-cover
     pytest-randomly
+    pytest-xdist
+    pytest-sugar
+    pytest-instafail
     mongobox
     pymongo
     motor


### PR DESCRIPTION
3 plugins added, pyup will pin the versions

1. improve output on the commandline
2. show failures when they happen instead of at the end
3. add xdist to run tests in parallel with -n 4 for example