### PR TITLE
Set --log-file-level option in the service files

### DIFF
--- a/misc/inmanta-agent.service
+++ b/misc/inmanta-agent.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/inmanta -c /etc/inmanta/agent.cfg --log-file /var/log/inmanta/agent.log --timed-logs -vv agent
+ExecStart=/usr/bin/inmanta -c /etc/inmanta/agent.cfg --log-file /var/log/inmanta/agent.log --log-file-level 2 --timed-logs agent
 Restart=on-failure
 User=root
 Group=root

--- a/misc/inmanta-server.service
+++ b/misc/inmanta-server.service
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 User=inmanta
 Group=inmanta
-ExecStart=/usr/bin/inmanta -c /etc/inmanta/server.cfg --log-file /var/log/inmanta/server.log --timed-logs -vv server
+ExecStart=/usr/bin/inmanta -c /etc/inmanta/server.cfg --log-file /var/log/inmanta/server.log --log-file-level 2 --timed-logs server
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Set --log-file-level option in the service files, since logs are always written to disk by default. 