### PR TITLE
Change generator type to prevent windows loading error

### DIFF
--- a/src/inmanta/protocol/endpoints.py
+++ b/src/inmanta/protocol/endpoints.py
@@ -35,7 +35,7 @@ from tornado import ioloop, gen
 LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
-NoneGen = Generator[Any, Any, NoReturn]
+NoneGen = Generator[Any, Any, None]
 
 
 class CallTarget(object):


### PR DESCRIPTION
This change belongs under windows support in changelog, so no entry.