### PR TITLE
Tornado httpclient does not work with asyncio loop for fetching jwks public keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changes in this release:
 - Add support to run the compiler on windows
 - Added exception explainer to compiler for 'modified after freeze' (#876)
 - Added logging of resource actions on the server and purging of resource actions in the database (#533)
+- Use urllib client for fetching jwks public keys
 
 DEPRECATIONS:
 - The config option agent-interval, agent-splay, autostart_agent_interval and autostart_splay are 

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -506,7 +506,7 @@ class AuthJWTConfig(object):
             self.validate_cert = True
 
         ctx = None
-        if self.validate_cert:
+        if not self.validate_cert:
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -112,5 +112,5 @@ validate_cert=false
     from inmanta.config import Config, AuthJWTConfig
     Config.load_config(config_file)
 
-    cfg_list = await asyncio.get_running_loop().run_in_executor(None, AuthJWTConfig.list)
+    cfg_list = await asyncio.get_event_loop().run_in_executor(None, AuthJWTConfig.list)
     assert len(cfg_list) == 2

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,5 +1,5 @@
 """
-    Copyright 2017 Inmanta
+    Copyright 2019 Inmanta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -15,8 +15,14 @@
 
     Contact: code@inmanta.com
 """
-from inmanta import protocol
 import time
+import os
+import pytest
+import tornado
+
+from tornado import web
+
+from inmanta import protocol
 
 
 def test_jwt_create(inmanta_config):
@@ -38,3 +44,63 @@ def test_jwt_create(inmanta_config):
     assert jot3 != jot4
     assert jot1 != jot3
     assert jot2 != jot3
+
+
+class PKHandler(web.RequestHandler):
+    def get(self):
+        public_key = {
+            "keys": [
+                {
+                    "kid": "NMROYvAmygR5zzmtYXgmCbJd8cXHcvAtx_o-JxJNPoQ",
+                    "kty": "RSA",
+                    "alg": "RS256",
+                    "use": "sig",
+                    "n": "oA7zi9u230-e3atV4rW9oI6z3ea_rViKlBTqq4_v9E-PK47yPpUvnHH9eJrKBXcuX-cVO2pSmDQ65nAzEaobjBU8XPtm3sceY1GsC"
+                    "cP4Uo7gEbqLxsaqN1WUt1tnbV10wEbZzHmtAW_J_J5wlIB696ceEdwxNyj3Zscq15QIMsahDmV54fvwussuPgNhd0t4ng9BzaW-kG"
+                    "2-Z80blyxN3fUbXX1JRMOiX4a7W_UXN5Q9B4kE9vlqAm30FnhYvLLqKh-DFvxq49dbYTWR-pJSFkjRMD6u1MUzKQEmOLYTnDX42zA"
+                    "rTVhbvQl7OnW-OXtwx9zVqiQIIqt5IQgZQ7PfwQ",
+                    "e": "AQAB",
+                }
+            ]
+        }
+
+        time.sleep(1.1)
+
+
+@pytest.fixture(scope="function")
+async def jwks(unused_tcp_port):
+    http_app = web.Application([(r"/auth/realms/inmanta/protocol/openid-connect/certs", PKHandler)])
+    server = tornado.httpserver.HTTPServer(http_app)
+    server.bind(unused_tcp_port)
+    server.start()
+    yield server
+
+    server.stop()
+    await server.close_all_connections()
+
+
+@pytest.mark.asyncio(timeout=30)
+async def test_validate_rs256(jwks, tmp_path):
+    """
+        Test that inmanta can download a rs256 public key
+    """
+    port = str(list(jwks._sockets.values())[0].getsockname()[1])
+    config_file = os.path.join(tmp_path, "auth.cfg")
+    with open(config_file, "w+") as fd:
+        fd.write("""
+[auth_jwt_keycloak]
+algorithm=RS256
+sign=false
+client_types=api
+issuer=https://localhost:{0}/auth/realms/inmanta
+audience=sodev
+jwks_uri=http://localhost:{0}/auth/realms/inmanta/protocol/openid-connect/certs
+validate_cert=false
+""".format(port))
+
+    from inmanta.config import Config, AuthJWTConfig
+    Config.load_config(config_file)
+
+    cfg_list = AuthJWTConfig.list()
+
+    assert len(cfg_list) == 1


### PR DESCRIPTION
This patch uses python urlopen and adds a test case for this