### PR TITLE
issue/remove-std-state

### DIFF
--- a/tests/data/modules/test/model/_init.cf
+++ b/tests/data/modules/test/model/_init.cf
@@ -1,4 +1,4 @@
-entity Resource extends std::PurgeableResource, std::State:
+entity Resource extends std::PurgeableResource:
     string agent="internal"
     string key
     string value


### PR DESCRIPTION
Do not use std::State in test cases, since it has been removed from the std module.