### PR TITLE
Make sure that the deletion of a project is properly cascaded

### DIFF
--- a/src/inmanta/data.py
+++ b/src/inmanta/data.py
@@ -459,7 +459,9 @@ class Project(BaseDocument):
 
     @gen.coroutine
     def delete_cascade(self):
-        yield Environment.delete_all(project=self.id)
+        environments = yield Environment.get_list(project=self.id)
+        for env in environments:
+            yield env.delete_cascade()
         yield self.delete()
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -242,6 +242,78 @@ async def test_project_no_project_name(data_module):
 
 
 @pytest.mark.asyncio
+async def test_project_cascade_delete(data_module):
+    project = data.Project(name="proj")
+    await project.insert()
+
+    env = data.Environment(name="dev", project=project.id, repo_url="", repo_branch="")
+    await env.insert()
+
+    agent_proc = data.AgentProcess(hostname="testhost",
+                                   environment=env.id,
+                                   first_seen=datetime.datetime.now(),
+                                   last_seen=datetime.datetime.now(),
+                                   sid=uuid.uuid4())
+    await agent_proc.insert()
+
+    agi1 = data.AgentInstance(process=agent_proc.id, name="agi1", tid=env.id)
+    await agi1.insert()
+    agi2 = data.AgentInstance(process=agent_proc.id, name="agi2", tid=env.id)
+    await agi2.insert()
+
+    agent = data.Agent(environment=env.id, name="agi1", last_failover=datetime.datetime.now(), paused=False,
+                       primary=agi1.id)
+    await agent.insert()
+
+    version = int(time.time())
+    cm = data.ConfigurationModel(version=version, environment=env.id)
+    await cm.insert()
+
+    resource_ids = []
+    for i in range(5):
+        path = "/etc/file" + str(i)
+        key = "std::File[agent1,path=" + path + "]"
+        res1 = data.Resource.new(environment=env.id, resource_version_id=key + ",v=%d" % version,
+                                 attributes={"path": path})
+        await res1.insert()
+        resource_ids.append(res1.id)
+
+    code = data.Code(version=version, resource="std::File", environment=env.id)
+    await code.insert()
+
+    unknown_parameter = data.UnknownParameter(name="test", environment=env.id, version=version, source="")
+    await unknown_parameter.insert()
+
+    await env.set(data.AUTO_DEPLOY, True)
+
+    assert (await data.Project.get_by_id(project.id)) is not None
+    assert (await data.Environment.get_by_id(env.id)) is not None
+    assert (await data.AgentProcess.get_by_id(agent_proc.id)) is not None
+    assert (await data.AgentInstance.get_by_id(agi1.id)) is not None
+    assert (await data.AgentInstance.get_by_id(agi2.id)) is not None
+    assert (await data.Agent.get_by_id(agent.id)) is not None
+    for current_id in resource_ids:
+        assert (await data.Resource.get_by_id(current_id)) is not None
+    assert (await data.Code.get_by_id(code.id)) is not None
+    assert (await data.UnknownParameter.get_by_id(unknown_parameter.id)) is not None
+    assert (await env.get(data.AUTO_DEPLOY)) is True
+
+    await project.delete_cascade()
+
+    assert (await data.Project.get_by_id(project.id)) is None
+    assert (await data.Environment.get_by_id(env.id)) is None
+    assert (await data.AgentProcess.get_by_id(agent_proc.id)) is None
+    assert (await data.AgentInstance.get_by_id(agi1.id)) is None
+    assert (await data.AgentInstance.get_by_id(agi2.id)) is None
+    assert (await data.Agent.get_by_id(agent.id)) is None
+    for current_id in resource_ids:
+        assert (await data.Resource.get_by_id(current_id)) is None
+    assert (await data.Code.get_by_id(code.id)) is None
+    assert (await data.UnknownParameter.get_by_id(unknown_parameter.id)) is None
+    assert (await env.get(data.AUTO_DEPLOY)) is True
+
+
+@pytest.mark.asyncio
 async def test_environment(data_module):
     project = data.Project(name="test")
     await project.insert()


### PR DESCRIPTION
This bug is responsible for the fact that the error message "The environment id does not exist" shows up in the agents tab of the dashboard when a project has been deleted before.