### PR TITLE
Use the built-in isoformat parser

### DIFF
--- a/src/inmanta/main.py
+++ b/src/inmanta/main.py
@@ -491,9 +491,6 @@ def version_release(client: Client, environment: str, push: bool, full: bool, ve
     )
 
 
-ISOFMT = "%Y-%m-%dT%H:%M:%S.%f"
-
-
 @cmd.group("param")
 @click.pass_context
 def param(ctx: click.Context) -> None:
@@ -506,7 +503,7 @@ def param(ctx: click.Context) -> None:
 def param_list(client: Client, environment: str) -> None:
     result = client.get_dict("list_params", arguments=dict(tid=client.to_environment_id(environment)))
     expire = int(result["expire"])
-    now = datetime.datetime.strptime(result["now"], ISOFMT)
+    now = datetime.datetime.fromisoformat(result["now"])
     when = now - datetime.timedelta(0, expire)
 
     data = []
@@ -518,7 +515,7 @@ def param_list(client: Client, environment: str) -> None:
                 p['name'],
                 p['source'],
                 p['updated'],
-                str(float(datetime.datetime.strptime(p["updated"], ISOFMT) < when))
+                str(float(datetime.datetime.fromisoformat(p["updated"]) < when))
             ]
         )
 

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -158,7 +158,7 @@ class CallArguments(object):
 
         try:
             if arg_type == datetime:
-                return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
+                return datetime.fromisoformat(value)
 
             elif issubclass(arg_type, enum.Enum):
                 return arg_type[value]


### PR DESCRIPTION
Until now we used the isoformat to string but not the parser for
datetime to string and vice versa. This patch uses both built-in
functions.