### PR TITLE
Issue/module update

### DIFF
--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -142,6 +142,9 @@ class CLIGitProvider(GitProvider):
         subprocess.check_call(["git", "tag", "-a", "-m", "auto tag by module tool", tag], cwd=repo,
                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
+    def pull(self, repo: str) -> str:
+        return subprocess.check_output(["git", "pull"], cwd=repo, stderr=subprocess.DEVNULL).decode("utf-8")
+
     def push(self, repo: str) -> str:
         return subprocess.check_output(["git", "push", "--follow-tags", "--porcelain"],
                                        cwd=repo, stderr=subprocess.DEVNULL).decode("utf-8")
@@ -809,6 +812,8 @@ class Module(ModuleLike):
 
         if install_mode == INSTALL_MASTER:
             gitprovider.checkout_tag(path, "master")
+            if fetch:
+                gitprovider.pull(path)
         else:
             release_only = (install_mode == INSTALL_RELEASES)
             version = cls.get_suitable_version_for(modulename, requirements, path, release_only=release_only)

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -403,7 +403,7 @@ version: 0.0.1dev0""" % {"name": name})
             else:
                 spec = specs[module]
                 try:
-                    Module.update(project, name, spec, install_mode=project._install_mode)
+                    Module.update(project, module, spec, install_mode=project._install_mode)
                 except Exception:
                     LOGGER.exception("Failed to update module")
 

--- a/tests/test_moduletool.py
+++ b/tests/test_moduletool.py
@@ -282,10 +282,10 @@ def modules_repo(modules_dir):
     commitmodule(masterproject, "first commit")
 
     masterproject_multi_mod = makemodule(reporoot,
-                                             "masterproject_multi_mod",
-                                             project=True,
-                                             imports=["mod2", "mod8"],
-                                             install_mode=INSTALL_MASTER)
+                                         "masterproject_multi_mod",
+                                         project=True,
+                                         imports=["mod2", "mod8"],
+                                         install_mode=INSTALL_MASTER)
     commitmodule(masterproject_multi_mod, "first commit")
 
     nover = makemodule(reporoot, "nover", [])

--- a/tests/test_moduletool.py
+++ b/tests/test_moduletool.py
@@ -151,6 +151,18 @@ def install_project(modules_dir, name, config=True):
     return coroot
 
 
+def clone_repo(source_dir, repo_name, destination_dir):
+    subprocess.check_output(["git", "clone", os.path.join(source_dir, repo_name)],
+                            cwd=destination_dir,
+                            stderr=subprocess.STDOUT)
+    subprocess.check_output(["git", "config", "user.email", '"test@test.example"'],
+                            cwd=os.path.join(destination_dir, repo_name),
+                            stderr=subprocess.STDOUT)
+    subprocess.check_output(["git", "config", "user.name", 'Tester test'],
+                            cwd=os.path.join(destination_dir, repo_name),
+                            stderr=subprocess.STDOUT)
+
+
 class BadModProvider(object):
 
     def __init__(self, parent, badname):
@@ -751,8 +763,7 @@ def test_module_update_with_install_mode_master(tmpdir, modules_dir, modules_rep
                                                 kwargs_update_method, mod2_should_be_updated, mod8_should_be_updated):
     # Make a copy of masterproject_multi_mod
     masterproject_multi_mod = tmpdir.join("masterproject_multi_mod")
-    subprocess.check_output(["git", "clone", os.path.join(modules_dir, "repos", "masterproject_multi_mod")],
-                            cwd=tmpdir, stderr=subprocess.STDOUT)
+    clone_repo(modules_repo, "masterproject_multi_mod", tmpdir)
     libs_folder = os.path.join(masterproject_multi_mod, "libs")
     os.mkdir(libs_folder)
 
@@ -764,11 +775,10 @@ def test_module_update_with_install_mode_master(tmpdir, modules_dir, modules_rep
     # Dependencies masterproject_multi_mod
     for mod in ["mod2", "mod8"]:
         # Clone mod in root tmpdir
-        subprocess.check_output(["git", "clone", os.path.join(modules_dir, "repos", mod)],
-                                cwd=tmpdir, stderr=subprocess.STDOUT)
+        clone_repo(modules_repo, mod, tmpdir)
+
         # Clone mod from root of tmpdir into libs folder of masterproject_multi_mod
-        subprocess.check_output(["git", "clone", os.path.join(tmpdir, mod)],
-                                cwd=libs_folder, stderr=subprocess.STDOUT)
+        clone_repo(tmpdir, mod, libs_folder)
 
         # Update module in root of tmpdir by adding an extra file
         file_name_extra_file = "test_file"


### PR DESCRIPTION
This PR fixes a bug in the update feature of the moduletool, which prevents a module from being updated to its latest version when install_mode is set to master. 