### PR TITLE
Bump version, exclude doc build and raise python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ v 2018.4 (2018-12-xx)
 Changes in this release:
 - Various bugfixes and performance enhancements (#873, #772, #958, #959)
 - Dependency updates
+- Minimal python version is now python 3.6
 - Removal of snapshot and restore functionality from the server (#789)
 - Removed the non-version api (#526)
 - Replace virtualenv by python standard venv (#783)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,3 +11,4 @@ recursive-include tests *
 global-exclude *.pyc
 global-exclude */__pycache__/*
 global-exclude **/.env/**
+exclude docs/build/**

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ requires = [
 ]
 
 setup(
-    version="2018.4",
-    python_requires='>=3.5', # also update classifiers 
+    version="2019.1",
+    python_requires='>=3.5', # also update classifiers
     # Meta data
     name="inmanta",
     description="Inmanta deployment tool",
@@ -57,5 +57,5 @@ setup(
             "inmanta = inmanta.app:app",
         ]
     },
-    
+
 )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requires = [
 
 setup(
     version="2019.1",
-    python_requires='>=3.5', # also update classifiers
+    python_requires='>=3.6', # also update classifiers
     # Meta data
     name="inmanta",
     description="Inmanta deployment tool",


### PR DESCRIPTION
This bumps version the to be release Inmanta 2019.1 and bumpd the python
version to 3.6 The code already required this version.