### PR TITLE
Reformat code base with black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,8 +10,9 @@
 # E252 missing whitespace around parameter equals
 # w503 line break occurred before a binary operator
 # E402 module level import not at top of file
+# E203 whitespaces and the slice operator. black and flake disagree
 
 [flake8]
-ignore = H405,H404,H302,H306,H301,H101,H801,E402,W503,E252
+ignore = H405,H404,H302,H306,H301,H101,H801,E402,W503,E252,E203
 max-line-length = 128
 exclude = **/.env,.venv,.git,.tox,dist,doc,**egg,src/inmanta/parser/parsetab.py,src/inmanta/parser/plyInmantaParser.py,tests/data/**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.black]
+line-length = 128
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | \.env
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ pytest-env==0.6.2
 jinja2==2.10.1
 pep8-naming==0.8.2
 flake8==3.7.7
+flake8-black==0.0.4
 psutil==5.6.2
 pyformance==0.4
 pymongo==3.8.0

--- a/src/inmanta/agent/cache.py
+++ b/src/inmanta/agent/cache.py
@@ -27,14 +27,12 @@ LOGGER = logging.getLogger()
 
 
 class Scope(object):
-
-    def __init__(self, timeout: int=24 * 3600, version: int=0):
+    def __init__(self, timeout: int = 24 * 3600, version: int = 0):
         self.timeout = timeout
         self.version = version
 
 
 class CacheItem(object):
-
     def __init__(self, key, scope: Scope, value, call_on_delete):
         self.key = key
         self.scope = scope
@@ -173,7 +171,7 @@ class AgentCache(object):
             key.append(str(resource.id.resource_str()))
         if version != 0:
             key.append(str(version))
-        key = '__'.join(key)
+        key = "__".join(key)
         self._cache(CacheItem(key, Scope(timeout, version), value, call_on_delete))
 
     def find(self, key, resource=None, version=0):
@@ -189,11 +187,12 @@ class AgentCache(object):
             key.append(resource.id.resource_str())
         if version != 0:
             key.append(str(version))
-        key = '__'.join(key)
+        key = "__".join(key)
         return self._get(key).value
 
-    def get_or_else(self, key, function, for_version=True, timeout=5000, ignore=set(),
-                    cache_none=True, call_on_delete=None, **kwargs):
+    def get_or_else(
+        self, key, function, for_version=True, timeout=5000, ignore=set(), cache_none=True, call_on_delete=None, **kwargs
+    ):
         """
             Attempt to find a value in the cache.
 

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -23,65 +23,97 @@ LOGGER = logging.getLogger(__name__)
 
 # flake8: noqa: H904
 
-agent_map = \
-    Option("config", "agent-map", None,
-           """By default the agent assumes that all agent names map to the host on which the process is executed. With the
+agent_map = Option(
+    "config",
+    "agent-map",
+    None,
+    """By default the agent assumes that all agent names map to the host on which the process is executed. With the
 agent map it can be mapped to other hosts. This value consists of a list of key/value pairs. The key is the name of the
 agent and the format of the value is described in :inmanta:entity:`std::AgentConfig`
 
-example: iaas_openstack=localhost,vm1=192.16.13.2""", is_map)
+example: iaas_openstack=localhost,vm1=192.16.13.2""",
+    is_map,
+)
 
-environment = \
-    Option("config", "environment", None,
-           "The environment this agent or compile belongs to", is_uuid_opt)
+environment = Option("config", "environment", None, "The environment this agent or compile belongs to", is_uuid_opt)
 
-agent_names = \
-    Option("config", "agent-names", "$node-name",
-           "Names of the agents this instance should deploy configuration for", is_str)
+agent_names = Option(
+    "config", "agent-names", "$node-name", "Names of the agents this instance should deploy configuration for", is_str
+)
 
-agent_interval = \
-    Option("config", "agent-interval", 600, """[DEPRECATED] The run interval of the agent.
-Every run-interval seconds, the agent will check the current state of its resources against to desired state model""", is_time)
+agent_interval = Option(
+    "config",
+    "agent-interval",
+    600,
+    """[DEPRECATED] The run interval of the agent.
+Every run-interval seconds, the agent will check the current state of its resources against to desired state model""",
+    is_time,
+)
 
-agent_splay = \
-    Option("config", "agent-splay", 600, """[DEPRECATED] The splaytime added to the runinterval.
+agent_splay = Option(
+    "config",
+    "agent-splay",
+    600,
+    """[DEPRECATED] The splaytime added to the runinterval.
 Set this to 0 to disable splaytime.
  At startup the agent will choose a random number between 0 and "agent_splay.
 It will wait this number of second before performing the first deploy.
-Each subsequent deploy will start agent-interval seconds after the previous one.""", is_time)
+Each subsequent deploy will start agent-interval seconds after the previous one.""",
+    is_time,
+)
 
-agent_reconnect_delay = \
-    Option("config", "agent-reconnect-delay", 5,
-           "Time to wait after a failed heartbeat message. DO NOT SET TO 0 ", is_int)
+agent_reconnect_delay = Option(
+    "config", "agent-reconnect-delay", 5, "Time to wait after a failed heartbeat message. DO NOT SET TO 0 ", is_int
+)
 
-server_timeout = \
-    Option("config", "server-timeout", 125,
-           "Amount of time to wait for a response from the server before we try to reconnect, must be smaller than server.agent-hold", is_time)
+server_timeout = Option(
+    "config",
+    "server-timeout",
+    125,
+    "Amount of time to wait for a response from the server before we try to reconnect, must be smaller than server.agent-hold",
+    is_time,
+)
 
-agent_deploy_interval = \
-    Option("config", "agent-deploy-interval", 0,
-           "The number of seconds between two (incremental) deployment runs of the agent.", is_time, predecessor_option=agent_interval)
-agent_deploy_splay_time = \
-    Option("config", "agent-deploy-splay-time", 600,
-           """The splaytime added to the agent-deploy-interval. Set this to 0 to disable the splaytime.
+agent_deploy_interval = Option(
+    "config",
+    "agent-deploy-interval",
+    0,
+    "The number of seconds between two (incremental) deployment runs of the agent.",
+    is_time,
+    predecessor_option=agent_interval,
+)
+agent_deploy_splay_time = Option(
+    "config",
+    "agent-deploy-splay-time",
+    600,
+    """The splaytime added to the agent-deploy-interval. Set this to 0 to disable the splaytime.
 
 At startup the agent will choose a random number between 0 and agent-deploy-splay-time.
 It will wait this number of second before performing the first deployment run.
-Each subsequent repair deployment will start agent-deploy-interval seconds after the previous one.""", is_time,
-           predecessor_option=agent_splay)
+Each subsequent repair deployment will start agent-deploy-interval seconds after the previous one.""",
+    is_time,
+    predecessor_option=agent_splay,
+)
 
-agent_repair_interval = \
-    Option("config", "agent-repair-interval", 600,
-           "The number of seconds between two repair runs (full deploy) of the agent. " +
-           "Set this to 0 to disable the scheduled repair runs.", is_time)
-agent_repair_splay_time = \
-    Option("config", "agent-repair-splay-time", 600,
-           """The splaytime added to the agent-repair-interval. Set this to 0 to disable the splaytime.
+agent_repair_interval = Option(
+    "config",
+    "agent-repair-interval",
+    600,
+    "The number of seconds between two repair runs (full deploy) of the agent. "
+    + "Set this to 0 to disable the scheduled repair runs.",
+    is_time,
+)
+agent_repair_splay_time = Option(
+    "config",
+    "agent-repair-splay-time",
+    600,
+    """The splaytime added to the agent-repair-interval. Set this to 0 to disable the splaytime.
 
 At startup the agent will choose a random number between 0 and agent-repair-splay-time.
 It will wait this number of second before performing the first repair run.
-Each subsequent repair deployment will start agent-repair-interval seconds after the previous one.""", is_time)
-
+Each subsequent repair deployment will start agent-repair-interval seconds after the previous one.""",
+    is_time,
+)
 
 
 ##############################

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -72,8 +72,14 @@ class ResourcePurged(Exception):
     """
 
 
-def cache(f=None, ignore: typing.List[str]=[], timeout: int=5000, for_version: bool=True, cache_none: bool=True,
-          cacheNone: bool=True):  # noqa: N803
+def cache(
+    f=None,
+    ignore: typing.List[str]=[],
+    timeout: int=5000,
+    for_version: bool=True,
+    cache_none: bool=True,
+    cacheNone: bool=True  # noqa: N803
+):
     """
         decorator for methods in resource handlers to provide caching
 

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -74,11 +74,11 @@ class ResourcePurged(Exception):
 
 def cache(
     f=None,
-    ignore: typing.List[str]=[],
-    timeout: int=5000,
-    for_version: bool=True,
-    cache_none: bool=True,
-    cacheNone: bool=True  # noqa: N803
+    ignore: typing.List[str] = [],
+    timeout: int = 5000,
+    for_version: bool = True,
+    cache_none: bool = True,
+    cacheNone: bool = True,  # noqa: N803
 ):
     """
         decorator for methods in resource handlers to provide caching
@@ -206,7 +206,7 @@ class HandlerContext(object):
     def change(self) -> const.Change:
         return self._change
 
-    def add_change(self, name: str, desired: typing.Any, current: typing.Any=None) -> None:
+    def add_change(self, name: str, desired: typing.Any, current: typing.Any = None) -> None:
         """
             Report a change of a field. This field is added to the set of updated fields
 
@@ -362,6 +362,7 @@ class ResourceHandler(object):
                 result = func()
                 if result is not None:
                     from tornado.gen import convert_yielded
+
                     result = convert_yielded(result)
                     concurrent.chain_future(result, f)
             except Exception as e:
@@ -537,7 +538,7 @@ class ResourceHandler(object):
         """
         raise NotImplementedError()
 
-    def execute(self, ctx: HandlerContext, resource: resources.Resource, dry_run: bool=False) -> None:
+    def execute(self, ctx: HandlerContext, resource: resources.Resource, dry_run: bool = False) -> None:
         """
             Update the given resource. This method is called by the agent. Most handlers will not override this method
             and will only override :func:`~inmanta.agent.handler.ResourceHandler.check_resource`, optionally
@@ -567,14 +568,20 @@ class ResourceHandler(object):
 
         except Exception as e:
             ctx.set_status(const.ResourceState.failed)
-            ctx.exception("An error occurred during deployment of %(resource_id)s (exception: %(exception)s",
-                          resource_id=resource.id, exception=repr(e))
+            ctx.exception(
+                "An error occurred during deployment of %(resource_id)s (exception: %(exception)s",
+                resource_id=resource.id,
+                exception=repr(e),
+            )
         finally:
             try:
                 self.post(ctx, resource)
             except Exception as e:
-                ctx.exception("An error occurred after deployment of %(resource_id)s (exception: %(exception)s",
-                              resource_id=resource.id, exception=repr(e))
+                ctx.exception(
+                    "An error occurred after deployment of %(resource_id)s (exception: %(exception)s",
+                    resource_id=resource.id,
+                    exception=repr(e),
+                )
 
     def facts(self, ctx: HandlerContext, resource: resources.Resource) -> dict:
         """
@@ -605,8 +612,11 @@ class ResourceHandler(object):
             try:
                 self.post(ctx, resource)
             except Exception as e:
-                ctx.exception("An error occurred after getting facts about %(resource_id)s (exception: %(exception)s",
-                              resource_id=resource.id, exception=repr(e))
+                ctx.exception(
+                    "An error occurred after getting facts about %(resource_id)s (exception: %(exception)s",
+                    resource_id=resource.id,
+                    exception=repr(e),
+                )
 
         return facts
 
@@ -627,6 +637,7 @@ class ResourceHandler(object):
             :param hash_id: The id of the content/file to retrieve from the server.
             :return: The content in the form of a bytestring or none is the content does not exist.
         """
+
         def call():
             return self.get_client().get_file(hash_id)
 
@@ -645,6 +656,7 @@ class ResourceHandler(object):
             :param hash_id: The id of the file on the server. The convention is the use the sha1sum of the content as id.
             :return: True if the file is available on the server.
         """
+
         def call():
             return self.get_client().stat_file(hash_id)
 
@@ -658,6 +670,7 @@ class ResourceHandler(object):
             :param hash_id: The id to identify the content. The convention is to use the sha1sum of the content to identify it.
             :param content: A byte string with the content
         """
+
         def call():
             return self.get_client().upload_file(id=hash_id, content=base64.b64encode(content).decode("ascii"))
 
@@ -717,7 +730,7 @@ class CRUDHandler(ResourceHandler):
             :param resource: The desired resource state.
         """
 
-    def execute(self, ctx: HandlerContext, resource: resources.PurgeableResource, dry_run: bool=None) -> None:
+    def execute(self, ctx: HandlerContext, resource: resources.PurgeableResource, dry_run: bool = None) -> None:
         """
             Update the given resource. This method is called by the agent. Override the CRUD methods of this class.
 
@@ -763,20 +776,28 @@ class CRUDHandler(ResourceHandler):
 
         except Exception as e:
             ctx.set_status(const.ResourceState.failed)
-            ctx.exception("An error occurred during deployment of %(resource_id)s (exception: %(exception)s)",
-                          resource_id=resource.id, exception=repr(e), traceback=traceback.format_exc())
+            ctx.exception(
+                "An error occurred during deployment of %(resource_id)s (exception: %(exception)s)",
+                resource_id=resource.id,
+                exception=repr(e),
+                traceback=traceback.format_exc(),
+            )
         finally:
             try:
                 self.post(ctx, resource)
             except Exception as e:
-                ctx.exception("An error occurred after deployment of %(resource_id)s (exception: %(exception)s",
-                              resource_id=resource.id, exception=repr(e))
+                ctx.exception(
+                    "An error occurred after deployment of %(resource_id)s (exception: %(exception)s",
+                    resource_id=resource.id,
+                    exception=repr(e),
+                )
 
 
 class Commander(object):
     """
         This class handles commands
     """
+
     __command_functions = defaultdict(dict)
     __handlers = []
     __handler_cache = {}

--- a/src/inmanta/agent/io/local.py
+++ b/src/inmanta/agent/io/local.py
@@ -588,8 +588,14 @@ if __name__ == '__channelexec__':
                 channel.send(result)  # NOQA
             except Exception as e:
                 import traceback
-                channel.send({"__type__": "RemoteException", "exception_type": str(e.__class__),  # noqa
-                              "exception_string": str(e), "traceback": str(traceback.format_exc())})
+                channel.send(  # NOQA
+                    {
+                        "__type__": "RemoteException",
+                        "exception_type": str(e.__class__),
+                        "exception_string": str(e),
+                        "traceback": str(traceback.format_exc())
+                    }
+                )
 
         else:
             raise AttributeError("Method %s is not supported" % item[0])

--- a/src/inmanta/agent/io/local.py
+++ b/src/inmanta/agent/io/local.py
@@ -46,6 +46,7 @@ class IOBase(object):
     """
         Base class for an IO module. This class is python2 compatible so IOs that work remote can load this module on python2.
     """
+
     def __init__(self, uri, config):
         """
             Initialize the IO
@@ -82,6 +83,7 @@ class BashIO(IOBase):
     """
         This class provides handler IO methods
     """
+
     def __init__(self, uri, config, run_as=None):
         super(BashIO, self).__init__(uri, config)
         self.run_as = run_as
@@ -153,8 +155,9 @@ class BashIO(IOBase):
             current_env.update(env)
 
         cmds = [command] + arguments
-        result = subprocess.Popen(self._run_as_args(*cmds),
-                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=current_env, cwd=cwd)
+        result = subprocess.Popen(
+            self._run_as_args(*cmds), stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=current_env, cwd=cwd
+        )
 
         if sys.version_info < (3, 0, 0):
             # TODO timeout is not supported
@@ -219,8 +222,9 @@ class BashIO(IOBase):
         """
             Do a statcall on a file
         """
-        result = subprocess.Popen(self._run_as_args("stat", "-c", "%a %U %G", path),
-                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        result = subprocess.Popen(
+            self._run_as_args("stat", "-c", "%a %U %G", path), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
         data = result.communicate()
 
         if result.returncode > 0:
@@ -253,8 +257,9 @@ class BashIO(IOBase):
         """
             Put the given content at the given path in UTF-8
         """
-        result = subprocess.Popen(self._run_as_args("dd", "of=" + path), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                  stdin=subprocess.PIPE)
+        result = subprocess.Popen(
+            self._run_as_args("dd", "of=" + path), stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE
+        )
         result.communicate(input=content)
 
         if result.returncode > 0:
@@ -288,8 +293,7 @@ class BashIO(IOBase):
         """
             Change the permissions
         """
-        result = subprocess.Popen(self._run_as_args("chmod", permissions, path),
-                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        result = subprocess.Popen(self._run_as_args("chmod", permissions, path), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         result.communicate()
 
         return result.returncode > 0
@@ -298,8 +302,7 @@ class BashIO(IOBase):
         """
             Create a directory
         """
-        result = subprocess.Popen(self._run_as_args("mkdir", path),
-                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        result = subprocess.Popen(self._run_as_args("mkdir", path), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         result.communicate()
 
         return result.returncode > 0
@@ -314,8 +317,7 @@ class BashIO(IOBase):
         if "*" in path:
             raise Exception("Do not use wildward in an rm -rf")
 
-        result = subprocess.Popen(self._run_as_args("rm", "-rf", path),
-                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        result = subprocess.Popen(self._run_as_args("rm", "-rf", path), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         result.communicate()
 
         return result.returncode > 0
@@ -335,6 +337,7 @@ class LocalIO(IOBase):
     """
         This class provides handler IO methods
     """
+
     def is_remote(self):
         """
             Are operation executed remote
@@ -353,7 +356,7 @@ class LocalIO(IOBase):
             :rtype: str
         """
         sha1sum = hashlib.sha1()
-        with open(path, 'rb') as f:
+        with open(path, "rb") as f:
             sha1sum.update(f.read())
 
         return sha1sum.hexdigest()
@@ -572,7 +575,7 @@ class LocalIO(IOBase):
         shutil.rmtree(path)
 
 
-if __name__ == '__channelexec__':
+if __name__ == "__channelexec__":
     global channel
 
     if os.getuid() == 0:
@@ -588,12 +591,13 @@ if __name__ == '__channelexec__':
                 channel.send(result)  # NOQA
             except Exception as e:
                 import traceback
+
                 channel.send(  # NOQA
                     {
                         "__type__": "RemoteException",
                         "exception_type": str(e.__class__),
                         "exception_string": str(e),
-                        "traceback": str(traceback.format_exc())
+                        "traceback": str(traceback.format_exc()),
                     }
                 )
 

--- a/src/inmanta/agent/io/remote.py
+++ b/src/inmanta/agent/io/remote.py
@@ -46,6 +46,7 @@ class SshIO(local.IOBase):
          * retries: The number of retries before giving up. The default number of retries 10
          * retry_wait: The time to wait between retries for the remote target to become available. The default wait is 30s
     """
+
     def is_remote(self):
         return True
 
@@ -89,8 +90,9 @@ class SshIO(local.IOBase):
                         self._group.terminate(0.1)
                         raise resources.HostNotFoundException(hostname=self._host, user=self._user, error=e)
 
-                    LOGGER.info("Failed to login to %s, waiting %d seconds and %d attempts left.",
-                                self.uri, self._retry_wait, attempts)
+                    LOGGER.info(
+                        "Failed to login to %s, waiting %d seconds and %d attempts left.", self.uri, self._retry_wait, attempts
+                    )
                     time.sleep(self._retry_wait)
 
         except BrokenPipeError as e:
@@ -128,8 +130,9 @@ class SshIO(local.IOBase):
 
         # check if we got an exception
         if isinstance(result, dict) and "__type__" in result and result["__type__"] == "RemoteException":
-            raise RemoteException(exception_type=result["exception_type"], msg=result["exception_string"],
-                                  traceback=result["traceback"])
+            raise RemoteException(
+                exception_type=result["exception_type"], msg=result["exception_string"], traceback=result["traceback"]
+            )
 
         return result
 
@@ -144,6 +147,7 @@ class SshIO(local.IOBase):
         """
             Proxy a function call to the local version on the other side of the channel.
         """
+
         def call(*args, **kwargs):
             result = self._execute(name, *args, **kwargs)
             return result

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -73,6 +73,7 @@ def start_server(options):
 @command("agent", help_msg="Start the inmanta agent")
 def start_agent(options):
     from inmanta import agent
+
     a = agent.Agent()
     setup_signal_handlers(a.stop)
     IOLoop.current().add_callback(a.start)
@@ -157,8 +158,14 @@ def compiler_config(parser):
         Configure the compiler of the export function
     """
     parser.add_argument("-e", dest="environment", help="The environment to compile this model for")
-    parser.add_argument("-X", "--extended-errors", dest="errors",
-                        help="Show stack traces for compile errors", action="store_true", default=False)
+    parser.add_argument(
+        "-X",
+        "--extended-errors",
+        dest="errors",
+        help="Show stack traces for compile errors",
+        action="store_true",
+        default=False,
+    )
     parser.add_argument("--server_address", dest="server", help="The address of the server hosting the environment")
     parser.add_argument("--server_port", dest="port", help="The port of the server hosting the environment")
     parser.add_argument("--username", dest="user", help="The username of the server")
@@ -168,8 +175,9 @@ def compiler_config(parser):
     parser.add_argument("-f", dest="main_file", help="Main file", default="main.cf")
 
 
-@command("compile", help_msg="Compile the project to a configuration model",
-         parser_config=compiler_config, require_project=True)
+@command(
+    "compile", help_msg="Compile the project to a configuration model", parser_config=compiler_config, require_project=True
+)
 def compile_project(options):
     if options.environment is not None:
         Config.set("config", "environment", options.environment)
@@ -197,8 +205,9 @@ def compile_project(options):
     if options.profile:
         import cProfile
         import pstats
-        result = cProfile.runctx('do_compile()', globals(), {}, "run.profile")
-        p = pstats.Stats('run.profile')
+
+        result = cProfile.runctx("do_compile()", globals(), {}, "run.profile")
+        p = pstats.Stats("run.profile")
         p.strip_dirs().sort_stats("time").print_stats(20)
     else:
         t1 = time.time()
@@ -215,8 +224,7 @@ def list_commands(options):
 
 
 def help_parser_config(parser: ArgumentParser):
-    parser.add_argument("subcommand", help="Output help for a particular subcommand",
-                        nargs="?", default=None)
+    parser.add_argument("subcommand", help="Output help for a particular subcommand", nargs="?", default=None)
 
 
 @command("help", help_msg="show a help message and exit", parser_config=help_parser_config)
@@ -230,16 +238,18 @@ def help_command(options):
     sys.exit(0)
 
 
-@command("modules", help_msg="Subcommand to manage modules",
-         parser_config=moduletool.ModuleTool.modules_parser_config,
-         aliases=["module"])
+@command(
+    "modules",
+    help_msg="Subcommand to manage modules",
+    parser_config=moduletool.ModuleTool.modules_parser_config,
+    aliases=["module"],
+)
 def modules(options):
     tool = moduletool.ModuleTool()
     tool.execute(options.cmd, options)
 
 
-@command("project", help_msg="Subcommand to manage the project",
-         parser_config=moduletool.ProjectTool.parser_config)
+@command("project", help_msg="Subcommand to manage the project", parser_config=moduletool.ProjectTool.parser_config)
 def project(options):
     tool = moduletool.ProjectTool()
     tool.execute(options.cmd, options)
@@ -252,9 +262,9 @@ def deploy_parser_config(parser):
         "--dashboard",
         dest="dashboard",
         help="Start the dashboard and keep the server running. "
-             "The server uses the current project as the source for server recompiles",
+        "The server uses the current project as the source for server recompiles",
         action="store_true",
-        default=False
+        default=False,
     )
 
 
@@ -276,28 +286,50 @@ def export_parser_config(parser):
         Configure the compiler of the export function
     """
     parser.add_argument("-g", dest="depgraph", help="Dump the dependency graph", action="store_true")
-    parser.add_argument("-j", dest="json", help="Do not submit to the server but only store the json that would have been "
-                                                "submitted in the supplied file")
+    parser.add_argument(
+        "-j",
+        dest="json",
+        help="Do not submit to the server but only store the json that would have been " "submitted in the supplied file",
+    )
     parser.add_argument("-e", dest="environment", help="The environment to compile this model for")
     parser.add_argument("-d", dest="deploy", help="Trigger a deploy for the exported version", action="store_true")
-    parser.add_argument("--full", dest="full_deploy",
-                        help="Make the agents execute a full deploy instead of an incremental deploy. "
-                             "Should be used together with the -d option",
-                        action="store_true", default=False)
+    parser.add_argument(
+        "--full",
+        dest="full_deploy",
+        help="Make the agents execute a full deploy instead of an incremental deploy. "
+        "Should be used together with the -d option",
+        action="store_true",
+        default=False,
+    )
     parser.add_argument("-m", dest="model", help="Also export the complete model", action="store_true", default=False)
     parser.add_argument("--server_address", dest="server", help="The address of the server to submit the model to")
     parser.add_argument("--server_port", dest="port", help="The port of the server to submit the model to")
     parser.add_argument("--token", dest="token", help="The token to auth to the server")
     parser.add_argument("--ssl", help="Enable SSL", action="store_true", default=False)
     parser.add_argument("--ssl-ca-cert", dest="ca_cert", help="Certificate authority for SSL")
-    parser.add_argument("-X", "--extended-errors", dest="errors",
-                        help="Show stack traces for compile errors", action="store_true", default=False)
+    parser.add_argument(
+        "-X",
+        "--extended-errors",
+        dest="errors",
+        help="Show stack traces for compile errors",
+        action="store_true",
+        default=False,
+    )
     parser.add_argument("-f", dest="main_file", help="Main file", default="main.cf")
-    parser.add_argument("--metadata", dest="metadata", help="JSON metadata why this compile happened. If a non-json string is "
-                        "passed it is used as the 'message' attribute in the metadata.",
-                        default=None)
-    parser.add_argument("--model-export", dest="model_export", help="Export the configuration model to the server as metadata.",
-                        action="store_true", default=False)
+    parser.add_argument(
+        "--metadata",
+        dest="metadata",
+        help="JSON metadata why this compile happened. If a non-json string is "
+        "passed it is used as the 'message' attribute in the metadata.",
+        default=None,
+    )
+    parser.add_argument(
+        "--model-export",
+        dest="model_export",
+        help="Export the configuration model to the server as metadata.",
+        action="store_true",
+        default=False,
+    )
 
 
 @command("export", help_msg="Export the configuration", parser_config=export_parser_config, require_project=True)
@@ -372,29 +404,34 @@ def export(options):
         conn.release_version(tid, version, True, agent_trigger_method)
 
 
-log_levels = {
-    0: logging.ERROR,
-    1: logging.WARNING,
-    2: logging.INFO,
-    3: logging.DEBUG,
-    4: 2
-}
+log_levels = {0: logging.ERROR, 1: logging.WARNING, 2: logging.INFO, 3: logging.DEBUG, 4: 2}
 
 
 def cmd_parser():
     # create the argument compiler
     parser = ArgumentParser()
-    parser.add_argument("-p", action="store_true", dest="profile", help='Profile this run of the program')
+    parser.add_argument("-p", action="store_true", dest="profile", help="Profile this run of the program")
     parser.add_argument("-c", "--config", dest="config_file", help="Use this config file")
     parser.add_argument("--log-file", dest="log_file", help="Path to the logfile")
-    parser.add_argument("--log-file-level", dest="log_file_level", default=2, type=int,
-                        help="Log level for messages going to the logfile: 0=ERROR, 1=WARNING, 2=INFO, 3=DEBUG")
+    parser.add_argument(
+        "--log-file-level",
+        dest="log_file_level",
+        default=2,
+        type=int,
+        help="Log level for messages going to the logfile: 0=ERROR, 1=WARNING, 2=INFO, 3=DEBUG",
+    )
     parser.add_argument("--timed-logs", dest="timed", help="Add timestamps to logs", action="store_true")
-    parser.add_argument('-v', '--verbose', action='count', default=0,
-                        help="Log level for messages going to the console. Default is only errors,"
-                        "-v warning, -vv info and -vvv debug and -vvvv trace")
-    parser.add_argument("-X", "--extended-errors", dest="errors",
-                        help="Show stack traces for errors", action="store_true", default=False)
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Log level for messages going to the console. Default is only errors,"
+        "-v warning, -vv info and -vvv debug and -vvvv trace",
+    )
+    parser.add_argument(
+        "-X", "--extended-errors", dest="errors", help="Show stack traces for errors", action="store_true", default=False
+    )
     subparsers = parser.add_subparsers(title="commands")
     for cmd_name, cmd_options in Commander.commands().items():
         cmd_subparser = subparsers.add_parser(cmd_name, help=cmd_options["help"], aliases=cmd_options["aliases"])
@@ -407,7 +444,7 @@ def cmd_parser():
 
 
 def _is_on_tty() -> bool:
-    return (hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()) or const.ENVIRON_FORCE_TTY in os.environ
+    return (hasattr(sys.stdout, "isatty") and sys.stdout.isatty()) or const.ENVIRON_FORCE_TTY in os.environ
 
 
 def _get_default_stream_handler():
@@ -425,7 +462,7 @@ def _get_watched_file_handler(options):
         raise Exception("No logfile was provided.")
     level = _convert_to_log_level(options.log_file_level)
     formatter = logging.Formatter(fmt="%(asctime)s %(levelname)-8s %(name)-10s %(message)s")
-    file_handler = logging.handlers.WatchedFileHandler(filename=options.log_file, mode='a+')
+    file_handler = logging.handlers.WatchedFileHandler(filename=options.log_file, mode="a+")
     file_handler.setFormatter(formatter)
     file_handler.setLevel(level)
 
@@ -446,13 +483,7 @@ def _get_log_formatter_for_stream_handler(timed):
             log_format,
             datefmt=None,
             reset=True,
-            log_colors={
-                'DEBUG': 'cyan',
-                'INFO': 'green',
-                'WARNING': 'yellow',
-                'ERROR': 'red',
-                'CRITICAL': 'red',
-            }
+            log_colors={"DEBUG": "cyan", "INFO": "green", "WARNING": "yellow", "ERROR": "red", "CRITICAL": "red"},
         )
     else:
         log_format += "%(name)-25s%(levelname)-8s%(message)s"
@@ -510,6 +541,7 @@ def app():
 
         if isinstance(e, CompilerException):
             from inmanta.compiler.help.explainer import ExplainerFactory
+
             helpmsg = ExplainerFactory().explain_and_format(e, plain=not _is_on_tty())
             if helpmsg is not None:
                 print(helpmsg)

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -39,7 +39,6 @@ if TYPE_CHECKING:
 
 
 class Location(object):
-
     def __init__(self, file: str, lnr: int) -> None:
         self.file = file
         self.lnr = lnr
@@ -63,7 +62,6 @@ class Location(object):
 
 
 class Range(Location):
-
     def __init__(self, file: str, start_lnr: int, start_char: int, end_lnr: int, end_char: int) -> None:
         Location.__init__(self, file, start_lnr)
         self.start_char = start_char
@@ -160,7 +158,6 @@ class LocatableString(object):
 
 
 class Anchor(object):
-
     def __init__(self, range: Range) -> None:
         self.range = range
 
@@ -176,7 +173,6 @@ class Anchor(object):
 
 
 class TypeReferenceAnchor(Anchor):
-
     def __init__(self, range: Range, namespace: "Namespace", type: str) -> None:
         Anchor.__init__(self, range=range)
         self.namespace = namespace
@@ -188,7 +184,6 @@ class TypeReferenceAnchor(Anchor):
 
 
 class AttributeReferenceAnchor(Anchor):
-
     def __init__(self, range: Range, namespace: "Namespace", type: str, attribute: str) -> None:
         Anchor.__init__(self, range=range)
         self.namespace = namespace
@@ -203,28 +198,24 @@ class AttributeReferenceAnchor(Anchor):
 
 
 class Namespaced(Locatable):
-
     @abstractmethod
     def get_namespace(self) -> "Namespace":
         raise NotImplementedError()
 
 
 class Named(Namespaced):
-
     @abstractmethod
     def get_full_name(self) -> str:
         raise NotImplementedError()
 
 
 class Import(Locatable):
-
     def __init__(self, target: "Namespace") -> None:
         Locatable.__init__(self)
         self.target = target
 
 
 class MockImport(Import):
-
     def __init__(self, target: "Namespace") -> None:
         Locatable.__init__(self)
         self.target = target
@@ -322,7 +313,7 @@ class Namespace(Namespaced):
         """
             Get the fully qualified name of this namespace
         """
-        if(self.__parent is None):
+        if self.__parent is None:
             raise Exception("Should not occur, compiler corrupt")
         if self.__parent.__parent is None:
             return self.get_name()
@@ -369,7 +360,7 @@ class Namespace(Namespaced):
 
         return self.__name
 
-    def children(self, recursive: bool=False) -> "List[Namespace]":
+    def children(self, recursive: bool = False) -> "List[Namespace]":
         """
             Get the children of this namespace
         """
@@ -486,7 +477,7 @@ class CompilerException(Exception):
         else:
             return self.get_message()
 
-    def format_trace(self, indent: str="", indent_level: int=0) -> str:
+    def format_trace(self, indent: str = "", indent_level: int = 0) -> str:
         """Make a representation of this exception and its causes"""
         out = indent * indent_level + self.format()
 
@@ -556,7 +547,7 @@ class ExternalException(RuntimeException):
     def get_causes(self) -> List[CompilerException]:
         return []
 
-    def format_trace(self, indent: str="", indent_level: int=0) -> str:
+    def format_trace(self, indent: str = "", indent_level: int = 0) -> str:
         """Make a representation of this exception and its causes"""
         out = indent * indent_level + self.format()
 
@@ -588,7 +579,8 @@ class AttributeException(WrappingRuntimeException):
 
     def __init__(self, stmt: "Locatable", instance: "Instance", attribute: str, cause: RuntimeException) -> None:
         WrappingRuntimeException.__init__(
-            self, stmt=stmt, msg="Could not set attribute `%s` on instance `%s`" % (attribute, str(instance)), cause=cause)
+            self, stmt=stmt, msg="Could not set attribute `%s` on instance `%s`" % (attribute, str(instance)), cause=cause
+        )
         self.attribute = attribute
         self.instance = instance
 
@@ -597,19 +589,22 @@ class OptionalValueException(RuntimeException):
     """Exception raised when an optional value is accessed that has no value (and is frozen)"""
 
     def __init__(self, instance: "Instance", attribute: "Attribute") -> None:
-        RuntimeException.__init__(self, instance, "Optional variable accessed that has no value (%s.%s)" %
-                                  (instance, attribute))
+        RuntimeException.__init__(
+            self, instance, "Optional variable accessed that has no value (%s.%s)" % (instance, attribute)
+        )
         self.instance = instance
         self.attribute = attribute
 
 
 class IndexException(RuntimeException):
     """Exception raised when an index definition is invalid"""
+
     pass
 
 
 class TypingException(RuntimeException):
     """Base class for exceptions raised during the typing phase of compilation"""
+
     pass
 
 
@@ -628,7 +623,7 @@ class CycleExcpetion(TypingException):
 
     def add(self, element: "DefineEntity") -> None:
         """Collect parent entities while traveling up the stack"""
-        if(self.complete):
+        if self.complete:
             return
         if element.get_full_name() == self.final_name:
             self.complete = True
@@ -640,8 +635,7 @@ class CycleExcpetion(TypingException):
 
 
 class ModuleNotFoundException(RuntimeException):
-
-    def __init__(self, name: str, stmt: "Statement", msg: str=None) -> None:
+    def __init__(self, name: str, stmt: "Statement", msg: str = None) -> None:
         if msg is None:
             msg = "could not find module %s" % name
         RuntimeException.__init__(self, stmt, msg)
@@ -649,8 +643,7 @@ class ModuleNotFoundException(RuntimeException):
 
 
 class NotFoundException(RuntimeException):
-
-    def __init__(self, stmt: "Optional[Statement]", name: str, msg: "Optional[str]"=None) -> None:
+    def __init__(self, stmt: "Optional[Statement]", name: str, msg: "Optional[str]" = None) -> None:
         if msg is None:
             msg = "could not find value %s" % name
         RuntimeException.__init__(self, stmt, msg)
@@ -658,31 +651,32 @@ class NotFoundException(RuntimeException):
 
 
 class DoubleSetException(RuntimeException):
-
-    def __init__(self,
-                 stmt: "Optional[Statement]",
-                 value: object,
-                 location: Location,
-                 newvalue: object,
-                 newlocation: Location) -> None:
+    def __init__(
+        self, stmt: "Optional[Statement]", value: object, location: Location, newvalue: object, newlocation: Location
+    ) -> None:
         self.value = value  # type: object
         self.location = location
         self.newvalue = newvalue  # type: object
         self.newlocation = newlocation
-        msg = ("value set twice:\n\told value: %s\n\t\tset at %s\n\tnew value: %s\n\t\tset at %s\n"
-               % (self.value, self.location, self.newvalue, self.newlocation))
+        msg = "value set twice:\n\told value: %s\n\t\tset at %s\n\tnew value: %s\n\t\tset at %s\n" % (
+            self.value,
+            self.location,
+            self.newvalue,
+            self.newlocation,
+        )
         RuntimeException.__init__(self, stmt, msg)
 
 
 class ModifiedAfterFreezeException(RuntimeException):
-
-    def __init__(self,
-                 rv: "DelayedResultVariable",
-                 instance: "Instance",
-                 attribute: "Attribute",
-                 value: object,
-                 location: Location,
-                 reverse: bool) -> None:
+    def __init__(
+        self,
+        rv: "DelayedResultVariable",
+        instance: "Instance",
+        attribute: "Attribute",
+        value: object,
+        location: Location,
+        reverse: bool,
+    ) -> None:
         RuntimeException.__init__(self, None, "List modified after freeze")
         self.instance = instance
         self.attribute = attribute
@@ -722,4 +716,4 @@ class MultiException(CompilerException):
         return "Reported %d errors" % len(self.others)
 
     def __str__(self) -> str:
-        return "Reported %d errors:\n\t" % len(self.others) + '\n\t'.join([str(e) for e in self.others])
+        return "Reported %d errors:\n\t" % len(self.others) + "\n\t".join([str(e) for e in self.others])

--- a/src/inmanta/ast/attribute.py
+++ b/src/inmanta/ast/attribute.py
@@ -40,7 +40,7 @@ class Attribute(Locatable):
         @param entity: The entity this attribute belongs to
     """
 
-    def __init__(self, entity: "Entity", value_type: "Type", name: str, multi: bool=False, nullable: bool=False) -> None:
+    def __init__(self, entity: "Entity", value_type: "Type", name: str, multi: bool = False, nullable: bool = False) -> None:
         Locatable.__init__(self)
         self.__name: str = name
         entity.add_attribute(self)
@@ -95,13 +95,13 @@ class Attribute(Locatable):
 
     def get_new_result_variable(self, instance: "Instance", queue: QueueScheduler) -> ResultVariable:
         if self.__multi:
-            mytype = (TypedList(self.__type))
+            mytype = TypedList(self.__type)
         else:
-            mytype = (self.__type)
+            mytype = self.__type
 
         out: ResultVariable["Instance"]
 
-        if(self.__nullallble):
+        if self.__nullallble:
             # be a 0-1 relation
             self.end = None
             self.low = 0
@@ -128,6 +128,7 @@ class RelationAttribute(Attribute):
     """
         An attribute that is a relation
     """
+
     def __init__(self, entity: "Entity", value_type: "Type", name: str) -> None:
         Attribute.__init__(self, entity, value_type, name)
         self.end: Optional[RelationAttribute] = None

--- a/src/inmanta/ast/blocks.py
+++ b/src/inmanta/ast/blocks.py
@@ -24,8 +24,7 @@ from inmanta.execute.runtime import Resolver, QueueScheduler
 
 
 class BasicBlock(object):
-
-    def __init__(self, namespace: Namespace, stmts: List[DynamicStatement]=[]) -> None:
+    def __init__(self, namespace: Namespace, stmts: List[DynamicStatement] = []) -> None:
         self.__stmts = []  # type: List[DynamicStatement]
         self.variables = []  # type: List[str]
         self.namespace = namespace
@@ -65,8 +64,8 @@ class BasicBlock(object):
 
         # self.external_not_global = [x for x in self.external if "::" not in x]
 
-#     def get_requires(self) -> List[str]:
-#         return self.external
+    #     def get_requires(self) -> List[str]:
+    #         return self.external
 
     def emit(self, resolver: Resolver, queue: QueueScheduler) -> None:
         for s in self.__stmts:

--- a/src/inmanta/ast/constraint/expression.py
+++ b/src/inmanta/ast/constraint/expression.py
@@ -62,7 +62,6 @@ class OpMetaClass(ABCMeta):
 
 
 class IsDefined(ReferenceStatement):
-
     def __init__(self, attr: Reference, name: LocatableString) -> None:
         super(IsDefined, self).__init__([attr])
         self.attr = attr.root_in_self()
@@ -86,8 +85,8 @@ class IsDefined(ReferenceStatement):
 
     def pretty_print(self) -> str:
         name = "%s.%s is defined" % (self.attr, self.name)
-        if name[:len("self.")] == "self.":
-            name = name[len("self."):]
+        if name[: len("self.")] == "self.":
+            name = name[len("self.") :]
 
         return "%s is defined" % name
 
@@ -96,6 +95,7 @@ class Operator(ReferenceStatement, metaclass=OpMetaClass):
     """
         This class is an abstract base class for all operators that can be used in expressions
     """
+
     # A hash to lookup each handler
     __operator = {}
 
@@ -211,9 +211,7 @@ class LazyBinaryOperator(BinaryOperator):
         if self._is_final(result):
             target.set_value(result, self.location)
         else:
-            ExecutionUnit(queue, resolver, target,
-                          self.children[1].requires_emit(resolver, queue),
-                          self.children[1])
+            ExecutionUnit(queue, resolver, target, self.children[1].requires_emit(resolver, queue), self.children[1])
 
     def execute_direct(self, requires):
         result = self.children[0].execute_direct(requires)
@@ -265,6 +263,7 @@ class Not(UnaryOperator):
     """
         The negation operator
     """
+
     __op = "not"
 
     def __init__(self, arg):
@@ -301,14 +300,14 @@ class Regex(BinaryOperator):
         """
             Return a representation of the op
         """
-        return "%s(%s, %s)" % (self.__class__.__name__, self._arguments[0],
-                               self._arguments[1].value)
+        return "%s(%s, %s)" % (self.__class__.__name__, self._arguments[0], self._arguments[1].value)
 
 
 class Equals(BinaryOperator):
     """
         The equality operator
     """
+
     __op = "=="
 
     def __init__(self, op1, op2):
@@ -325,6 +324,7 @@ class LessThan(BinaryOperator):
     """
         The less than operator
     """
+
     __op = "<"
 
     def __init__(self, op1, op2):
@@ -343,6 +343,7 @@ class GreaterThan(BinaryOperator):
     """
         The more than operator
     """
+
     __op = ">"
 
     def __init__(self, op1, op2):
@@ -361,6 +362,7 @@ class LessThanOrEqual(BinaryOperator):
     """
         The less than or equal operator
     """
+
     __op = "<="
 
     def __init__(self, op1, op2):
@@ -379,6 +381,7 @@ class GreaterThanOrEqual(BinaryOperator):
     """
         The more than or equal operator
     """
+
     __op = ">="
 
     def __init__(self, op1, op2):
@@ -397,6 +400,7 @@ class NotEqual(BinaryOperator):
     """
         The not equal operator
     """
+
     __op = "!="
 
     def __init__(self, op1, op2):
@@ -413,6 +417,7 @@ class And(LazyBinaryOperator):
     """
         The and boolean operator
     """
+
     __op = "and"
 
     def __init__(self, op1, op2):
@@ -426,6 +431,7 @@ class Or(LazyBinaryOperator):
     """
         The or boolean operator
     """
+
     __op = "or"
 
     def __init__(self, op1, op2):
@@ -439,6 +445,7 @@ class In(BinaryOperator):
     """
         The in operator for iterable types and dicts
     """
+
     __op = "in"
 
     def __init__(self, op1, op2):

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -22,8 +22,16 @@ from inmanta.ast.type import Type, NamedType
 from inmanta.ast.blocks import BasicBlock
 from inmanta.execute.runtime import Resolver, QueueScheduler
 from inmanta.ast.statements.generator import SubConstructor
-from inmanta.ast import RuntimeException, DuplicateException, NotFoundException, Namespace, Location, \
-    Named, Locatable, CompilerException
+from inmanta.ast import (
+    RuntimeException,
+    DuplicateException,
+    NotFoundException,
+    Namespace,
+    Location,
+    Named,
+    Locatable,
+    CompilerException,
+)
 from inmanta.util import memoize
 from inmanta.execute.runtime import Instance
 from inmanta.execute.util import AnyType
@@ -91,6 +99,7 @@ class Entity(EntityLike, NamedType):
         :param name: The name of this entity. This name can not be changed
             after this object has been created
     """
+
     comment: Optional[str]
 
     def __init__(self, name: str, namespace: Namespace) -> None:
@@ -317,11 +326,9 @@ class Entity(EntityLike, NamedType):
         for parent in self.parent_entities:
             parent.add_instance(obj)
 
-    def get_instance(self,
-                     attributes: Dict[str, object],
-                     resolver: Resolver,
-                     queue: QueueScheduler,
-                     location: Location) -> "Instance":
+    def get_instance(
+        self, attributes: Dict[str, object], resolver: Resolver, queue: QueueScheduler, location: Location
+    ) -> "Instance":
         """
             Return an instance of the class defined in this entity
         """
@@ -440,10 +447,9 @@ class Entity(EntityLike, NamedType):
                         x.set_value(instance, stmt.location)
                     self.index_queue.pop(keys)
 
-    def lookup_index(self,
-                     params: "List[str,object]",
-                     stmt: "Statement",
-                     target: "Optional[ResultVariable]"=None) -> "Optional[Instance]":
+    def lookup_index(
+        self, params: "List[str,object]", stmt: "Statement", target: "Optional[ResultVariable]" = None
+    ) -> "Optional[Instance]":
         """
             Search an instance in the index.
         """
@@ -456,9 +462,10 @@ class Entity(EntityLike, NamedType):
 
         if not found_index:
             raise NotFoundException(
-                stmt, self.get_full_name(), "No index defined on %s for this lookup: " % self.get_full_name() + str(params))
+                stmt, self.get_full_name(), "No index defined on %s for this lookup: " % self.get_full_name() + str(params)
+            )
 
-        key = ", ".join(["%s=%s" % (k, repr(v)) for (k, v) in sorted(params, key=lambda x:x[0])])
+        key = ", ".join(["%s=%s" % (k, repr(v)) for (k, v) in sorted(params, key=lambda x: x[0])])
 
         if target is None:
             if key in self._index:
@@ -483,14 +490,14 @@ class Entity(EntityLike, NamedType):
     def final(self, excns: List[Exception]) -> None:
         for key, indices in self.index_queue.items():
             for _, stmt in indices:
-                excns.append(NotFoundException(stmt, key,
-                                               "No match in index on type %s with key %s" % (self.get_full_name(), key)))
+                excns.append(
+                    NotFoundException(stmt, key, "No match in index on type %s with key %s" % (self.get_full_name(), key))
+                )
         for _, attr in self.get_attributes().items():
             attr.final(excns)
 
     def get_double_defined_exception(self, other: "Namespaced") -> "DuplicateException":
-        return DuplicateException(
-            self, other, "Entity %s is already defined" % (self.get_full_name()))
+        return DuplicateException(self, other, "Entity %s is already defined" % (self.get_full_name()))
 
     def get_location(self) -> Location:
         return self.location
@@ -503,12 +510,9 @@ class Implementation(NamedType):
         to create mixin like aspects.
     """
 
-    def __init__(self,
-                 name: str,
-                 stmts: BasicBlock,
-                 namespace: Namespace,
-                 target_type: str,
-                 comment: Optional[str]=None) -> None:
+    def __init__(
+        self, name: str, stmts: BasicBlock, namespace: Namespace, target_type: str, comment: Optional[str] = None
+    ) -> None:
         Named.__init__(self)
         self.name = name
         self.statements = stmts
@@ -537,8 +541,9 @@ class Implementation(NamedType):
         return self.namespace
 
     def get_double_defined_exception(self, other: "Namespaced") -> "DuplicateException":
-        raise DuplicateException(self, other, "Implementation %s for type %s is already defined" %
-                                 (self.get_full_name(), self.target_type))
+        raise DuplicateException(
+            self, other, "Implementation %s for type %s is already defined" % (self.get_full_name(), self.target_type)
+        )
 
     def get_location(self) -> Location:
         return self.location
@@ -548,6 +553,7 @@ class Implement(Locatable):
     """
         Define an implementation of an entity in functions of implementations
     """
+
     comment: Optional[str]
 
     def __init__(self) -> None:

--- a/src/inmanta/ast/statements/__init__.py
+++ b/src/inmanta/ast/statements/__init__.py
@@ -82,7 +82,6 @@ class DynamicStatement(Statement):
 
 
 class ExpressionStatement(DynamicStatement):
-
     def __init__(self) -> None:
         DynamicStatement.__init__(self)
 
@@ -110,21 +109,12 @@ class ExpressionStatement(DynamicStatement):
 
 
 class Resumer(ExpressionStatement):
-
-    def resume(self,
-               requires: Dict[object, object],
-               resolver: Resolver,
-               queue: QueueScheduler,
-               target: ResultVariable) -> None:
+    def resume(self, requires: Dict[object, object], resolver: Resolver, queue: QueueScheduler, target: ResultVariable) -> None:
         pass
 
 
 class RawResumer(ExpressionStatement):
-
-    def resume(self,
-               equires: Dict[object, ResultVariable],
-               resolver: Resolver,
-               queue_scheduler: QueueScheduler) -> None:
+    def resume(self, equires: Dict[object, ResultVariable], resolver: Resolver, queue_scheduler: QueueScheduler) -> None:
         pass
 
 
@@ -181,7 +171,6 @@ class GeneratorStatement(ExpressionStatement):
 
 
 class Literal(ExpressionStatement):
-
     def __init__(self, value: object) -> None:
         ExpressionStatement.__init__(self)
         self.value = value
@@ -237,6 +226,5 @@ class TypeDefinitionStatement(DefinitionStatement, Named):
 
 
 class BiStatement(DefinitionStatement, DynamicStatement):
-
     def __init__(self):
         Statement.__init__(self)

--- a/src/inmanta/ast/statements/call.py
+++ b/src/inmanta/ast/statements/call.py
@@ -112,14 +112,13 @@ class FunctionCall(ReferenceStatement):
                 raise ExternalException(self, "Exception in plugin %s" % self.name, e)
 
     def __repr__(self):
-        return "%s(%s)" % (self.name, ','.join([repr(a) for a in self.arguments]))
+        return "%s(%s)" % (self.name, ",".join([repr(a) for a in self.arguments]))
 
     def pretty_print(self):
-        return "%s(%s)" % (self.name, ','.join([a.pretty_print() for a in self.arguments]))
+        return "%s(%s)" % (self.name, ",".join([a.pretty_print() for a in self.arguments]))
 
 
 class FunctionUnit(Waiter):
-
     def __init__(self, queue_scheduler, resolver, result: ResultVariable, requires, function: FunctionCall):
         Waiter.__init__(self, queue_scheduler)
         self.result = result

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -25,8 +25,18 @@ from inmanta.ast.attribute import Attribute, RelationAttribute
 from inmanta.ast.entity import Implementation, Entity, Default, Implement, EntityLike
 from inmanta.ast.constraint.expression import Equals
 from inmanta.ast.statements import TypeDefinitionStatement, Statement, ExpressionStatement, Literal, BiStatement
-from inmanta.ast import Namespace, TypingException, DuplicateException, TypeNotFoundException, NotFoundException,\
-    LocatableString, TypeReferenceAnchor, AttributeReferenceAnchor, IndexException, Import
+from inmanta.ast import (
+    Namespace,
+    TypingException,
+    DuplicateException,
+    TypeNotFoundException,
+    NotFoundException,
+    LocatableString,
+    TypeReferenceAnchor,
+    AttributeReferenceAnchor,
+    IndexException,
+    Import,
+)
 from typing import List, Optional, Dict, Tuple
 from inmanta.execute.runtime import ResultVariable, ExecutionUnit, Resolver, QueueScheduler
 from inmanta.ast.blocks import BasicBlock
@@ -37,9 +47,15 @@ LOGGER = logging.getLogger(__name__)
 
 
 class DefineAttribute(Statement):
-
-    def __init__(self, attr_type: LocatableString, name: LocatableString, default_value: ExpressionStatement=None,
-                 multi: bool=False, remove_default: bool=True, nullable: bool=False) -> None:
+    def __init__(
+        self,
+        attr_type: LocatableString,
+        name: LocatableString,
+        default_value: ExpressionStatement = None,
+        multi: bool = False,
+        remove_default: bool = True,
+        nullable: bool = False,
+    ) -> None:
         """
             if default_value is None, this is an explicit removal of a default value
         """
@@ -56,15 +72,18 @@ class DefineEntity(TypeDefinitionStatement):
     """
         Define a new entity in the configuration
     """
+
     comment: Optional[str]
     type: Entity
 
-    def __init__(self,
-                 namespace: Namespace,
-                 lname: LocatableString,
-                 comment: Optional[LocatableString],
-                 parents: List[LocatableString],
-                 attributes: List[DefineAttribute]) -> None:
+    def __init__(
+        self,
+        namespace: Namespace,
+        lname: LocatableString,
+        comment: Optional[LocatableString],
+        parents: List[LocatableString],
+        attributes: List[DefineAttribute],
+    ) -> None:
         name = str(lname)
         TypeDefinitionStatement.__init__(self, namespace, name)
 
@@ -85,7 +104,9 @@ class DefineEntity(TypeDefinitionStatement):
         self.type = Entity(self.name, namespace)
         self.type.location = lname.location
 
-    def add_attribute(self, attr_type: LocatableString, name: LocatableString, default_value: ExpressionStatement=None) -> None:
+    def add_attribute(
+        self, attr_type: LocatableString, name: LocatableString, default_value: ExpressionStatement = None
+    ) -> None:
         """
             Add an attribute to this entity
         """
@@ -102,6 +123,7 @@ class DefineEntity(TypeDefinitionStatement):
             ptype = self.namespace.get_type(str(parent))
             assert isinstance(ptype, Entity), "Parents of entities should be entities, but %s is a %s" % (parent, type(ptype))
             return ptype.get_full_name()
+
         try:
             return [resolve_parent(parent) for parent in self.parents]
         except TypeNotFoundException as e:
@@ -125,14 +147,10 @@ class DefineEntity(TypeDefinitionStatement):
                 name = str(attribute.name)
                 attr_obj = Attribute(entity_type, attr_type, name, attribute.multi, attribute.nullable)
                 attr_obj.location = attribute.get_location()
-                self.anchors.append(TypeReferenceAnchor(
-                    attribute.type.get_location(), self.namespace, str(attribute.type)))
+                self.anchors.append(TypeReferenceAnchor(attribute.type.get_location(), self.namespace, str(attribute.type)))
 
                 if name in add_attributes:
-                    raise DuplicateException(
-                        attr_obj,
-                        add_attributes[name],
-                        "Same attribute defined twice in one entity")
+                    raise DuplicateException(attr_obj, add_attributes[name], "Same attribute defined twice in one entity")
 
                 add_attributes[name] = attr_obj
 
@@ -148,8 +166,11 @@ class DefineEntity(TypeDefinitionStatement):
                 if parent_type is self.type:
                     raise TypingException(self, "Entity can not be its own parent (%s) " % parent)
                 if not isinstance(parent_type, Entity):
-                    raise TypingException(self, "Parents of an entity need to be entities. "
-                                          "Default constructors are not supported. %s is not an entity" % parent)
+                    raise TypingException(
+                        self,
+                        "Parents of an entity need to be entities. "
+                        "Default constructors are not supported. %s is not an entity" % parent,
+                    )
 
                 entity_type.parent_entities.append(parent_type)
                 parent_type.child_entities.append(entity_type)
@@ -165,8 +186,7 @@ class DefineEntity(TypeDefinitionStatement):
                         if my_attr.type == other_attr.type:
                             add_attributes[attr_name] = other_attr
                         else:
-                            raise DuplicateException(
-                                my_attr, other_attr, "Incompatible attributes")
+                            raise DuplicateException(my_attr, other_attr, "Incompatible attributes")
             # verify all attribute compatibility
         except TypeNotFoundException as e:
             e.set_statement(self)
@@ -183,12 +203,14 @@ class DefineImplementation(TypeDefinitionStatement):
     comment: Optional[str]
     type: Implementation
 
-    def __init__(self,
-                 namespace: Namespace,
-                 name: LocatableString,
-                 target_type: LocatableString,
-                 statements: BasicBlock,
-                 comment: LocatableString):
+    def __init__(
+        self,
+        namespace: Namespace,
+        name: LocatableString,
+        target_type: LocatableString,
+        statements: BasicBlock,
+        comment: LocatableString,
+    ):
         TypeDefinitionStatement.__init__(self, namespace, str(name))
         self.name = str(name)
         self.block = statements
@@ -216,8 +238,9 @@ class DefineImplementation(TypeDefinitionStatement):
         try:
             cls = self.namespace.get_type(self.entity)
             if not isinstance(cls, Entity):
-                raise TypingException(self, "Implementation can only be define for an Entity, but %s is a %s" %
-                                      (self.entity, type(self.entity)))
+                raise TypingException(
+                    self, "Implementation can only be define for an Entity, but %s is a %s" % (self.entity, type(self.entity))
+                )
             self.type.set_type(cls)
             self.copy_location(self.type)
         except TypeNotFoundException as e:
@@ -228,7 +251,7 @@ class DefineImplementation(TypeDefinitionStatement):
 class DefineImplementInherits(DefinitionStatement):
     comment: Optional[str]
 
-    def __init__(self, entity_name: LocatableString, comment: LocatableString=None):
+    def __init__(self, entity_name: LocatableString, comment: LocatableString = None):
         DefinitionStatement.__init__(self)
         self.entity = str(entity_name)
         if comment is not None:
@@ -252,8 +275,9 @@ class DefineImplementInherits(DefinitionStatement):
             entity_type = self.namespace.get_type(self.entity)
 
             if not isinstance(entity_type, Entity):
-                raise TypingException(self, "Implementation can only be define for an Entity, but %s is a %s" %
-                                      (self.entity, type(self.entity)))
+                raise TypingException(
+                    self, "Implementation can only be define for an Entity, but %s is a %s" % (self.entity, type(self.entity))
+                )
 
             entity_type.implements_inherits = True
         except TypeNotFoundException as e:
@@ -269,13 +293,16 @@ class DefineImplement(DefinitionStatement):
         @param implementations: A list of implementations
         @param whem: A clause that determines when this implementation is "active"
     """
+
     comment: Optional[str]
 
-    def __init__(self,
-                 entity_name: LocatableString,
-                 implementations: List[LocatableString],
-                 select: ExpressionStatement,
-                 comment: LocatableString=None) -> None:
+    def __init__(
+        self,
+        entity_name: LocatableString,
+        implementations: List[LocatableString],
+        select: ExpressionStatement,
+        comment: LocatableString = None,
+    ) -> None:
         DefinitionStatement.__init__(self)
         self.entity = str(entity_name)
         self.entity_location = entity_name.get_location()
@@ -303,8 +330,9 @@ class DefineImplement(DefinitionStatement):
             entity_type = self.namespace.get_type(str(self.entity))
 
             if not isinstance(entity_type, EntityLike):
-                raise TypingException(self, "Implementation can only be define for an Entity, but %s is a %s" %
-                                      (self.entity, type(self.entity)))
+                raise TypingException(
+                    self, "Implementation can only be define for an Entity, but %s is a %s" % (self.entity, type(self.entity))
+                )
 
             entity_type = entity_type.get_entity()
 
@@ -321,11 +349,13 @@ class DefineImplement(DefinitionStatement):
                 impl_obj = self.namespace.get_type(_impl)
                 assert isinstance(impl_obj, Implementation), "%s is not and implementation" % (_impl)
 
-                if (impl_obj.entity is not None and not
-                        (entity_type is impl_obj.entity or entity_type.is_parent(impl_obj.entity))):
-                    raise Exception("Type mismatch: cannot use %s as implementation for "
-                                    " %s because its implementing type is %s" %
-                                    (impl_obj.name, entity_type, impl_obj.entity))
+                if impl_obj.entity is not None and not (
+                    entity_type is impl_obj.entity or entity_type.is_parent(impl_obj.entity)
+                ):
+                    raise Exception(
+                        "Type mismatch: cannot use %s as implementation for "
+                        " %s because its implementing type is %s" % (impl_obj.name, entity_type, impl_obj.entity)
+                    )
 
                 # add it
                 implement.implementations.append(impl_obj)
@@ -344,15 +374,14 @@ class DefineTypeConstraint(TypeDefinitionStatement):
         @param name: The name of the new  type
         @param basetype: The name of the type that is "refined"
     """
+
     comment: Optional[str]
     __expression: ExpressionStatement
     type: ConstraintType
 
-    def __init__(self,
-                 namespace: Namespace,
-                 name: LocatableString,
-                 basetype: LocatableString,
-                 expression: ExpressionStatement) -> None:
+    def __init__(
+        self, namespace: Namespace, name: LocatableString, basetype: LocatableString, expression: ExpressionStatement
+    ) -> None:
         TypeDefinitionStatement.__init__(self, namespace, str(name))
         self.basetype = str(basetype)
         self.anchors.append(TypeReferenceAnchor(basetype.get_location(), namespace, str(basetype)))
@@ -418,6 +447,7 @@ class DefineTypeDefault(TypeDefinitionStatement):
         @param name: The name of the new type
         @param class_ctor: A constructor statement
     """
+
     type: Default
 
     def __init__(self, namespace: Namespace, name: LocatableString, class_ctor: Constructor):
@@ -442,8 +472,9 @@ class DefineTypeDefault(TypeDefinitionStatement):
         type_class = self.namespace.get_type(self.ctor.class_type)
 
         if not isinstance(type_class, EntityLike):
-            raise TypingException(self, "Default can only be define for an Entity, but %s is a %s" %
-                                  (self.ctor.class_type, self.ctor.class_type))
+            raise TypingException(
+                self, "Default can only be define for an Entity, but %s is a %s" % (self.ctor.class_type, self.ctor.class_type)
+            )
 
         self.type.comment = self.comment
 
@@ -461,9 +492,10 @@ class DefineRelation(BiStatement):
     """
         Define a relation
     """
+
     annotation_expression: List[Tuple[ResultVariable, ExpressionStatement]]
 
-    def __init__(self, left: Relationside, right: Relationside, annotations: List[ExpressionStatement]=[]) -> None:
+    def __init__(self, left: Relationside, right: Relationside, annotations: List[ExpressionStatement] = []) -> None:
         DefinitionStatement.__init__(self)
         # for later evaluation
         self.annotation_expression = [(ResultVariable(), exp) for exp in annotations]
@@ -498,16 +530,18 @@ class DefineRelation(BiStatement):
         if isinstance(left, Default):
             raise TypingException(
                 self,
-                "Can not define relation on a default constructor %s, use base type instead: %s " % (
-                    left.name, left.get_entity().get_full_name())
+                "Can not define relation on a default constructor %s, use base type instead: %s "
+                % (left.name, left.get_entity().get_full_name()),
             )
 
         assert isinstance(left, Entity), "%s is not an entity" % left
 
         if left.get_attribute_from_related(str(self.right[1])) is not None:
-            raise DuplicateException(self, left.get_attribute_from_related(str(self.right[1])),
-                                     ("Attribute name %s is already defined in %s, unable to define relationship")
-                                     % (str(self.right[1]), left.name))
+            raise DuplicateException(
+                self,
+                left.get_attribute_from_related(str(self.right[1])),
+                ("Attribute name %s is already defined in %s, unable to define relationship") % (str(self.right[1]), left.name),
+            )
 
         try:
             right = self.namespace.get_type(str(self.right[0]))
@@ -518,16 +552,18 @@ class DefineRelation(BiStatement):
         if isinstance(right, Default):
             raise TypingException(
                 self,
-                "Can not define relation on a default constructor %s, use base type instead: %s " % (
-                    right.name, right.get_entity().get_full_name())
+                "Can not define relation on a default constructor %s, use base type instead: %s "
+                % (right.name, right.get_entity().get_full_name()),
             )
 
         assert isinstance(right, Entity), "%s is not an entity" % left
 
         if right.get_attribute_from_related(str(self.left[1])) is not None:
-            raise DuplicateException(self, right.get_attribute_from_related(str(self.left[1])),
-                                     ("Attribute name %s is already defined in %s, unable to define relationship")
-                                     % (str(self.left[1]), right.name))
+            raise DuplicateException(
+                self,
+                right.get_attribute_from_related(str(self.left[1])),
+                ("Attribute name %s is already defined in %s, unable to define relationship") % (str(self.left[1]), right.name),
+            )
 
         if self.left[1] is not None:
             left_end = RelationAttribute(right, left, str(self.left[1]))
@@ -571,10 +607,11 @@ class DefineIndex(DefinitionStatement):
         self.type = str(entity_type)
         self.attributes = [str(a) for a in attributes]
         self.anchors.append(TypeReferenceAnchor(entity_type.get_location(), entity_type.namespace, str(entity_type)))
-        self.anchors.extend([AttributeReferenceAnchor(x.get_location(), entity_type.namespace,
-                                                      str(entity_type), str(x)) for x in attributes])
+        self.anchors.extend(
+            [AttributeReferenceAnchor(x.get_location(), entity_type.namespace, str(entity_type), str(x)) for x in attributes]
+        )
 
-    def types(self, recursive: bool=False) -> List[Tuple[str, str]]:
+    def types(self, recursive: bool = False) -> List[Tuple[str, str]]:
         """
             @see Statement#types
         """
@@ -594,17 +631,20 @@ class DefineIndex(DefinitionStatement):
         allattributes = entity_type.get_all_attribute_names()
         for attribute in self.attributes:
             if attribute not in allattributes:
-                raise NotFoundException(self, attribute, "Attribute '%s' referenced in index is not defined in entity %s" %
-                                        (attribute, entity_type))
+                raise NotFoundException(
+                    self, attribute, "Attribute '%s' referenced in index is not defined in entity %s" % (attribute, entity_type)
+                )
             else:
                 rattribute = entity_type.get_attribute(attribute)
                 if rattribute.is_optional():
                     raise IndexException(
-                        self, "Index can not contain optional attributes, Attribute ' %s.%s' is optional" %
-                        (attribute, entity_type))
+                        self,
+                        "Index can not contain optional attributes, Attribute ' %s.%s' is optional" % (attribute, entity_type),
+                    )
                 if rattribute.is_multi():
                     raise IndexException(
-                        self, "Index can not contain list attributes, Attribute ' %s.%s' is a list" % (attribute, entity_type))
+                        self, "Index can not contain list attributes, Attribute ' %s.%s' is a list" % (attribute, entity_type)
+                    )
 
         entity_type.add_index(self.attributes)
 
@@ -634,7 +674,6 @@ class PluginStatement(TypeDefinitionStatement):
 
 
 class DefineImport(TypeDefinitionStatement, Import):
-
     def __init__(self, name: LocatableString, toname: LocatableString) -> None:
         DefinitionStatement.__init__(self)
         self.name = str(name)

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -24,8 +24,17 @@ from inmanta.ast.statements import GeneratorStatement
 from inmanta.const import LOG_LEVEL_TRACE
 from inmanta.execute.util import Unknown
 from inmanta.execute.runtime import ExecutionContext, Resolver, QueueScheduler, ResultVariable, ResultCollector
-from inmanta.ast import RuntimeException, TypingException, NotFoundException, Location, Namespace, DuplicateException,\
-    LocatableString, TypeReferenceAnchor, AttributeReferenceAnchor
+from inmanta.ast import (
+    RuntimeException,
+    TypingException,
+    NotFoundException,
+    Location,
+    Namespace,
+    DuplicateException,
+    LocatableString,
+    TypeReferenceAnchor,
+    AttributeReferenceAnchor,
+)
 from inmanta.execute.tracking import ImplementsTracker
 from typing import List, Dict, Tuple, Set  # noqa: F401
 from inmanta.ast.statements import ExpressionStatement
@@ -183,11 +192,13 @@ class Constructor(GeneratorStatement):
             constructor call.
     """
 
-    def __init__(self,
-                 class_type: LocatableString,
-                 attributes: List[Tuple[LocatableString, ExpressionStatement]],
-                 location: Location,
-                 namespace: Namespace) -> None:
+    def __init__(
+        self,
+        class_type: LocatableString,
+        attributes: List[Tuple[LocatableString, ExpressionStatement]],
+        location: Location,
+        namespace: Namespace,
+    ) -> None:
         GeneratorStatement.__init__(self)
         self.class_type = str(class_type)
         self.__attributes = {}  # type: Dict[str,ExpressionStatement]
@@ -245,11 +256,9 @@ class Constructor(GeneratorStatement):
         direct = [x for x in self._direct_attributes.items()]
 
         direct_requires = {rk: rv for (k, v) in direct for (rk, rv) in v.requires_emit(resolver, queue).items()}
-        LOGGER.log(LOG_LEVEL_TRACE,
-                   "emitting constructor for %s at %s with %s",
-                   self.class_type,
-                   self.location,
-                   direct_requires)
+        LOGGER.log(
+            LOG_LEVEL_TRACE, "emitting constructor for %s at %s with %s", self.class_type, self.location, direct_requires
+        )
 
         return direct_requires
 
@@ -327,8 +336,9 @@ class Constructor(GeneratorStatement):
             self.anchors.append(AttributeReferenceAnchor(lname.get_location(), lname.namespace, self.class_type, name))
             self.anchors.extend(value.get_anchors())
         else:
-            raise RuntimeException(self, "The attribute %s in the constructor call of %s is already set."
-                                   % (name, self.class_type))
+            raise RuntimeException(
+                self, "The attribute %s in the constructor call of %s is already set." % (name, self.class_type)
+            )
 
     def get_attributes(self) -> Dict[str, ExpressionStatement]:
         """

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -23,7 +23,6 @@ from typing import Optional
 
 
 class BasicResolver(object):
-
     def __init__(self, types):
         self.types = types
 
@@ -48,7 +47,6 @@ class BasicResolver(object):
 
 
 class NameSpacedResolver(object):
-
     def __init__(self, ns):
         self.ns = ns
 
@@ -126,14 +124,12 @@ class Type(Locatable):
 
 
 class NamedType(Type, Named):
-
     def get_double_defined_exception(self, other: "NamedType") -> DuplicateException:
         """produce a customized error message for this type"""
         raise NotImplementedError()
 
 
 class NullableType(Type):
-
     def __init__(self, basetype):
         Type.__init__(self)
         self.basetype = basetype
@@ -254,10 +250,10 @@ class Bool(Type):
             Convert the given value to value that can be used by the operators
             defined on this type.
         """
-        if (value == "true" or value == "True" or value == 1 or value == "1" or value is True):
+        if value == "true" or value == "True" or value == 1 or value == "1" or value is True:
             return True
 
-        if (value == "false" or value == "False" or value == 0 or value == "0" or value is False):
+        if value == "false" or value == "False" or value == 0 or value == "0" or value is False:
             return False
 
         raise CastException()
@@ -320,7 +316,6 @@ class String(Type, str):
 
 
 class TypedList(Type):
-
     def __init__(self, basetype):
         Type.__init__(self)
         self.basetype = basetype
@@ -392,9 +387,9 @@ class List(Type, list):
 
         return True
 
-#     @classmethod
-#     def __str__(cls):
-#         return "list"
+    #     @classmethod
+    #     def __str__(cls):
+    #         return "list"
 
     @classmethod
     def type_string(cls):
@@ -462,6 +457,7 @@ class ConstraintType(NamedType):
 
         The constraint on this type is defined by a regular expression.
     """
+
     comment: Optional[str]
 
     def __init__(self, namespace, name):
@@ -524,8 +520,7 @@ class ConstraintType(NamedType):
         return self.namespace
 
     def get_double_defined_exception(self, other: "NamedType") -> DuplicateException:
-        return DuplicateException(
-            self, other, "TypeConstraint %s is already defined" % (self.get_full_name()))
+        return DuplicateException(self, other, "TypeConstraint %s is already defined" % (self.get_full_name()))
 
 
 def create_function(expression):
@@ -534,6 +529,7 @@ def create_function(expression):
         The generated function accepts the unbound variables in the expression
         as arguments.
     """
+
     def function(*args, **kwargs):
         """
             A function that evaluates the expression
@@ -541,7 +537,7 @@ def create_function(expression):
         if len(args) != 1:
             raise NotImplementedError()
 
-        return expression.execute_direct({'self': args[0]})
+        return expression.execute_direct({"self": args[0]})
 
     return function
 

--- a/src/inmanta/ast/variables.py
+++ b/src/inmanta/ast/variables.py
@@ -18,8 +18,16 @@
 
 import logging
 
-from inmanta.execute.runtime import ResultVariable, ExecutionUnit, RawUnit, HangUnit, Instance, Resolver, QueueScheduler,\
-    ResultCollector
+from inmanta.execute.runtime import (
+    ResultVariable,
+    ExecutionUnit,
+    RawUnit,
+    HangUnit,
+    Instance,
+    Resolver,
+    QueueScheduler,
+    ResultCollector,
+)
 from inmanta.ast.statements.assign import Assign, SetAttribute
 from inmanta.ast.statements import ExpressionStatement, AssignStatement
 from inmanta.ast import RuntimeException, Locatable, Location, LocatableString
@@ -64,16 +72,16 @@ class Reference(ExpressionStatement):
             raise RuntimeException(self, "Could not resolve the value %s in this static context" % self.name)
         return requires[self.name]
 
-    def as_assign(self, value: ExpressionStatement, list_only: bool=False) -> AssignStatement:
+    def as_assign(self, value: ExpressionStatement, list_only: bool = False) -> AssignStatement:
         if list_only:
             raise ParserException(self.location, "+=", "Can not perform += on variable %s" % self.name)
         return Assign(self.name, value)
 
     def root_in_self(self) -> "Reference":
-        if self.name == 'self':
+        if self.name == "self":
             return self
         else:
-            ref = Reference('self')
+            ref = Reference("self")
             self.copy_location(ref)
             attr_ref = AttributeReference(ref, self.name)
             self.copy_location(attr_ref)
@@ -98,11 +106,9 @@ class AttributeReferenceHelper(Locatable):
         self.instance = instance
         self.resultcollector = resultcollector
 
-    def resume(self,
-               requires: Dict[object, object],
-               resolver: Resolver,
-               queue_scheduler: QueueScheduler,
-               target: ResultVariable) -> None:
+    def resume(
+        self, requires: Dict[object, object], resolver: Resolver, queue_scheduler: QueueScheduler, target: ResultVariable
+    ) -> None:
         """
             Instance is ready to execute, do it and see if the attribute is already present
         """
@@ -224,7 +230,7 @@ class AttributeReference(Reference):
         # helper returned: return result
         return requires[self]
 
-    def as_assign(self, value: ExpressionStatement, list_only: bool=False) -> AssignStatement:
+    def as_assign(self, value: ExpressionStatement, list_only: bool = False) -> AssignStatement:
         return SetAttribute(self.instance, self.attribute, value, list_only)
 
     def root_in_self(self) -> Reference:

--- a/src/inmanta/command.py
+++ b/src/inmanta/command.py
@@ -18,7 +18,6 @@
 
 
 class CLIException(Exception):
-
     def __init__(self, exitcode, *args, **kwargs):
         self.exitcode = exitcode
         super(CLIException, self).__init__(*args, **kwargs)
@@ -28,6 +27,7 @@ class Commander(object):
     """
         This class handles commands
     """
+
     __command_functions = {}
 
     @classmethod
@@ -43,7 +43,7 @@ class Commander(object):
             "help": help_msg,
             "parser_config": parser_config,
             "require_project": require_project,
-            "aliases": aliases
+            "aliases": aliases,
         }
 
     config = None

--- a/src/inmanta/compiler/__init__.py
+++ b/src/inmanta/compiler/__init__.py
@@ -173,12 +173,15 @@ class Compiler(object):
         # add the entity type (hack?)
         ns = self.__root_ns.get_child_or_create("std")
         nullrange = Range("internal", 1, 0, 0, 0)
-        entity = DefineEntity(ns, LocatableString("Entity", nullrange, 0, ns),
-                              "The entity all other entities inherit from.", [], [])
+        entity = DefineEntity(
+            ns, LocatableString("Entity", nullrange, 0, ns), "The entity all other entities inherit from.", [], []
+        )
         str_std_entity = LocatableString("std::Entity", nullrange, 0, ns)
 
-        requires_rel = DefineRelation((str_std_entity, LocatableString("requires", nullrange, 0, ns), [0, None], False),
-                                      (str_std_entity, LocatableString("provides", nullrange, 0, ns), [0, None], False))
+        requires_rel = DefineRelation(
+            (str_std_entity, LocatableString("requires", nullrange, 0, ns), [0, None], False),
+            (str_std_entity, LocatableString("provides", nullrange, 0, ns), [0, None], False),
+        )
         requires_rel.namespace = self.__root_ns.get_ns_from_string("std")
 
         statements.append(entity)

--- a/src/inmanta/compiler/help/explainer.py
+++ b/src/inmanta/compiler/help/explainer.py
@@ -28,38 +28,32 @@ import os
 import re
 
 
-def bold(content: str=None) -> str:
+def bold(content: str = None) -> str:
     if content is None:
         return "\033[1m"
     return "\033[1m{0}\033[0m".format(content)
 
 
-def underline(content: str=None) -> str:
+def underline(content: str = None) -> str:
     if content is None:
         return "\033[4m"
     return "\033[4m{0}\033[0m".format(content)
 
 
-def noformat(content: str=None) -> str:
+def noformat(content: str = None) -> str:
     return "\033[0m"
 
 
-CUSTOM_FILTERS = {
-    "bold": bold,
-    "underline": underline,
-    "noformat": noformat,
-}
+CUSTOM_FILTERS = {"bold": bold, "underline": underline, "noformat": noformat}
 
 
 class Explainer(object):
-
     @abstractmethod
     def explain(self, problem: CompilerException) -> List[str]:
         pass
 
 
 class JinjaExplainer(Explainer):
-
     def __init__(self, template: str, acceptable_type):
         self.template = template
         self.acceptable_type = acceptable_type
@@ -75,7 +69,7 @@ class JinjaExplainer(Explainer):
     def explain(self, problem: CompilerException) -> List[str]:
         allcauses = set()
         work = [problem]
-        while(work):
+        while work:
             w = work.pop()
             allcauses.add(w)
             work.extend(w.get_causes())
@@ -88,9 +82,7 @@ class JinjaExplainer(Explainer):
             return [self.do_explain(x) for x in explainable]
 
     def do_explain(self, problem: CompilerException) -> str:
-        env = Environment(
-            loader=PackageLoader('inmanta.compiler.help'),
-        )
+        env = Environment(loader=PackageLoader("inmanta.compiler.help"))
         for name, filter in CUSTOM_FILTERS.items():
             env.filters[name] = filter
 
@@ -102,15 +94,16 @@ class JinjaExplainer(Explainer):
 
 
 class ModifiedAfterFreezeExplainer(JinjaExplainer):
-
     def __init__(self):
         super(ModifiedAfterFreezeExplainer, self).__init__("modified_after_freeze.j2", ModifiedAfterFreezeException)
 
     def build_reverse_hint(self, problem):
         if isinstance(problem.stmt, AssignStatement):
-            return "%s.%s = %s" % (problem.stmt.rhs.pretty_print(),
-                                   problem.attribute.get_name(),
-                                   problem.stmt.lhs.pretty_print())
+            return "%s.%s = %s" % (
+                problem.stmt.rhs.pretty_print(),
+                problem.attribute.get_name(),
+                problem.stmt.lhs.pretty_print(),
+            )
 
         if isinstance(problem.stmt, Constructor):
             # find right parameter:
@@ -122,7 +115,7 @@ class ModifiedAfterFreezeExplainer(JinjaExplainer):
             return "%s.%s = %s" % (attr_rhs, problem.attribute.get_name(), problem.stmt.pretty_print())
 
     def get_arguments(self, problem: CompilerException) -> Dict[str, Any]:
-        return{
+        return {
             "relation": problem.attribute.get_name(),
             "instance": problem.instance,
             "values": problem.resultvariable.value,
@@ -130,17 +123,16 @@ class ModifiedAfterFreezeExplainer(JinjaExplainer):
             "location": problem.location,
             "reverse": problem.reverse,
             "reverse_example": "" if not problem.reverse else self.build_reverse_hint(problem),
-            "optional": isinstance(problem.resultvariable, OptionVariable)
+            "optional": isinstance(problem.resultvariable, OptionVariable),
         }
 
 
 def escape_ansi(line):
-    ansi_escape = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -/]*[@-~]')
-    return ansi_escape.sub('', line)
+    ansi_escape = re.compile(r"(\x9B|\x1B\[)[0-?]*[ -/]*[@-~]")
+    return ansi_escape.sub("", line)
 
 
 class ExplainerFactory(object):
-
     def get_explainers(self) -> List[Explainer]:
         return [ModifiedAfterFreezeExplainer()]
 

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -40,17 +40,30 @@ TRANSIENT_STATES = [ResourceState.available, ResourceState.deploying, ResourceSt
 # not counting as done
 NOT_DONE_STATES = TRANSIENT_STATES
 # counts as done
-DONE_STATES = [ResourceState.unavailable, ResourceState.skipped, ResourceState.deployed, ResourceState.failed,
-               ResourceState.cancelled] + UNDEPLOYABLE_STATES
+DONE_STATES = [
+    ResourceState.unavailable,
+    ResourceState.skipped,
+    ResourceState.deployed,
+    ResourceState.failed,
+    ResourceState.cancelled,
+] + UNDEPLOYABLE_STATES
 
 # starting states
 INITIAL_STATES = [ResourceState.available]
 # states one can't transition out off
 TERMINAL_STATES = UNDEPLOYABLE_STATES
 # states on can transition to
-VALID_STATES_ON_STATE_UPDATE = [ResourceState.unavailable, ResourceState.skipped, ResourceState.deployed,
-                                ResourceState.failed, ResourceState.deploying, ResourceState.cancelled, ResourceState.undefined,
-                                ResourceState.skipped_for_undefined, ResourceState.processing_events]
+VALID_STATES_ON_STATE_UPDATE = [
+    ResourceState.unavailable,
+    ResourceState.skipped,
+    ResourceState.deployed,
+    ResourceState.failed,
+    ResourceState.deploying,
+    ResourceState.cancelled,
+    ResourceState.undefined,
+    ResourceState.skipped_for_undefined,
+    ResourceState.processing_events,
+]
 
 UNKNOWN_STRING = "<<undefined>>"
 

--- a/src/inmanta/db/migrate_to_postgresql.py
+++ b/src/inmanta/db/migrate_to_postgresql.py
@@ -25,61 +25,21 @@ from inmanta import data
 
 LOGGER = logging.getLogger()
 
-TABLES_TO_MIGRATE = [
-    data.Project,
-    data.Environment,
-    data.Parameter,
-    data.Form,
-    data.FormRecord,
-]
+TABLES_TO_MIGRATE = [data.Project, data.Environment, data.Parameter, data.Form, data.FormRecord]
 
 
 @click.command()
+@click.option("--mongo-host", help="Host running the MongoDB database.", default="127.0.0.1")
+@click.option("--mongo-port", help="The port on which the MongoDB server is listening.", default=27017, type=int)
+@click.option("--mongo-database", help="The name of the MongoDB database.", default="inmanta")
+@click.option("--pg-host", help="Host running the PostgreSQL database.", default="127.0.0.1")
+@click.option("--pg-port", help="The port on which the PostgreSQL database is listening.", default=5432, type=int)
+@click.option("--pg-database", help="The name of the PostgreSQL database.", default="inmanta")
+@click.option("--pg-username", help="The username to use to login on the PostgreSQL database", default="inmanta")
 @click.option(
-    "--mongo-host", help="Host running the MongoDB database.", default="127.0.0.1"
+    "--pg-password", help="The password that belongs to user specified with --pg-username", prompt=True, hide_input=True
 )
-@click.option(
-    "--mongo-port",
-    help="The port on which the MongoDB server is listening.",
-    default=27017,
-    type=int,
-)
-@click.option(
-    "--mongo-database", help="The name of the MongoDB database.", default="inmanta"
-)
-@click.option(
-    "--pg-host", help="Host running the PostgreSQL database.", default="127.0.0.1"
-)
-@click.option(
-    "--pg-port",
-    help="The port on which the PostgreSQL database is listening.",
-    default=5432,
-    type=int,
-)
-@click.option(
-    "--pg-database", help="The name of the PostgreSQL database.", default="inmanta"
-)
-@click.option(
-    "--pg-username",
-    help="The username to use to login on the PostgreSQL database",
-    default="inmanta",
-)
-@click.option(
-    "--pg-password",
-    help="The password that belongs to user specified with --pg-username",
-    prompt=True,
-    hide_input=True,
-)
-def main(
-    mongo_host,
-    mongo_port,
-    mongo_database,
-    pg_host,
-    pg_port,
-    pg_database,
-    pg_username,
-    pg_password,
-):
+def main(mongo_host, mongo_port, mongo_database, pg_host, pg_port, pg_database, pg_username, pg_password):
     """
         Migrate the database of the Inmanta server from MongoDB to PostgreSQL.
 
@@ -93,51 +53,22 @@ def main(
 
     loop = asyncio.get_event_loop()
     future = migrate_mongo_to_postgres(
-        mongo_host,
-        mongo_port,
-        mongo_database,
-        pg_host,
-        pg_port,
-        pg_database,
-        pg_username,
-        pg_password,
+        mongo_host, mongo_port, mongo_database, pg_host, pg_port, pg_database, pg_username, pg_password
     )
     loop.run_until_complete(future)
     loop.close()
 
 
 async def migrate_mongo_to_postgres(
-    mongo_host,
-    mongo_port,
-    mongo_database,
-    pg_host,
-    pg_port,
-    pg_database,
-    pg_username,
-    pg_password,
+    mongo_host, mongo_port, mongo_database, pg_host, pg_port, pg_database, pg_username, pg_password
 ):
     try:
-        LOGGER.info(
-            "Connecting to MongoDB database %s on %s:%s",
-            mongo_database,
-            mongo_host,
-            mongo_port,
-        )
+        LOGGER.info("Connecting to MongoDB database %s on %s:%s", mongo_database, mongo_host, mongo_port)
         mongo_client = MongoClient(mongo_host, mongo_port)
         mongo_connection = mongo_client[mongo_database]
-        LOGGER.info(
-            "Connecting to PostgreSQL database %s on %s:%s",
-            pg_database,
-            pg_host,
-            pg_port,
-        )
+        LOGGER.info("Connecting to PostgreSQL database %s on %s:%s", pg_database, pg_host, pg_port)
         await data.connect(
-            host=pg_host,
-            port=pg_port,
-            database=pg_database,
-            username=pg_username,
-            password=pg_password,
-            create_db_schema=True,
+            host=pg_host, port=pg_port, database=pg_database, username=pg_username, password=pg_password, create_db_schema=True
         )
         await do_migration(mongo_connection)
     finally:
@@ -154,11 +85,7 @@ async def do_migration(mongo_connection):
         records = mongo_connection[cls.__name__].find()
         for record in records:
             # Don't migrate parameters which have a resource_id associated
-            if (
-                cls == data.Parameter
-                and "resource_id" in record
-                and record["resource_id"]
-            ):
+            if cls == data.Parameter and "resource_id" in record and record["resource_id"]:
                 continue
             args = {}
             for field_name in cls._fields.copy().keys():

--- a/src/inmanta/deploy.py
+++ b/src/inmanta/deploy.py
@@ -64,7 +64,7 @@ class Deploy(object):
         loud_logger = logging.getLogger("tornado")
         loud_logger.propagate = False
 
-    def _check_result(self, result: protocol.Result, fatal: bool=True) -> protocol.Result:
+    def _check_result(self, result: protocol.Result, fatal: bool = True) -> protocol.Result:
         """ Check the result of a call protocol call. If the result is not 200, issue an error
         """
         if result.code != 200:
@@ -282,9 +282,7 @@ port=%(server_port)s
             os.symlink(full_path, server_env)
 
         if not os.path.exists(os.path.join(full_path, ".git")) and self._options.dashboard:
-            LOGGER.error(
-                "Make sure the project is a git repository, otherwise the embedded server cannot recompile the model."
-            )
+            LOGGER.error("Make sure the project is a git repository, otherwise the embedded server cannot recompile the model.")
 
         return True
 
@@ -353,9 +351,14 @@ port=%(server_port)s
 
         # release the version!
         if not dry_run:
-            self._check_result(self._client.release_version(
-                tid=self._environment_id, id=version, push=True, agent_trigger_method=const.AgentTriggerMethod.push_full_deploy
-            ))
+            self._check_result(
+                self._client.release_version(
+                    tid=self._environment_id,
+                    id=version,
+                    push=True,
+                    agent_trigger_method=const.AgentTriggerMethod.push_full_deploy,
+                )
+            )
             if report:
                 self.progress_deploy_report(version)
 

--- a/src/inmanta/doctools.py
+++ b/src/inmanta/doctools.py
@@ -27,7 +27,6 @@ from inmanta.config import Config
 
 
 class CompilerFixture(object):
-
     def __init__(self):
         self.libs = tempfile.mkdtemp()
         self.env = tempfile.mkdtemp()
@@ -46,7 +45,8 @@ class CompilerFixture(object):
             downloadpath: %s
             version: 1.0
             repo: ['git@git.inmanta.com:modules/', 'git@git.inmanta.com:config/']"""
-                % (self.libs, self.libs))
+                % (self.libs, self.libs)
+            )
 
         with open(os.path.join(project_dir, "main.cf"), "w") as x:
             x.write(snippet)
@@ -72,7 +72,8 @@ class CompilerFixture(object):
             downloadpath: %s
             version: 1.0
             repo: ['git@git.inmanta.com:modules/', 'git@git.inmanta.com:config/']"""
-                % (self.libs, self.libs))
+                % (self.libs, self.libs)
+            )
 
         Project.set(Project(project_dir))
         compiler.do_compile()
@@ -112,6 +113,6 @@ def test_snippets():
     return fail
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if not test_snippets():
         sys.exit(1)

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -37,6 +37,7 @@ class VirtualEnv(object):
     """
         Creates and uses a virtual environment for this process
     """
+
     _egg_fragment_re = re.compile(r"#egg=(?P<name>[^&]*)")
     _at_fragment_re = re.compile(r"^(?P<name>[^@]+)@(?P<req>.+)")
 

--- a/src/inmanta/execute/proxy.py
+++ b/src/inmanta/execute/proxy.py
@@ -146,7 +146,6 @@ class DynamicProxy(object):
 
 
 class SequenceProxy(DynamicProxy):
-
     def __init__(self, iterator):
         DynamicProxy.__init__(self, iterator)
 
@@ -167,7 +166,6 @@ class SequenceProxy(DynamicProxy):
 
 
 class DictProxy(DynamicProxy, Mapping):
-
     def __init__(self, mydict):
         DynamicProxy.__init__(self, mydict)
 

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -90,11 +90,9 @@ class Scheduler(object):
             self.do_sort_entities(entity_map, workon, out, loopstack)
         return out
 
-    def do_sort_entities(self,
-                         entity_map: Dict[str, DefineEntity],
-                         name: str,
-                         acc: List[DefineEntity],
-                         loopstack: Set[str]) -> None:
+    def do_sort_entities(
+        self, entity_map: Dict[str, DefineEntity], name: str, acc: List[DefineEntity], loopstack: Set[str]
+    ) -> None:
         nexte = entity_map[name]
         try:
             del entity_map[name]
@@ -128,8 +126,9 @@ class Scheduler(object):
         compiler.get_ns().set_primitives(TYPES)
 
         # all stmts contributing types and impls
-        newtypes = [k for k in [t.register_types()
-                                for t in definitions if isinstance(t, TypeDefinitionStatement)] if k is not None]
+        newtypes = [
+            k for k in [t.register_types() for t in definitions if isinstance(t, TypeDefinitionStatement)] if k is not None
+        ]
 
         for (name, type_symbol) in newtypes:
             types_and_impl[name] = type_symbol
@@ -183,8 +182,12 @@ class Scheduler(object):
 
         # relations are also in blocks
         statements = (s for s in statements if not isinstance(s, DefineRelation))
-        anchors = (anchor for container in itertools.chain(statements, blocks)
-                   for anchor in container.get_anchors() if anchor is not None)
+        anchors = (
+            anchor
+            for container in itertools.chain(statements, blocks)
+            for anchor in container.get_anchors()
+            if anchor is not None
+        )
 
         rangetorange = [(anchor.get_location(), anchor.resolve()) for anchor in anchors]
         rangetorange = [(f, t) for f, t in rangetorange if t is not None]
@@ -241,8 +244,15 @@ class Scheduler(object):
             else:
                 i += 1
 
-            LOGGER.debug("Iteration %d (e: %d, w: %d, p: %d, done: %d, time: %f)", i,
-                         len(basequeue), len(waitqueue), len(zerowaiters), count, now - prev)
+            LOGGER.debug(
+                "Iteration %d (e: %d, w: %d, p: %d, done: %d, time: %f)",
+                i,
+                len(basequeue),
+                len(waitqueue),
+                len(zerowaiters),
+                count,
+                now - prev,
+            )
             prev = now
 
             # evaluate all that is ready
@@ -298,8 +308,15 @@ class Scheduler(object):
                     next.freeze()
 
         now = time.time()
-        LOGGER.debug("Iteration %d (e: %d, w: %d, p: %d, done: %d, time: %f)", i,
-                     len(basequeue), len(waitqueue), len(zerowaiters), count, now - prev)
+        LOGGER.debug(
+            "Iteration %d (e: %d, w: %d, p: %d, done: %d, time: %f)",
+            i,
+            len(basequeue),
+            len(waitqueue),
+            len(zerowaiters),
+            count,
+            now - prev,
+        )
 
         if i == MAX_ITERATIONS:
             print("could not complete model")

--- a/src/inmanta/execute/tracking.py
+++ b/src/inmanta/execute/tracking.py
@@ -34,7 +34,6 @@ class Tracker(object):
 
 
 class ModuleTracker(Tracker):
-
     def __init__(self, block):
         self.block = block
         self.namespace = block.namespace
@@ -44,7 +43,6 @@ class ModuleTracker(Tracker):
 
 
 class ImplementsTracker(Tracker):
-
     def __init__(self, subc, instance):
         self.instance = instance
         self.subc = subc

--- a/src/inmanta/execute/util.py
+++ b/src/inmanta/execute/util.py
@@ -24,6 +24,7 @@ class AnyType(object):
     """
         Supertype for objects that are an instance of all types
     """
+
     pass
 
 

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -55,7 +55,6 @@ ProxiedType = Dict[str, List[Union[str, tuple, int, float, bool, "DynamicProxy"]
 
 
 class DependencyCycleException(Exception):
-
     def __init__(self, start: Resource) -> None:
         super().__init__()
         self.start = start
@@ -84,9 +83,8 @@ def upload_code(conn: protocol.Client, tid: uuid.UUID, version: int, code_manage
             raise Exception("Unable to upload handler plugin code to the server (msg: %s)" % res.result)
 
     source_map = {
-        resource_name: {
-            source.hash: (source.path, source.module_name, source.requires) for source in sources
-        } for resource_name, sources in code_manager.get_types()
+        resource_name: {source.hash: (source.path, source.module_name, source.requires) for source in sources}
+        for resource_name, sources in code_manager.get_types()
     }
 
     res = conn.upload_code_batched(tid=tid, id=version, resources=source_map)
@@ -98,6 +96,7 @@ class Exporter(object):
     """
         This class handles exporting the compiled configuration model
     """
+
     # instance vars
     types: Optional[Dict[str, Entity]]
     scopes: Optional[Namespace]
@@ -120,7 +119,7 @@ class Exporter(object):
         """
         cls.__dep_manager.append(function)
 
-    def __init__(self, options: argparse.Namespace=None) -> None:
+    def __init__(self, options: argparse.Namespace = None) -> None:
         self.options = options
 
         self._resources: ResourceDict = {}
@@ -167,13 +166,19 @@ class Exporter(object):
                         ignored_set.add(instance)
                         # We get this exception when the attribute that is used to create the object id contains an unknown.
                         # We can safely ignore this resource == prune it
-                        LOGGER.debug("Skipped resource of type %s because its id contains an unknown (location: %s)",
-                                     entity, instance.location)
+                        LOGGER.debug(
+                            "Skipped resource of type %s because its id contains an unknown (location: %s)",
+                            entity,
+                            instance.location,
+                        )
 
                     except IgnoreResourceException:
                         ignored_set.add(instance)
-                        LOGGER.info("Ignoring resource of type %s because it requested to ignore it. (location: %s)",
-                                    entity, instance.location)
+                        LOGGER.info(
+                            "Ignoring resource of type %s because it requested to ignore it. (location: %s)",
+                            entity,
+                            instance.location,
+                        )
 
         Resource.convert_requires(resource_mapping, ignored_set)
 
@@ -186,7 +191,7 @@ class Exporter(object):
             export.append(pl.strip())
 
         for name in export:
-            if name.strip() == '':
+            if name.strip() == "":
                 continue
 
             if name not in self.__class__.__export_functions:
@@ -254,10 +259,10 @@ class Exporter(object):
         self,
         types: Optional[Dict[str, type.Type]],
         scopes: Optional[Namespace],
-        metadata: Dict[str, str]={},
-        no_commit: bool=False,
-        include_status: bool=False,
-        model_export: bool=False
+        metadata: Dict[str, str] = {},
+        no_commit: bool = False,
+        include_status: bool = False,
+        model_export: bool = False,
     ) -> None:
         """
         Run the export functions
@@ -350,7 +355,7 @@ class Exporter(object):
 
         return resources
 
-    def deploy_code(self, conn: protocol.Client, tid: uuid, version: int=None) -> None:
+    def deploy_code(self, conn: protocol.Client, tid: uuid, version: int = None) -> None:
         """ Deploy code to the server
         """
         if version is None:
@@ -370,9 +375,7 @@ class Exporter(object):
 
         upload_code(conn, tid, version, code_manager)
 
-    def commit_resources(
-        self, version: int, resources: List[Dict[str, str]], metadata: Dict[str, str], model: Dict
-    ) -> None:
+    def commit_resources(self, version: int, resources: List[Dict[str, str]], metadata: Dict[str, str], model: Dict) -> None:
         """
             Commit the entire list of resource to the configurations server.
         """
@@ -409,16 +412,21 @@ class Exporter(object):
                 LOGGER.debug("Uploaded file with hash %s" % hash_id)
 
         # Collecting version information
-        version_info = {const.EXPORT_META_DATA: metadata,
-                        "model": model}
+        version_info = {const.EXPORT_META_DATA: metadata, "model": model}
 
         # TODO: start transaction
         LOGGER.info("Sending resource updates to server")
         for res in resources:
             LOGGER.debug("  %s", res["id"])
 
-        res = conn.put_version(tid=tid, version=version, resources=resources, unknowns=unknown_parameters,
-                               resource_state=self._resource_state, version_info=version_info)
+        res = conn.put_version(
+            tid=tid,
+            version=version,
+            resources=resources,
+            unknowns=unknown_parameters,
+            resource_state=self._resource_state,
+            version_info=version_info,
+        )
 
         if res.code != 200:
             LOGGER.error("Failed to commit resource updates (%s)", res.result["message"])
@@ -430,7 +438,7 @@ class Exporter(object):
             executed in the transaction.
         """
         if not isinstance(content, bytes):
-            content = content.encode('utf-8')
+            content = content.encode("utf-8")
 
         hash_id = hash_file(content)
         self._file_store[hash_id] = content
@@ -451,6 +459,7 @@ class code_manager(object):  # noqa: N801
     """ Register a function that will be invoked after all resource and handler code is collected. A code manager can add
     or modify code before it is uploaded to the server.
     """
+
     def __init__(self, function: Callable[[], None]) -> None:
         pass
 
@@ -510,7 +519,6 @@ def relation_name(type: Entity, rel: RelationAttribute) -> str:
 
 
 class ModelExporter(object):
-
     def __init__(self, types: ModelDict):
         self.root_type = types["std::Entity"]
         self.types = types
@@ -519,9 +527,10 @@ class ModelExporter(object):
         """
             Run after export_model!!
         """
+
         def convert_comment(value):
             if value is None:
-                return ''
+                return ""
             else:
                 return str(value)
 
@@ -534,25 +543,38 @@ class ModelExporter(object):
                 return model.DirectValue(value)
 
         def convert_attribute(attr):
-            return model.Attribute(attr.type.type_string(), attr.is_optional(), attr.is_multi(),
-                                   convert_comment(attr.comment), location(attr))
+            return model.Attribute(
+                attr.type.type_string(), attr.is_optional(), attr.is_multi(), convert_comment(attr.comment), location(attr)
+            )
 
         def convert_relation(relation: RelationAttribute):
 
-            return model.Relation(relation.type.get_full_name(),
-                                  (relation.low, relation.high),
-                                  relation_name(relation.type, relation.end),
-                                  convert_comment(relation.comment), location(relation),
-                                  [convert_value_for_type(x.get_value()) for x in relation.source_annotations],
-                                  [convert_value_for_type(x.get_value()) for x in relation.target_annotations])
+            return model.Relation(
+                relation.type.get_full_name(),
+                (relation.low, relation.high),
+                relation_name(relation.type, relation.end),
+                convert_comment(relation.comment),
+                location(relation),
+                [convert_value_for_type(x.get_value()) for x in relation.source_annotations],
+                [convert_value_for_type(x.get_value()) for x in relation.target_annotations],
+            )
 
         def convert_type(mytype):
-            return model.Entity([x.get_full_name() for x in mytype.parent_entities],
-                                {n: convert_attribute(attr) for n, attr in mytype.get_attributes().items()
-                                 if not isinstance(attr, RelationAttribute)},
-                                {n: convert_relation(attr) for n, attr in mytype.get_attributes().items()
-                                 if isinstance(attr, RelationAttribute)},
-                                location(mytype))
+            return model.Entity(
+                [x.get_full_name() for x in mytype.parent_entities],
+                {
+                    n: convert_attribute(attr)
+                    for n, attr in mytype.get_attributes().items()
+                    if not isinstance(attr, RelationAttribute)
+                },
+                {
+                    n: convert_relation(attr)
+                    for n, attr in mytype.get_attributes().items()
+                    if isinstance(attr, RelationAttribute)
+                },
+                location(mytype),
+            )
+
         return {k: convert_type(v).to_dict() for k, v in self.types.items() if isinstance(v, Entity)}
 
     def export_model(self) -> Dict[str, Any]:
@@ -624,7 +646,4 @@ class ModelExporter(object):
         return maps
 
     def export_all(self) -> Dict[str, Any]:
-        return {
-            "instances": self.export_model(),
-            "types": self.export_types()
-        }
+        return {"instances": self.export_model(), "types": self.export_types()}

--- a/src/inmanta/loader.py
+++ b/src/inmanta/loader.py
@@ -83,8 +83,7 @@ class SourceInfo(object):
         if module_parts[0] != const.PLUGINS_PACKAGE:
             raise Exception(
                 "All instances from which the source is loaded, should be defined in the inmanta plugins package. "
-                "%s does not match"
-                % self.module_name
+                "%s does not match" % self.module_name
             )
 
         return module_parts[1]
@@ -179,7 +178,7 @@ class CodeLoader(object):
 
         for py in glob.glob(os.path.join(mod_dir, "*.py")):
             if mod_dir in py:
-                mod_name = py[len(mod_dir) + 1: -3]
+                mod_name = py[len(mod_dir) + 1 : -3]
             else:
                 mod_name = py[:-3]
 

--- a/src/inmanta/main.py
+++ b/src/inmanta/main.py
@@ -57,14 +57,12 @@ class Client(object):
         self._client = protocol.SyncClient("cmdline")
 
     def do_request(
-        self, method_name: str, key_name: Optional[str]=None, arguments: JsonType={}, allow_none: bool=False
+        self, method_name: str, key_name: Optional[str] = None, arguments: JsonType = {}, allow_none: bool = False
     ) -> Optional[JsonType]:
         """
             Do a request and return the response
         """
-        self.log.debug(
-            "Calling method %s on server %s:%s with arguments %s", method_name, self.host, self.host, arguments
-        )
+        self.log.debug("Calling method %s on server %s:%s with arguments %s", method_name, self.host, self.host, arguments)
 
         if not hasattr(self._client, method_name):
             raise Exception("API call %s is not available." % method_name)
@@ -97,7 +95,7 @@ class Client(object):
 
             raise Exception(("An error occurred while requesting %s" % key_name) + msg)
 
-    def get_list(self, method_name: str, key_name: Optional[str]=None, arguments: JsonType={}) -> List[Dict[str, str]]:
+    def get_list(self, method_name: str, key_name: Optional[str] = None, arguments: JsonType = {}) -> List[Dict[str, str]]:
         """
             Same as do request, but return type is a list of dicts
         """
@@ -135,7 +133,7 @@ class Client(object):
 
         return project_id
 
-    def to_environment_id(self, ref: str, project_id: uuid.UUID=None) -> uuid.UUID:
+    def to_environment_id(self, ref: str, project_id: uuid.UUID = None) -> uuid.UUID:
         """
             Convert ref to an env uuid, optionally scoped to a project
         """
@@ -189,7 +187,7 @@ class Client(object):
         return env_id
 
 
-def print_table(header: List[str], rows: List[List[str]], data_type: List[str]=None) -> None:
+def print_table(header: List[str], rows: List[List[str]], data_type: List[str] = None) -> None:
     width, _ = click.get_terminal_size()
 
     table = texttable.Texttable(max_width=width)
@@ -222,7 +220,7 @@ def project_list(client: Client) -> None:
     projects = client.get_list("list_projects", "projects")
 
     if len(projects) > 0:
-        print_table(['ID', 'Name'], [[n['id'], n['name']] for n in projects])
+        print_table(["ID", "Name"], [[n["id"], n["name"]] for n in projects])
 
     else:
         click.echo("No projects defined.", err=True)
@@ -274,19 +272,28 @@ def environment(ctx: click.Context) -> None:
 @environment.command(name="create")
 @click.option("--name", "-n", help="The name of the new environment", required=True)
 @click.option("--project", "-p", help="The id of the project this environment belongs to", required=True)
-@click.option("--repo-url", "-r", required=False, default="",
-              help="The url of the repository that contains the configuration model")
-@click.option("--branch", "-b", required=False, default="master",
-              help="The branch in the repository that contains the configuration model")
-@click.option("--save", "-s", default=False, is_flag=True,
-              help="Save the ID of the environment and the server to the .inmanta config file")
+@click.option(
+    "--repo-url", "-r", required=False, default="", help="The url of the repository that contains the configuration model"
+)
+@click.option(
+    "--branch",
+    "-b",
+    required=False,
+    default="master",
+    help="The branch in the repository that contains the configuration model",
+)
+@click.option(
+    "--save",
+    "-s",
+    default=False,
+    is_flag=True,
+    help="Save the ID of the environment and the server to the .inmanta config file",
+)
 @click.pass_obj
 def environment_create(client: Client, name: str, project: str, repo_url: str, branch: str, save: bool) -> None:
     project_id = client.to_project_id(project)
     env = client.get_dict(
-        "create_environment",
-        "environment",
-        dict(project_id=project_id, name=name, repository=repo_url, branch=branch)
+        "create_environment", "environment", dict(project_id=project_id, name=name, repository=repo_url, branch=branch)
     )
     project_data = client.get_dict("get_project", "project", {"id": project_id})
 
@@ -303,16 +310,20 @@ port=%(port)s
 [cmdline_rest_transport]
 host=%(host)s
 port=%(port)s
-""" % {"env": env["id"], "host": client.host, "port": client.port}
+""" % {
+            "env": env["id"],
+            "host": client.host,
+            "port": client.port,
+        }
         if os.path.exists(".inmanta"):
             click.echo(".inmanta exits, not writing config", err=True)
         else:
-            with open(".inmanta", 'w') as f:
+            with open(".inmanta", "w") as f:
                 f.write(cfg)
 
     print_table(
-        ['Environment ID', 'Environment name', 'Project ID', 'Project name'],
-        [[env["id"], env["name"], project_data["id"], project_data["name"]]]
+        ["Environment ID", "Environment name", "Project ID", "Project name"],
+        [[env["id"], env["name"], project_data["id"], project_data["name"]]],
     )
 
 
@@ -324,11 +335,11 @@ def environment_list(client: Client) -> None:
     data = []
     for env in environments:
         prj = client.get_dict("get_project", "project", dict(id=env["project"]))
-        prj_name = prj['name']
-        data.append([prj_name, env['project'], env['name'], env['id']])
+        prj_name = prj["name"]
+        data.append([prj_name, env["project"], env["name"], env["id"]])
 
     if len(data) > 0:
-        print_table(['Project name', 'Project ID', 'Environment', 'Environment ID'], data)
+        print_table(["Project name", "Project ID", "Environment", "Environment ID"], data)
     else:
         click.echo("No environment defined.")
 
@@ -339,29 +350,33 @@ def environment_list(client: Client) -> None:
 def environment_show(client: Client, environment: str) -> None:
     env = client.get_dict("get_environment", "environment", dict(id=client.to_environment_id(environment)))
     print_table(
-        ['ID', 'Name', 'Repository URL', 'Branch Name'],
-        [[env["id"], env["name"], env["repo_url"], env["repo_branch"]]],
+        ["ID", "Name", "Repository URL", "Branch Name"], [[env["id"], env["name"], env["repo_url"], env["repo_branch"]]]
     )
 
 
 @environment.command(name="modify")
 @click.option("--name", "-n", help="The name of the new environment", required=True)
-@click.option("--repo-url", "-r", required=False, default="",
-              help="The url of the repository that contains the configuration model")
-@click.option("--branch", "-b", required=False, default="master",
-              help="The branch in the repository that contains the configuration model")
+@click.option(
+    "--repo-url", "-r", required=False, default="", help="The url of the repository that contains the configuration model"
+)
+@click.option(
+    "--branch",
+    "-b",
+    required=False,
+    default="master",
+    help="The branch in the repository that contains the configuration model",
+)
 @click.argument("environment")
 @click.pass_obj
 def environment_modify(client: Client, environment: str, name: str, repo_url: str, branch: str) -> None:
     env = client.get_dict(
         "modify_environment",
         "environment",
-        dict(id=client.to_environment_id(environment), name=name, repository=repo_url, branch=branch)
+        dict(id=client.to_environment_id(environment), name=name, repository=repo_url, branch=branch),
     )
 
     print_table(
-        ['ID', 'Name', 'Repository URL', 'Branch Name'],
-        [[env["id"], env["name"], env["repo_url"], env["repo_branch"]]]
+        ["ID", "Name", "Repository URL", "Branch Name"], [[env["id"], env["name"], env["repo_url"], env["repo_branch"]]]
     )
 
 
@@ -449,7 +464,7 @@ def agent_list(client: Client, environment: str) -> None:
     for agent in agents:
         data.append([agent["name"], agent["environment"], agent["last_failover"]])
 
-    print_table(['Agent', 'Environment', 'Last fail over'], data)
+    print_table(["Agent", "Environment", "Last fail over"], data)
 
 
 @cmd.group("version")
@@ -466,31 +481,36 @@ def version_list(client: Client, environment: str) -> None:
     versions = client.get_list("list_versions", "versions", arguments=dict(tid=env_id))
 
     print_table(
-        ['Created at', 'Version', 'Released', 'Deployed', '# Resources', '# Done', 'State'],
-        [[x['date'], x['version'], x['released'], x['deployed'], x['total'], x['done'], x['result']] for x in versions],
-        ["t", "t", "t", "t", "t", "t", "t"]
+        ["Created at", "Version", "Released", "Deployed", "# Resources", "# Done", "State"],
+        [[x["date"], x["version"], x["released"], x["deployed"], x["total"], x["done"], x["result"]] for x in versions],
+        ["t", "t", "t", "t", "t", "t", "t"],
     )
 
 
 @version.command(name="release")
 @click.option("--environment", "-e", help="The environment to use", required=True)
 @click.option("--push", "-p", help="Push the version to the deployment agents", is_flag=True)
-@click.option("--full", help="Make the agents execute a full deploy instead of an incremental deploy. "
-                             "Should be used together with the --push option", is_flag=True)
+@click.option(
+    "--full",
+    help="Make the agents execute a full deploy instead of an incremental deploy. "
+    "Should be used together with the --push option",
+    is_flag=True,
+)
 @click.argument("version")
 @click.pass_obj
 def version_release(client: Client, environment: str, push: bool, full: bool, version: str) -> None:
     env_id = client.to_environment_id(environment)
     if push:
         trigger_method = AgentTriggerMethod.get_agent_trigger_method(full)
-        x = client.get_dict("release_version", "model", dict(tid=env_id, id=version, push=True,
-                                                             agent_trigger_method=trigger_method))
+        x = client.get_dict(
+            "release_version", "model", dict(tid=env_id, id=version, push=True, agent_trigger_method=trigger_method)
+        )
     else:
         x = client.get_dict("release_version", "model", dict(tid=env_id, id=version))
 
     print_table(
-        ['Created at', 'Version', 'Released', 'Deployed', '# Resources', '# Done', 'State'],
-        [[x['date'], x['version'], x['released'], x['deployed'], x['total'], x['done'], x['result']]]
+        ["Created at", "Version", "Released", "Deployed", "# Resources", "# Done", "State"],
+        [[x["date"], x["version"], x["released"], x["deployed"], x["total"], x["done"], x["result"]]],
     )
 
 
@@ -515,14 +535,14 @@ def param_list(client: Client, environment: str) -> None:
         data.append(
             [
                 p["resource_id"],
-                p['name'],
-                p['source'],
-                p['updated'],
-                str(float(datetime.datetime.strptime(p["updated"], TIME_ISOFMT) < when))
+                p["name"],
+                p["source"],
+                p["updated"],
+                str(float(datetime.datetime.strptime(p["updated"], TIME_ISOFMT) < when)),
             ]
         )
 
-    print_table(['Resource', 'Name', 'Source', 'Updated', 'Expired'], data)
+    print_table(["Resource", "Name", "Source", "Updated", "Expired"], data)
 
 
 @param.command(name="set")
@@ -535,19 +555,19 @@ def param_set(client: Client, environment: str, name: str, value: str) -> None:
     # first fetch the parameter
     param_data = cast(
         Optional[Dict[str, str]],
-        client.do_request("get_param", "parameter", dict(tid=tid, id=name, resource_id=""), allow_none=True)
+        client.do_request("get_param", "parameter", dict(tid=tid, id=name, resource_id=""), allow_none=True),
     )
 
     param = {"source": "user", "metadata": {}} if param_data is None else param_data
     param_return = client.get_dict(
         "set_param",
         "parameter",
-        dict(tid=tid, id=name, value=value, source=param["source"], resource_id="", metadata=param["metadata"])
+        dict(tid=tid, id=name, value=value, source=param["source"], resource_id="", metadata=param["metadata"]),
     )
 
     print_table(
-        ['Name', 'Value', 'Source', 'Updated'],
-        [[param_return['name'], param_return['value'], param_return['source'], param_return['updated']]]
+        ["Name", "Value", "Source", "Updated"],
+        [[param_return["name"], param_return["value"], param_return["source"], param_return["updated"]]],
     )
 
 
@@ -565,10 +585,7 @@ def param_get(client: Client, environment: str, name: str, resource: str) -> Non
     # first fetch the parameter
     param = client.get_dict("get_param", "parameter", dict(tid=tid, id=name, resource_id=resource))
 
-    print_table(
-        ['Name', 'Value', 'Source', 'Updated'],
-        [[param['name'], param['value'], param['source'], param['updated']]]
-    )
+    print_table(["Name", "Value", "Source", "Updated"], [[param["name"], param["value"], param["source"], param["updated"]]])
 
 
 @version.command(name="report")
@@ -591,8 +608,10 @@ def version_report(client: Client, environment: str, version: str, l: bool) -> N
 
         for t in sorted(agents[agent].keys()):
             parsed_resource_version_id = Id.parse_id(agents[agent][t][0]["resource_version_id"])
-            click.echo(click.style("Resource type:", bold=True)
-                       + "{type} ({attr})".format(type=t, attr=parsed_resource_version_id.attribute))
+            click.echo(
+                click.style("Resource type:", bold=True)
+                + "{type} ({attr})".format(type=t, attr=parsed_resource_version_id.attribute)
+            )
             click.echo("-" * 72)
 
             for res in agents[agent][t]:
@@ -642,9 +661,9 @@ def form_list(client: Client, environment: str) -> None:
 
     data = []
     for p in result:
-        data.append([p["form_type"], p['form_id']])
+        data.append([p["form_type"], p["form_id"]])
 
-    print_table(['Form Type', 'Form ID'], data)
+    print_table(["Form Type", "Form ID"], data)
 
 
 @form.command(name="show")
@@ -670,11 +689,7 @@ def form_show(client: Client, environment: str, form_type: str) -> None:
 def form_export(client: Client, environment: str, form_type: str) -> None:
     tid = client.to_environment_id(environment)
     form_def = client.get_dict("get_form", "form", arguments=dict(tid=tid, id=form_type))
-    form_records = client.get_list(
-        "list_records",
-        "records",
-        arguments=dict(tid=tid, form_type=form_type, include_record=True)
-    )
+    form_records = client.get_list("list_records", "records", arguments=dict(tid=tid, form_type=form_type, include_record=True))
 
     click.echo(json.dumps({"form_type": form_def, "records": form_records}))
 
@@ -727,20 +742,20 @@ def record_list(client: Client, environment: str, form_type: str, show_all: bool
         result = client.get_list("list_records", "records", arguments=dict(tid=tid, form_type=form_type))
         data = []
         for p in result:
-            data.append([p["id"], p['changed']])
+            data.append([p["id"], p["changed"]])
 
-        print_table(['Record ID', 'Changed'], data)
+        print_table(["Record ID", "Changed"], data)
     else:
         result = client.get_list("list_records", "records", arguments=dict(tid=tid, form_type=form_type, include_record=True))
         fields = []
         data = []
         for p in result:
             fields = p["fields"].keys()
-            values = [p["id"], p['changed']]
+            values = [p["id"], p["changed"]]
             values.extend(p["fields"].values())
             data.append(values)
 
-        allfields = ['Record ID', 'Changed']
+        allfields = ["Record ID", "Changed"]
         allfields.extend(fields)
         print_table(allfields, data)
 
@@ -794,8 +809,7 @@ def record_update(client: Client, environment: str, record: str, field: List[str
         fields[parts[0].strip()] = parts[1].strip()
 
     result = cast(
-        Dict[str, Dict[str, str]],
-        client.do_request("update_record", "record", arguments=dict(tid=tid, id=record, form=fields))
+        Dict[str, Dict[str, str]], client.do_request("update_record", "record", arguments=dict(tid=tid, id=record, form=fields))
     )
 
     values = []
@@ -845,8 +859,7 @@ def monitor_deploy(client: Client, environment: str) -> None:
                 last = done
             sleep(1)
             version = cast(
-                Dict[str, Dict[str, int]],
-                client.get_dict("get_version", arguments=dict(tid=tid, id=int(ident), limit=0))
+                Dict[str, Dict[str, int]], client.get_dict("get_version", arguments=dict(tid=tid, id=int(ident), limit=0))
             )
             done = version["model"]["done"]
         if done != last:
@@ -900,5 +913,5 @@ def main() -> None:
     cmd()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/inmanta/model.py
+++ b/src/inmanta/model.py
@@ -1,4 +1,4 @@
-'''
+"""
   Copyright 2018 Inmanta
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
     limitations under the License.
 
     Contact: code@inmanta.com
-'''
+"""
 from builtins import str
 from typing import List, Dict, Tuple
 
@@ -48,10 +48,7 @@ class Location(object):
                     "lnr": self.lnr
                 }
         """
-        return {
-            "file": self.file,
-            "lnr": self.lnr
-        }
+        return {"file": self.file, "lnr": self.lnr}
 
     @staticmethod
     def from_dict(ctx):
@@ -93,20 +90,24 @@ class Attribute(object):
                     "location": self.location.to_dict()
                 }
         """
-        return {"type": self.type,
-                "multi": self.multi,
-                "nullable": self.nullable,
-                "comment": self.comment,
-                "location": self.location.to_dict()}
+        return {
+            "type": self.type,
+            "multi": self.multi,
+            "nullable": self.nullable,
+            "comment": self.comment,
+            "location": self.location.to_dict(),
+        }
 
     @staticmethod
     def from_dict(ctx):
 
-        return Attribute(mytype=ctx["type"],
-                         nullable=ctx["nullable"],
-                         multi=ctx["multi"],
-                         comment=ctx["comment"],
-                         location=Location.from_dict(ctx["location"]))
+        return Attribute(
+            mytype=ctx["type"],
+            nullable=ctx["nullable"],
+            multi=ctx["multi"],
+            comment=ctx["comment"],
+            location=Location.from_dict(ctx["location"]),
+        )
 
     @staticmethod
     def from_list(l):
@@ -190,8 +191,16 @@ class Relation(object):
     :param List[Value] target_annotations: annotations on this relation on the target side
     """
 
-    def __init__(self, mytype: str, multi: Tuple[int, int], reverse: str, comment: str, location: Location,
-                 source_annotations: List[Value], target_annotations: List[Value]) -> None:
+    def __init__(
+        self,
+        mytype: str,
+        multi: Tuple[int, int],
+        reverse: str,
+        comment: str,
+        location: Location,
+        source_annotations: List[Value],
+        target_annotations: List[Value],
+    ) -> None:
         self.type = mytype
         lower = multi[0]
         if lower is None:
@@ -224,24 +233,28 @@ class Relation(object):
                 "target_annotations": [x.to_dict() for x in self.target_annotations]
                 }
         """
-        return {"type": self.type,
-                "multi": [self.multi[0], self.multi[1]],
-                "reverse": self.reverse,
-                "comment": self.comment,
-                "location": self.location.to_dict(),
-                "source_annotations": [x.to_dict() for x in self.source_annotations],
-                "target_annotations": [x.to_dict() for x in self.target_annotations]}
+        return {
+            "type": self.type,
+            "multi": [self.multi[0], self.multi[1]],
+            "reverse": self.reverse,
+            "comment": self.comment,
+            "location": self.location.to_dict(),
+            "source_annotations": [x.to_dict() for x in self.source_annotations],
+            "target_annotations": [x.to_dict() for x in self.target_annotations],
+        }
 
     @staticmethod
     def from_dict(ctx):
         multi = ctx["multi"]
-        return Relation(ctx["type"],
-                        (multi[0], multi[1]),
-                        ctx["reverse"],
-                        ctx["comment"],
-                        Location.from_dict(ctx["location"]),
-                        Value.from_list(ctx["source_annotations"]),
-                        Value.from_list(ctx["target_annotations"]))
+        return Relation(
+            ctx["type"],
+            (multi[0], multi[1]),
+            ctx["reverse"],
+            ctx["comment"],
+            Location.from_dict(ctx["location"]),
+            Value.from_list(ctx["source_annotations"]),
+            Value.from_list(ctx["target_annotations"]),
+        )
 
     @staticmethod
     def from_list(l):
@@ -258,8 +271,9 @@ class Entity(object):
         :param Location location: source location this entity was defined at
     """
 
-    def __init__(self, parents: List[str], attributes: Dict[str, Attribute],
-                 relations: Dict[str, Relation], location: Location) -> None:
+    def __init__(
+        self, parents: List[str], attributes: Dict[str, Attribute], relations: Dict[str, Relation], location: Location
+    ) -> None:
         self.parents = parents
         self.attributes = attributes
         self.relations = relations
@@ -278,15 +292,18 @@ class Entity(object):
                 "location": self.location.to_dict(),
                 }
         """
-        return {"parents": self.parents,
-                "attributes": {n: a.to_dict() for n, a in self.attributes.items()},
-                "relations": {n: r.to_dict() for n, r in self.relations.items()},
-                "location": self.location.to_dict(),
-                }
+        return {
+            "parents": self.parents,
+            "attributes": {n: a.to_dict() for n, a in self.attributes.items()},
+            "relations": {n: r.to_dict() for n, r in self.relations.items()},
+            "location": self.location.to_dict(),
+        }
 
     @staticmethod
     def from_dict(ctx):
-        return Entity(ctx["parents"],
-                      Attribute.from_list(ctx["attributes"]),
-                      Relation.from_list(ctx["relations"]),
-                      Location.from_dict(ctx["location"]))
+        return Entity(
+            ctx["parents"],
+            Attribute.from_list(ctx["attributes"]),
+            Relation.from_list(ctx["relations"]),
+            Location.from_dict(ctx["location"]),
+        )

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -79,7 +79,6 @@ class ProjectNotFoundExcpetion(Exception):
 
 
 class GitProvider(object):
-
     def clone(self, src: str, dest: str) -> None:
         pass
 
@@ -95,7 +94,7 @@ class GitProvider(object):
     def checkout_tag(self, repo: str, tag: str) -> None:
         pass
 
-    def commit(self, repo: str, message: str, commit_all: bool, add: List[str]=[]) -> None:
+    def commit(self, repo: str, message: str, commit_all: bool, add: List[str] = []) -> None:
         pass
 
     def tag(self, repo: str, tag: str) -> None:
@@ -106,18 +105,17 @@ class GitProvider(object):
 
 
 class CLIGitProvider(GitProvider):
-
     def clone(self, src: str, dest: str) -> None:
         env = os.environ.copy()
         env["GIT_ASKPASS"] = "true"
-        subprocess.check_call(["git", "clone", src, dest], stdout=subprocess.DEVNULL,
-                              stderr=subprocess.DEVNULL, env=env)
+        subprocess.check_call(["git", "clone", src, dest], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
 
     def fetch(self, repo: str) -> None:
         env = os.environ.copy()
         env["GIT_ASKPASS"] = "true"
-        subprocess.check_call(["git", "fetch", "--tags"], cwd=repo, stdout=subprocess.DEVNULL,
-                              stderr=subprocess.DEVNULL, env=env)
+        subprocess.check_call(
+            ["git", "fetch", "--tags"], cwd=repo, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env
+        )
 
     def status(self, repo: str) -> str:
         return subprocess.check_output(["git", "status", "--porcelain"], cwd=repo).decode("utf-8")
@@ -128,30 +126,36 @@ class CLIGitProvider(GitProvider):
     def checkout_tag(self, repo: str, tag: str) -> None:
         subprocess.check_call(["git", "checkout", tag], cwd=repo, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
-    def commit(self, repo: str, message: str, commit_all: bool, add: List[str]=[]) -> None:
+    def commit(self, repo: str, message: str, commit_all: bool, add: List[str] = []) -> None:
         for file in add:
             subprocess.check_call(["git", "add", file], cwd=repo, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         if not commit_all:
-            subprocess.check_call(["git", "commit", "-m", message], cwd=repo,
-                                  stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.check_call(
+                ["git", "commit", "-m", message], cwd=repo, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )
         else:
-            subprocess.check_call(["git", "commit", "-a", "-m", message], cwd=repo,
-                                  stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.check_call(
+                ["git", "commit", "-a", "-m", message], cwd=repo, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )
 
     def tag(self, repo: str, tag: str) -> None:
-        subprocess.check_call(["git", "tag", "-a", "-m", "auto tag by module tool", tag], cwd=repo,
-                              stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.check_call(
+            ["git", "tag", "-a", "-m", "auto tag by module tool", tag],
+            cwd=repo,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
 
     def pull(self, repo: str) -> str:
         return subprocess.check_output(["git", "pull"], cwd=repo, stderr=subprocess.DEVNULL).decode("utf-8")
 
     def push(self, repo: str) -> str:
-        return subprocess.check_output(["git", "push", "--follow-tags", "--porcelain"],
-                                       cwd=repo, stderr=subprocess.DEVNULL).decode("utf-8")
+        return subprocess.check_output(
+            ["git", "push", "--follow-tags", "--porcelain"], cwd=repo, stderr=subprocess.DEVNULL
+        ).decode("utf-8")
 
     def get_file_for_version(self, repo: str, tag: str, file: str) -> str:
-        data = subprocess.check_output(["git", "archive", "--format=tar", tag, file],
-                                       cwd=repo, stderr=subprocess.DEVNULL)
+        data = subprocess.check_output(["git", "archive", "--format=tar", tag, file], cwd=repo, stderr=subprocess.DEVNULL)
         tf = TarFile(fileobj=BytesIO(data))
         tfile = tf.next()
         assert tfile is not None
@@ -164,7 +168,6 @@ gitprovider = CLIGitProvider()
 
 
 class ModuleRepo(object):
-
     def clone(self, name: str, dest: str) -> bool:
         raise NotImplementedError("Abstract method")
 
@@ -174,7 +177,6 @@ class ModuleRepo(object):
 
 
 class CompositeModuleRepo(ModuleRepo):
-
     def __init__(self, children: List[ModuleRepo]) -> None:
         self.children = children
 
@@ -193,7 +195,6 @@ class CompositeModuleRepo(ModuleRepo):
 
 
 class LocalFileRepo(ModuleRepo):
-
     def __init__(self, root: str, parent_root: Optional[str] = None) -> None:
         if parent_root is None:
             self.root = os.path.abspath(root)
@@ -216,7 +217,6 @@ class LocalFileRepo(ModuleRepo):
 
 
 class RemoteRepo(ModuleRepo):
-
     def __init__(self, baseurl: str) -> None:
         self.baseurl = baseurl
 
@@ -324,6 +324,7 @@ class Project(ModuleLike):
     """
         An inmanta project
     """
+
     PROJECT_FILE = "project.yml"
     _project = None
 
@@ -374,8 +375,7 @@ class Project(ModuleLike):
 
         self.downloadpath = None
         if "downloadpath" in self._meta:
-            self.downloadpath = os.path.abspath(os.path.join(
-                path, self._meta["downloadpath"]))
+            self.downloadpath = os.path.abspath(os.path.join(path, self._meta["downloadpath"]))
             if self.downloadpath not in self.modulepath:
                 LOGGER.warning("Downloadpath is not in module path! Module install will not work as expected")
 
@@ -394,7 +394,7 @@ class Project(ModuleLike):
         if "install_mode" in self._meta:
             mode = self._meta["install_mode"]
             if mode not in INSTALL_OPTS:
-                LOGGER.warning("Invallid value for install_mode, should be one of [%s]" % ','.join(INSTALL_OPTS))
+                LOGGER.warning("Invallid value for install_mode, should be one of [%s]" % ",".join(INSTALL_OPTS))
             else:
                 self._install_mode = mode
 
@@ -526,7 +526,7 @@ class Project(ModuleLike):
                 module = self.get_module(module_name)
                 # get NS
                 for i in range(1, len(parts) + 1):
-                    subs = '::'.join(parts[0:i])
+                    subs = "::".join(parts[0:i])
                     if subs in done:
                         continue
                     (nstmt, nb) = module.get_ast(subs)
@@ -551,10 +551,9 @@ class Project(ModuleLike):
                 if module_name in reqs:
                     module = Module.install(self, module_name, reqs[module_name], install_mode=self._install_mode)
                 else:
-                    module = Module.install(self,
-                                            module_name,
-                                            list(parse_requirements(module_name)),
-                                            install_mode=self._install_mode)
+                    module = Module.install(
+                        self, module_name, list(parse_requirements(module_name)), install_mode=self._install_mode
+                    )
             self.modules[module_name] = module
             return module
         except Exception:
@@ -648,7 +647,7 @@ class Project(ModuleLike):
             Collect the list of all python requirements off all modules in this project
         """
         pyreq = [x.strip() for x in [mod.get_python_requirements() for mod in self.modules.values()] if x is not None]
-        pyreqa = '\n'.join(pyreq).split("\n")
+        pyreqa = "\n".join(pyreq).split("\n")
         pyreqb = [x for x in pyreqa if len(x.strip()) > 0]
         return list(set(pyreqb))
 
@@ -682,6 +681,7 @@ class Module(ModuleLike):
     """
         This class models an inmanta configuration module
     """
+
     MODEL_DIR = "model"
     requires_fields = ["name", "license", "version"]
 
@@ -699,8 +699,13 @@ class Module(ModuleLike):
         self._plugin_namespaces = []  # type: List[str]
 
         if not Module.is_valid_module(self._path):
-            raise InvalidModuleException(("Module %s is not a valid inmanta configuration module. Make sure that a "
-                                          "model/_init.cf file exists and a module.yml definition file.") % self._path)
+            raise InvalidModuleException(
+                (
+                    "Module %s is not a valid inmanta configuration module. Make sure that a "
+                    "model/_init.cf file exists and a module.yml definition file."
+                )
+                % self._path
+            )
 
         self.load_module_file()
         self.is_versioned()
@@ -718,8 +723,9 @@ class Module(ModuleLike):
         if current_version == new_version:
             LOGGER.debug("Current version is the same as the new version: %s", current_version)
 
-        new_module_def = re.sub(r"([\s]version\s*:\s*['\"\s]?)[^\"'}\s]+(['\"]?)",
-                                r"\g<1>" + new_version + r"\g<2>", module_def)
+        new_module_def = re.sub(
+            r"([\s]version\s*:\s*['\"\s]?)[^\"'}\s]+(['\"]?)", r"\g<1>" + new_version + r"\g<2>", module_def
+        )
 
         try:
             new_info = yaml.safe_load(new_module_def)
@@ -727,8 +733,9 @@ class Module(ModuleLike):
             raise Exception("Unable to rewrite module definition %s" % self.get_config_file_name())
 
         if str(new_info["version"]) != new_version:
-            raise Exception("Unable to write module definition, should be %s got %s instead." %
-                            (new_version, new_info["version"]))
+            raise Exception(
+                "Unable to write module definition, should be %s got %s instead." % (new_version, new_info["version"])
+            )
 
         with open(self.get_config_file_name(), "w+") as fd:
             fd.write(new_module_def)
@@ -768,12 +775,14 @@ class Module(ModuleLike):
         return None
 
     @classmethod
-    def install(cls,
-                project: Project,
-                modulename: str,
-                requirements: "List[Requirement]",
-                install: bool = True,
-                install_mode: str = INSTALL_RELEASES) -> "Module":
+    def install(
+        cls,
+        project: Project,
+        modulename: str,
+        requirements: "List[Requirement]",
+        install: bool = True,
+        install_mode: str = INSTALL_RELEASES,
+    ) -> "Module":
         """
            Install a module, return module object
         """
@@ -793,13 +802,15 @@ class Module(ModuleLike):
         return cls.update(project, modulename, requirements, path, False, install_mode=install_mode)
 
     @classmethod
-    def update(cls,
-               project: Project,
-               modulename: str,
-               requirements: "List[Requirement]",
-               path: str = None,
-               fetch: bool = True,
-               install_mode: str = INSTALL_RELEASES) -> "Module":
+    def update(
+        cls,
+        project: Project,
+        modulename: str,
+        requirements: "List[Requirement]",
+        path: str = None,
+        fetch: bool = True,
+        install_mode: str = INSTALL_RELEASES,
+    ) -> "Module":
         """
            Update a module, return module object
         """
@@ -815,7 +826,7 @@ class Module(ModuleLike):
             if fetch:
                 gitprovider.pull(path)
         else:
-            release_only = (install_mode == INSTALL_RELEASES)
+            release_only = install_mode == INSTALL_RELEASES
             version = cls.get_suitable_version_for(modulename, requirements, path, release_only=release_only)
 
             if version is None:
@@ -826,11 +837,9 @@ class Module(ModuleLike):
         return Module(project, path)
 
     @classmethod
-    def get_suitable_version_for(cls,
-                                 modulename: str,
-                                 requirements: "List[Requirement]",
-                                 path: str,
-                                 release_only: bool = True) -> "Optional[Version]":
+    def get_suitable_version_for(
+        cls, modulename: str, requirements: "List[Requirement]", path: str, release_only: bool = True
+    ) -> "Optional[Version]":
         versions = gitprovider.get_all_tags(path)
 
         def try_parse(x: str) -> "Version":
@@ -856,11 +865,9 @@ class Module(ModuleLike):
             return versions[0] if len(versions) > 0 else None
 
     @classmethod
-    def __best_for_compiler_version(cls,
-                                    modulename: str,
-                                    versions: "List[Version]",
-                                    path: str,
-                                    comp_version: "Version") -> "Optional[Version]":
+    def __best_for_compiler_version(
+        cls, modulename: str, versions: "List[Version]", path: str, comp_version: "Version"
+    ) -> "Optional[Version]":
         def get_cv_for(best: "Version") -> "Optional[Version]":
             cfg = gitprovider.get_file_for_version(path, str(best), "module.yml")
             cfg = yaml.safe_load(cfg)
@@ -901,8 +908,9 @@ class Module(ModuleLike):
             version should match the tag
         """
         if not os.path.exists(os.path.join(self._path, ".git")):
-            LOGGER.warning("Module %s is not version controlled, we recommend you do this as soon as possible."
-                           % self._meta["name"])
+            LOGGER.warning(
+                "Module %s is not version controlled, we recommend you do this as soon as possible." % self._meta["name"]
+            )
             return False
         return True
 
@@ -925,20 +933,23 @@ class Module(ModuleLike):
             mod_def = yaml.safe_load(fd)
 
             if mod_def is None or len(mod_def) < len(Module.requires_fields):
-                raise InvalidModuleFileException("The module file of %s does not have the required fields: %s" %
-                                                 (self._path, ", ".join(Module.requires_fields)))
+                raise InvalidModuleFileException(
+                    "The module file of %s does not have the required fields: %s"
+                    % (self._path, ", ".join(Module.requires_fields))
+                )
 
             for name, value in mod_def.items():
                 self._meta[name] = value
 
         for req_field in Module.requires_fields:
             if req_field not in self._meta:
-                raise InvalidModuleFileException(
-                    "%s is required in module file of module %s" % (req_field, self._path))
+                raise InvalidModuleFileException("%s is required in module file of module %s" % (req_field, self._path))
 
         if self._meta["name"] != os.path.basename(self._path):
-            LOGGER.warning("The name in the module file (%s) does not match the directory name (%s)"
-                           % (self._meta["name"], os.path.basename(self._path)))
+            LOGGER.warning(
+                "The name in the module file (%s) does not match the directory name (%s)"
+                % (self._meta["name"], os.path.basename(self._path))
+            )
 
     def get_config_file_name(self) -> str:
         return os.path.join(self._path, "module.yml")
@@ -1026,7 +1037,7 @@ class Module(ModuleLike):
         files = self._get_model_files(cur_dir)
 
         for f in files:
-            name = f[len(cur_dir) + 1:-3]
+            name = f[len(cur_dir) + 1 : -3]
             parts = name.split("/")
             if parts[-1] == "_init":
                 parts = parts[:-1]
@@ -1049,7 +1060,8 @@ class Module(ModuleLike):
 
         if not os.path.exists(os.path.join(plugin_dir, "__init__.py")):
             raise CompilerException(
-                "The plugin directory %s should be a valid python package with a __init__.py file" % plugin_dir)
+                "The plugin directory %s should be a valid python package with a __init__.py file" % plugin_dir
+            )
 
         try:
             mod_name = self._meta["name"]
@@ -1127,7 +1139,7 @@ class Module(ModuleLike):
         """
         file = os.path.join(self._path, "requirements.txt")
         if os.path.exists(file):
-            with open(file, 'r') as fd:
+            with open(file, "r") as fd:
                 return fd.read()
         else:
             return None

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -15,8 +15,7 @@
 
     Contact: code@inmanta.com
 """
-from inmanta.module import INSTALL_MASTER, Project, Module,\
-    INSTALL_RELEASES, gitprovider
+from inmanta.module import INSTALL_MASTER, Project, Module, INSTALL_RELEASES, gitprovider
 import inspect
 import logging
 import os
@@ -69,7 +68,7 @@ class ModuleLikeTool(object):
         """
             Execute the given subcommand
         """
-        if cmd is not None and cmd != '' and hasattr(self, cmd):
+        if cmd is not None and cmd != "" and hasattr(self, cmd):
             method = getattr(self, cmd)
             margs = inspect.getfullargspec(method).args
             margs.remove("self")
@@ -127,7 +126,7 @@ class ModuleLikeTool(object):
                     parts[0] += 1
                     parts[1] = 0
                     parts[2] = 0
-                outversion = '.'.join([str(x) for x in parts])
+                outversion = ".".join([str(x) for x in parts])
 
             if dev:
                 outversion = "%s.dev%d" % (outversion, time.time())
@@ -141,23 +140,30 @@ class ModuleLikeTool(object):
 
 
 class ProjectTool(ModuleLikeTool):
-
     @classmethod
     def parser_config(cls, parser: ArgumentParser):
         subparser = parser.add_subparsers(title="subcommand", dest="cmd")
         freeze = subparser.add_parser("freeze", help="Set all version numbers in project.yml")
-        freeze.add_argument("-o", "--outfile",
-                            help="File in which to put the new project.yml, default is the existing project.yml",
-                            default=None)
-        freeze.add_argument("-r", "--recursive",
-                            help="Freeze dependencies recursively. If not set, freeze_recursive option in project.yml is used,"
-                            "which defaults to False",
-                            action="store_true",
-                            default=None)
-        freeze.add_argument("--operator",
-                            help="Comparison operator used to freeze versions, If not set, the freeze_operator option in"
-                            " project.yml is used which defaults to ~=",
-                            default=None)
+        freeze.add_argument(
+            "-o",
+            "--outfile",
+            help="File in which to put the new project.yml, default is the existing project.yml",
+            default=None,
+        )
+        freeze.add_argument(
+            "-r",
+            "--recursive",
+            help="Freeze dependencies recursively. If not set, freeze_recursive option in project.yml is used,"
+            "which defaults to False",
+            action="store_true",
+            default=None,
+        )
+        freeze.add_argument(
+            "--operator",
+            help="Comparison operator used to freeze versions, If not set, the freeze_operator option in"
+            " project.yml is used which defaults to ~=",
+            default=None,
+        )
 
     def freeze(self, outfile, recursive, operator):
         """
@@ -188,11 +194,11 @@ class ProjectTool(ModuleLikeTool):
         newconfig["requires"] = requires
 
         if outfile is None:
-            outfile = open(project.get_config_file_name(), "w", encoding='UTF-8')
+            outfile = open(project.get_config_file_name(), "w", encoding="UTF-8")
         elif outfile == "-":
             outfile = sys.stdout
         else:
-            outfile = open(outfile, "w", encoding='UTF-8')
+            outfile = open(outfile, "w", encoding="UTF-8")
 
         outfile.write(yaml.dump(newconfig, default_flow_style=False, sort_keys=False))
 
@@ -212,11 +218,12 @@ class ModuleTool(ModuleLikeTool):
         subparser = parser.add_subparsers(title="subcommand", dest="cmd")
 
         lst = subparser.add_parser("list", help="List all modules used in this project in a table")
-        lst.add_argument("-r", help="Output a list of requires that can be included in project.yml", dest="requires",
-                         action="store_true")
+        lst.add_argument(
+            "-r", help="Output a list of requires that can be included in project.yml", dest="requires", action="store_true"
+        )
 
         do = subparser.add_parser("do", help="Execute a command on all loaded modules")
-        do.add_argument("command", metavar='command', help='the command to  execute')
+        do.add_argument("command", metavar="command", help="the command to  execute")
 
         subparser.add_parser("update", help="Update all modules used in this project")
 
@@ -230,16 +237,23 @@ class ModuleTool(ModuleLikeTool):
         subparser.add_parser("verify", help="Verify dependencies and frozen module versions")
 
         validate = subparser.add_parser(
-            "validate", help="Validate the module we are currently in. i.e. try to compile it against an empty main model")
+            "validate", help="Validate the module we are currently in. i.e. try to compile it against an empty main model"
+        )
         validate.add_argument("-r", "--repo", help="Additional repo to load modules from", action="append")
-        validate.add_argument("-n", "--no-clean", help="Do not remove the validation project when finished",
-                              action="store_true")
+        validate.add_argument(
+            "-n", "--no-clean", help="Do not remove the validation project when finished", action="store_true"
+        )
         validate.add_argument("-s", "--parse-only", help="Only parse the module", action="store_true")
-        validate.add_argument("-i", "--isolate", help="Move the module to another directory before cloning."
-                              " I.e. remove all other modules in the current directory from the search path",
-                              action="store_true")
-        validate.add_argument("-w", "--workingcopy", help="Use the actual state of the module instead of the latest tag",
-                              action="store_true")
+        validate.add_argument(
+            "-i",
+            "--isolate",
+            help="Move the module to another directory before cloning."
+            " I.e. remove all other modules in the current directory from the search path",
+            action="store_true",
+        )
+        validate.add_argument(
+            "-w", "--workingcopy", help="Use the actual state of the module instead of the latest tag", action="store_true"
+        )
 
         commit = subparser.add_parser("commit", help="Commit all changes in the current module.")
         commit.add_argument("-m", "--message", help="Commit message", required=True)
@@ -254,18 +268,26 @@ class ModuleTool(ModuleLikeTool):
         create.add_argument("name", help="The name of the module")
 
         freeze = subparser.add_parser("freeze", help="Set all version numbers in project.yml")
-        freeze.add_argument("-o", "--outfile",
-                            help="File in which to put the new project.yml, default is the existing project.yml",
-                            default=None)
-        freeze.add_argument("-r", "--recursive",
-                            help="Freeze dependencies recursively. If not set, freeze_recursive option in project.yml is used,"
-                            "which defaults to False",
-                            action="store_true",
-                            default=None)
-        freeze.add_argument("--operator",
-                            help="Comparison operator used to freeze versions, If not set, the freeze_operator option in"
-                                 " project.yml is used which defaults to ~=",
-                            default=None)
+        freeze.add_argument(
+            "-o",
+            "--outfile",
+            help="File in which to put the new project.yml, default is the existing project.yml",
+            default=None,
+        )
+        freeze.add_argument(
+            "-r",
+            "--recursive",
+            help="Freeze dependencies recursively. If not set, freeze_recursive option in project.yml is used,"
+            "which defaults to False",
+            action="store_true",
+            default=None,
+        )
+        freeze.add_argument(
+            "--operator",
+            help="Comparison operator used to freeze versions, If not set, the freeze_operator option in"
+            " project.yml is used which defaults to ~=",
+            default=None,
+        )
 
     def get_project_for_module(self, module):
         try:
@@ -274,7 +296,7 @@ class ModuleTool(ModuleLikeTool):
             # see #721
             return None
 
-    def get_module(self, module: str=None, project=None) -> Module:
+    def get_module(self, module: str = None, project=None) -> Module:
         """Finds and loads a module, either based on the CWD or based on the name passed in as an argument and the project"""
         if module is None:
             module = Module(self.get_project_for_module(module), os.path.realpath(os.curdir))
@@ -283,7 +305,7 @@ class ModuleTool(ModuleLikeTool):
             project = self.get_project(load=True)
             return project.get_module(module)
 
-    def get_modules(self, module: str=None):
+    def get_modules(self, module: str = None):
         if module is not None:
             return [self.get_module(module)]
         else:
@@ -302,20 +324,25 @@ class ModuleTool(ModuleLikeTool):
 
         os.mkdir(mod_path)
         with open(os.path.join(mod_path, "module.yml"), "w+") as fd:
-            fd.write("""name: %(name)s
+            fd.write(
+                """name: %(name)s
 license: ASL 2.0
-version: 0.0.1dev0""" % {"name": name})
+version: 0.0.1dev0"""
+                % {"name": name}
+            )
 
         os.mkdir(os.path.join(mod_path, "model"))
         with open(os.path.join(mod_path, "model", "_init.cf"), "w+") as fd:
             fd.write("\n")
 
         with open(os.path.join(mod_path, ".gitignore"), "w+") as fd:
-            fd.write("""*.swp
+            fd.write(
+                """*.swp
 *.pyc
 *~
 .cache
-            """)
+            """
+            )
 
         subprocess.check_output(["git", "init"], cwd=mod_path)
         subprocess.check_output(["git", "add", ".gitignore", "module.yml", "model/_init.cf"], cwd=mod_path)
@@ -355,8 +382,7 @@ version: 0.0.1dev0""" % {"name": name})
                     reqv = "master"
                 else:
                     release_only = project._install_mode == INSTALL_RELEASES
-                    versions = Module.get_suitable_version_for(
-                        name, specs[name], mod._path, release_only=release_only)
+                    versions = Module.get_suitable_version_for(name, specs[name], mod._path, release_only=release_only)
                     if versions is None:
                         reqv = "None"
                     else:
@@ -514,24 +540,29 @@ version: 0.0.1dev0""" % {"name": name})
 
             repo.insert(0, search_root)
             allrepos = ["'%s'" % x for x in repo]
-            allrepos = ','.join(allrepos)
+            allrepos = ",".join(allrepos)
 
             if len(module.versions()) > 0:
-                version_constraint = "%(name)s: %(name)s == %(version)s" % \
-                                     {"name": module.name, "version": str(module.versions()[0])}
+                version_constraint = "%(name)s: %(name)s == %(version)s" % {
+                    "name": module.name,
+                    "version": str(module.versions()[0]),
+                }
             else:
                 version_constraint = module.name
 
             LOGGER.info("Setting up project")
             with open(os.path.join(project_dir, "project.yml"), "w+") as fd:
-                fd.write("""name: test
+                fd.write(
+                    """name: test
 description: Project to validate module %(name)s
 repo: [%(repo)s]
 modulepath: libs
 downloadpath: libs
 requires:
     %(version)s
-""" % {"name": module.name, "version": version_constraint, "repo": allrepos})
+"""
+                    % {"name": module.name, "version": version_constraint, "repo": allrepos}
+                )
 
             LOGGER.info("Installing dependencies")
             test_project = Project(project_dir)
@@ -613,10 +644,10 @@ requires:
         newconfig["requires"] = requires
 
         if outfile is None:
-            outfile = open(module.get_config_file_name(), "w", encoding='UTF-8')
+            outfile = open(module.get_config_file_name(), "w", encoding="UTF-8")
         elif outfile == "-":
             outfile = sys.stdout
         else:
-            outfile = open(outfile, "w", encoding='UTF-8')
+            outfile = open(outfile, "w", encoding="UTF-8")
 
         outfile.write(yaml.dump(newconfig, default_flow_style=False, sort_keys=False))

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -21,36 +21,47 @@ from inmanta.ast.variables import Reference
 from inmanta.ast.constraint.expression import Regex
 from inmanta.ast import LocatableString, Range
 
-states = (
-    ('mls', 'exclusive'),
-)
+states = (("mls", "exclusive"),)
 
-keyworldlist = ['typedef', 'as', 'matching', 'entity', 'extends', 'end', 'in',
-                'implementation', 'for', 'index', 'implement', 'using', 'when', 'and', 'or', 'not', 'true', 'false', 'import',
-                'is', 'defined', 'dict', 'null', 'undef', "parents"]
-literals = [':', '[', ']', '(', ')', '=', ',', '.', '{', '}', '?']
+keyworldlist = [
+    "typedef",
+    "as",
+    "matching",
+    "entity",
+    "extends",
+    "end",
+    "in",
+    "implementation",
+    "for",
+    "index",
+    "implement",
+    "using",
+    "when",
+    "and",
+    "or",
+    "not",
+    "true",
+    "false",
+    "import",
+    "is",
+    "defined",
+    "dict",
+    "null",
+    "undef",
+    "parents",
+]
+literals = [":", "[", "]", "(", ")", "=", ",", ".", "{", "}", "?"]
 reserved = {k: k.upper() for k in keyworldlist}
 
 # List of token names.   This is always required
-tokens = [
-    'INT',
-    'FLOAT',
-    'ID',
-    'CID',
-    'SEP',
-    'STRING',
-    'MLS',
-    'MLS_END',
-    'CMP_OP',
-    'REGEX',
-    'REL',
-    'PEQ'
-] + sorted(list(reserved.values()))
+tokens = ["INT", "FLOAT", "ID", "CID", "SEP", "STRING", "MLS", "MLS_END", "CMP_OP", "REGEX", "REL", "PEQ"] + sorted(
+    list(reserved.values())
+)
 
 
 def t_ID(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r'[a-zA-Z_][a-zA-Z_0-9-]*'
-    t.type = reserved.get(t.value, 'ID')  # Check for reserved words
+    r"[a-zA-Z_][a-zA-Z_0-9-]*"
+    t.type = reserved.get(t.value, "ID")  # Check for reserved words
     if t.value[0].isupper():
         t.type = "CID"
     lexer = t.lexer
@@ -59,40 +70,41 @@ def t_ID(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
     (s, e) = lexer.lexmatch.span()
     start = end - (e - s)
 
-    t.value = LocatableString(t.value, Range(lexer.inmfile, lexer.lineno, start,
-                                             lexer.lineno, end), lexer.lexpos, lexer.namespace)
+    t.value = LocatableString(
+        t.value, Range(lexer.inmfile, lexer.lineno, start, lexer.lineno, end), lexer.lexpos, lexer.namespace
+    )
     return t
 
 
 def t_SEP(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r'[:]{2}'
+    r"[:]{2}"
     return t
 
 
 def t_REL(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r'--|->|<-'
+    r"--|->|<-"
     return t
 
 
 def t_CMP_OP(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r'!=|==|>=|<=|<|>'
+    r"!=|==|>=|<=|<|>"
     return t
 
 
 def t_PEQ(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r'[+]='
+    r"[+]="
     return t
 
 
 def t_COMMENT(t: lex.LexToken) -> None:  # noqa: N802
-    r'\#.*?\n'
+    r"\#.*?\n"
     t.lexer.lineno += 1
     t.lexer.linestart = t.lexer.lexpos
     pass
 
 
 def t_JCOMMENT(t: lex.LexToken) -> None:  # noqa: N802
-    r'\//.*?\n'
+    r"\//.*?\n"
     t.lexer.lineno += 1
     t.lexer.linestart = t.lexer.lexpos
     pass
@@ -100,7 +112,7 @@ def t_JCOMMENT(t: lex.LexToken) -> None:  # noqa: N802
 
 def t_begin_mls(t: lex.LexToken) -> lex.LexToken:
     r'["]{3}'
-    t.lexer.begin('mls')
+    t.lexer.begin("mls")
     t.type = "MLS"
 
     lexer = t.lexer
@@ -109,15 +121,14 @@ def t_begin_mls(t: lex.LexToken) -> lex.LexToken:
     (s, e) = lexer.lexmatch.span()
     start = end - (e - s)
 
-    t.value = LocatableString("", Range(lexer.inmfile, lexer.lineno, start,
-                                        lexer.lineno, end), lexer.lexpos, lexer.namespace)
+    t.value = LocatableString("", Range(lexer.inmfile, lexer.lineno, start, lexer.lineno, end), lexer.lexpos, lexer.namespace)
 
     return t
 
 
 def t_mls_end(t: lex.LexToken) -> lex.LexToken:
     r'.*["]{3}'
-    t.lexer.begin('INITIAL')
+    t.lexer.begin("INITIAL")
     t.type = "MLS_END"
     value = t.value[:-3]
 
@@ -127,38 +138,39 @@ def t_mls_end(t: lex.LexToken) -> lex.LexToken:
     (s, e) = lexer.lexmatch.span()
     start = end - (e - s)
 
-    t.value = LocatableString(value, Range(lexer.inmfile, lexer.lineno, start,
-                                           lexer.lineno, end), lexer.lexpos, lexer.namespace)
+    t.value = LocatableString(
+        value, Range(lexer.inmfile, lexer.lineno, start, lexer.lineno, end), lexer.lexpos, lexer.namespace
+    )
 
     return t
 
 
 def t_mls_MLS(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r'.+'
+    r".+"
     return t
 
 
 def t_FLOAT(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r'[-]?[0-9]*[.][0-9]+'
+    r"[-]?[0-9]*[.][0-9]+"
     t.value = float(t.value)
     return t
 
 
 def t_INT(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r'[-]?[0-9]+'
+    r"[-]?[0-9]+"
     t.value = int(t.value)
     return t
 
 
 def t_STRING_EMPTY(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r'(\"\")|(\'\')'
+    r"(\"\")|(\'\')"
     t.type = "STRING"
     t.value = ""
     return t
 
 
 def t_STRING(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r'(\".*?[^\\]\")|(\'.*?[^\\]\')'
+    r"(\".*?[^\\]\")|(\'.*?[^\\]\')"
     t.value = bytes(t.value[1:-1], "utf-8").decode("unicode_escape")
     lexer = t.lexer
 
@@ -166,14 +178,15 @@ def t_STRING(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
     (s, e) = lexer.lexmatch.span()
     start = end - (e - s)
 
-    t.value = LocatableString(t.value, Range(lexer.inmfile, lexer.lineno, start,
-                                             lexer.lineno, end), lexer.lexpos, lexer.namespace)
+    t.value = LocatableString(
+        t.value, Range(lexer.inmfile, lexer.lineno, start, lexer.lineno, end), lexer.lexpos, lexer.namespace
+    )
 
     return t
 
 
 def t_REGEX(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r'/([^/]|\\/)*?[^\\]/'
+    r"/([^/]|\\/)*?[^\\]/"
     value = Reference("self")  # anonymous value
     expr = Regex(value, t.value[1:-1])
     t.value = expr
@@ -182,13 +195,13 @@ def t_REGEX(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
 
 # Define a rule so we can track line numbers
 def t_newline(t: lex.LexToken) -> None:  # noqa: N802
-    r'\n+'
+    r"\n+"
     t.lexer.lineno += len(t.value)
     t.lexer.linestart = t.lexer.lexpos
 
 
 def t_mls_newline(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r'\n+'
+    r"\n+"
     t.lexer.lineno += len(t.value)
     t.lexer.linestart = t.lexer.lexpos
     t.type = "MLS"
@@ -196,8 +209,8 @@ def t_mls_newline(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
 
 
 # A string containing ignored characters (spaces and tabs)
-t_ignore = ' \t'
-t_mls_ignore = ''
+t_ignore = " \t"
+t_mls_ignore = ""
 
 # Error handling rule
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -26,8 +26,18 @@ from inmanta.parser.plyInmantaLex import tokens, reserved
 from inmanta.ast.statements import Literal, Statement
 from inmanta.ast import Location, LocatableString, Range, Namespace
 from inmanta.ast.statements.generator import For, Constructor
-from inmanta.ast.statements.define import DefineEntity, DefineAttribute, DefineImplement, DefineImplementation, DefineRelation, \
-    DefineTypeConstraint, DefineTypeDefault, DefineIndex, DefineImport, DefineImplementInherits
+from inmanta.ast.statements.define import (
+    DefineEntity,
+    DefineAttribute,
+    DefineImplement,
+    DefineImplementation,
+    DefineRelation,
+    DefineTypeConstraint,
+    DefineTypeDefault,
+    DefineIndex,
+    DefineImport,
+    DefineImplementInherits,
+)
 from inmanta.ast.constraint.expression import Operator, Not, IsDefined
 from inmanta.ast.statements.call import FunctionCall
 from inmanta.ast.statements.assign import CreateList, IndexLookup, StringFormat, CreateDict, ShortIndexLookup, MapLookup
@@ -46,13 +56,7 @@ LOGGER = logging.getLogger()
 file = "NOFILE"
 namespace = None
 
-precedence = (
-    ('left', 'OR'),
-    ('left', 'AND'),
-    ('right', 'NOT'),
-    ('right', 'MLS'),
-    ('right', 'MLS_END')
-)
+precedence = (("left", "OR"), ("left", "AND"), ("right", "NOT"), ("right", "MLS"), ("right", "MLS_END"))
 
 
 def attach_lnr(p: YaccProduction, token: int = 1) -> None:
@@ -102,12 +106,12 @@ def p_main_collect(p: YaccProduction) -> None:
 
 
 def p_main_term(p: YaccProduction) -> None:
-    'main : top_stmt'
+    "main : top_stmt"
     p[0] = [p[1]]
 
 
 def p_top_stmt(p: YaccProduction) -> None:
-    '''top_stmt : mls
+    """top_stmt : mls
                 | entity_def
                 | implement_def
                 | implementation_def
@@ -115,7 +119,7 @@ def p_top_stmt(p: YaccProduction) -> None:
                 | statement
                 | typedef
                 | index
-                | import '''
+                | import """
     p[0] = p[1]
 
 
@@ -123,26 +127,29 @@ def p_top_stmt(p: YaccProduction) -> None:
 # IMPORT
 #######################
 
+
 def p_import(p: YaccProduction) -> None:
-    '''import : IMPORT ns_ref'''
+    """import : IMPORT ns_ref"""
     p[0] = DefineImport(str(p[2]), str(p[2]))
     attach_lnr(p, 1)
 
 
 def p_import_1(p: YaccProduction) -> None:
-    '''import : IMPORT ns_ref AS ID'''
+    """import : IMPORT ns_ref AS ID"""
     p[0] = DefineImport(str(p[2]), p[4])
     attach_lnr(p, 1)
+
+
 #######################
 # STMTS
 #######################
 
 
 def p_stmt(p: YaccProduction) -> None:
-    '''statement : assign
+    """statement : assign
                 | constructor
                 | function_call
-                | for'''
+                | for"""
     p[0] = p[1]
 
 
@@ -163,7 +170,7 @@ def p_stmt_list_collect(p: YaccProduction) -> None:
 
 
 def p_stmt_list_term(p: YaccProduction) -> None:
-    'stmt_list : statement'
+    "stmt_list : statement"
     p[0] = [p[1]]
 
 
@@ -183,6 +190,8 @@ def p_for(p: YaccProduction) -> None:
     "for : FOR ID IN operand ':' block"
     p[0] = For(p[4], p[2], BasicBlock(namespace, p[6]))
     attach_lnr(p, 1)
+
+
 #######################
 # DEFINITIONS
 #######################
@@ -211,38 +220,38 @@ def p_entity_extends_err(p: YaccProduction) -> None:
 
 
 def p_entity_body_outer(p: YaccProduction) -> None:
-    '''entity_body_outer : mls entity_body END'''
+    """entity_body_outer : mls entity_body END"""
     p[0] = (p[1], p[2])
 
 
 def p_entity_body_outer_1(p: YaccProduction) -> None:
-    '''entity_body_outer : entity_body END '''
+    """entity_body_outer : entity_body END """
     p[0] = (None, p[1])
 
 
 def p_entity_body_outer_none(p: YaccProduction) -> None:
-    '''entity_body_outer : END '''
+    """entity_body_outer : END """
     p[0] = (None, [])
 
 
 def p_entity_body_outer_4(p: YaccProduction) -> None:
-    '''entity_body_outer : mls END'''
+    """entity_body_outer : mls END"""
     p[0] = (p[1], [])
 
 
 def p_entity_body_collect(p: YaccProduction) -> None:
-    ''' entity_body : entity_body attr'''
+    """ entity_body : entity_body attr"""
     p[1].append(p[2])
     p[0] = p[1]
 
 
 def p_entity_body(p: YaccProduction) -> None:
-    ''' entity_body : attr'''
+    """ entity_body : attr"""
     p[0] = [p[1]]
 
 
 def p_attribute_type(p: YaccProduction) -> None:
-    '''attr_type : ns_ref'''
+    """attr_type : ns_ref"""
     p[0] = (p[1], False)
 
 
@@ -325,7 +334,7 @@ def p_attr_list_dict(p: YaccProduction) -> None:
 
 def p_attr_list_dict_null_err(p: YaccProduction) -> None:
     "attr : DICT ID '=' NULL"
-    raise ParserException(p[2].location, str(p[2]), "null can not be assigned to dict, did you mean \"dict? %s = null\"" % p[2])
+    raise ParserException(p[2].location, str(p[2]), 'null can not be assigned to dict, did you mean "dict? %s = null"' % p[2])
 
 
 def p_attr_dict_nullable(p: YaccProduction) -> None:
@@ -342,7 +351,7 @@ def p_attr_list_dict_nullable(p: YaccProduction) -> None:
 
 def p_attr_list_dict_null(p: YaccProduction) -> None:
     "attr : DICT '?'  ID '=' NULL"
-    p[0] = DefineAttribute(p[1], p[3],  make_none(p, 5), nullable=True)
+    p[0] = DefineAttribute(p[1], p[3], make_none(p, 5), nullable=True)
     attach_lnr(p, 1)
 
 
@@ -398,6 +407,7 @@ def p_implementation_def(p: YaccProduction) -> None:
 #     p[0] = DefineImplementation(namespace, p[2], None, BasicBlock(namespace, p[3]))
 #     attach_lnr(p)
 
+
 def p_implementation(p: YaccProduction) -> None:
     "implementation : ':' mls block"
     p[0] = (p[2], p[3])
@@ -417,23 +427,26 @@ def p_block_empty(p: YaccProduction) -> None:
     "block : END"
     p[0] = []
 
+
 # RELATION
 
 
 def p_relation(p: YaccProduction) -> None:
     "relation : class_ref ID multi REL multi class_ref ID"
-    if not(p[4] == '--'):
-        LOGGER.warning("DEPRECATION: use of %s in relation definition is deprecated, use -- (in %s)" %
-                       (p[4], Location(file, p.lineno(4))))
+    if not (p[4] == "--"):
+        LOGGER.warning(
+            "DEPRECATION: use of %s in relation definition is deprecated, use -- (in %s)" % (p[4], Location(file, p.lineno(4)))
+        )
     p[0] = DefineRelation((p[1], p[2], p[3]), (p[6], p[7], p[5]))
     attach_lnr(p, 2)
 
 
 def p_relation_comment(p: YaccProduction) -> None:
     "relation : class_ref ID multi REL multi class_ref ID mls"
-    if not(p[4] == '--'):
-        LOGGER.warning("DEPRECATION: use of %s in relation definition is deprecated, use -- (in %s)" %
-                       (p[4], Location(file, p.lineno(4))))
+    if not (p[4] == "--"):
+        LOGGER.warning(
+            "DEPRECATION: use of %s in relation definition is deprecated, use -- (in %s)" % (p[4], Location(file, p.lineno(4)))
+        )
     rel = DefineRelation((p[1], p[2], p[3]), (p[6], p[7], p[5]))
     rel.comment = str(p[8])
     p[0] = rel
@@ -495,6 +508,7 @@ def p_multi_4(p: YaccProduction) -> None:
     "multi : '['  ':' INT ']' "
     p[0] = (None, p[3])
 
+
 # typedef
 
 
@@ -521,6 +535,8 @@ def p_typedef_cls(p: YaccProduction) -> None:
     """typedef_inner : TYPEDEF CID AS constructor"""
     p[0] = DefineTypeDefault(namespace, p[2], p[4])
     attach_lnr(p, 2)
+
+
 # index
 
 
@@ -528,6 +544,7 @@ def p_index(p: YaccProduction) -> None:
     """index : INDEX class_ref '(' id_list ')' """
     p[0] = DefineIndex(p[2], p[4])
     attach_lnr(p, 1)
+
 
 #######################
 # CONDITIONALS
@@ -569,7 +586,7 @@ def p_condition_is_defined(p: YaccProduction) -> None:
 
 def p_condition_is_defined_short(p: YaccProduction) -> None:
     """condition : ID IS DEFINED"""
-    ref = Reference('self')
+    ref = Reference("self")
     ref.location = p[1].get_location()
     p[0] = IsDefined(ref, p[1])
     attach_lnr(p)
@@ -580,6 +597,7 @@ def p_condition_term_1(p: YaccProduction) -> None:
                 | FALSE"""
     p[0] = Literal(p[1])
     attach_lnr(p)
+
 
 #######################
 # EXPRESSIONS
@@ -661,6 +679,8 @@ def p_short_index_lookup(p: YaccProduction) -> None:
     attref = p[1]
     p[0] = ShortIndexLookup(attref.instance, attref.attribute, p[3])
     attach_lnr(p, 2)
+
+
 #######################
 # HELPERS
 
@@ -791,7 +811,7 @@ def p_operand_list_collect(p: YaccProduction) -> None:
 
 
 def p_operand_list_term(p: YaccProduction) -> None:
-    'operand_list : operand'
+    "operand_list : operand"
     p[0] = [p[1]]
 
 
@@ -807,7 +827,7 @@ def p_ns_list_collect(p: YaccProduction) -> None:
 
 
 def p_ns_list_term(p: YaccProduction) -> None:
-    'ns_list : ns_ref'
+    "ns_list : ns_ref"
     p[0] = [p[1]]
 
 
@@ -869,12 +889,12 @@ def p_class_ref_list_collect_err(p: YaccProduction) -> None:
 
 
 def p_class_ref_list_term(p: YaccProduction) -> None:
-    'class_ref_list : class_ref'
+    "class_ref_list : class_ref"
     p[0] = [p[1]]
 
 
 def p_class_ref_list_term_err(p: YaccProduction) -> None:
-    'class_ref_list : var_ref'
+    "class_ref_list : var_ref"
 
     raise ParserException(p[1].location, str(p[1]), "Invalid identifier: Entity names must start with a capital")
 
@@ -897,7 +917,7 @@ def p_id_list_collect(p: YaccProduction) -> None:
 
 
 def p_id_list_term(p: YaccProduction) -> None:
-    'id_list : ID'
+    "id_list : ID"
     p[0] = [p[1]]
 
 
@@ -930,8 +950,9 @@ def p_error(p: YaccProduction) -> None:
     if parser.symstack[-1].type in reserved.values():
         if hasattr(parser.symstack[-1].value, "location"):
             r = parser.symstack[-1].value.location
-        raise ParserException(r, str(parser.symstack[-1].value),
-                              "invalid identifier, %s is a reserved keyword" % parser.symstack[-1].value)
+        raise ParserException(
+            r, str(parser.symstack[-1].value), "invalid identifier, %s is a reserved keyword" % parser.symstack[-1].value
+        )
 
     raise ParserException(r, p.value)
 
@@ -948,10 +969,10 @@ def myparse(ns: Namespace, tfile: str, content: Optional[str]) -> List[Statement
     global namespace
     namespace = ns
     lexer.namespace = ns
-    lexer.begin('INITIAL')
+    lexer.begin("INITIAL")
 
     if content is None:
-        with open(tfile, 'r') as myfile:
+        with open(tfile, "r") as myfile:
             data = myfile.read()
             if len(data) == 0:
                 return []

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -41,6 +41,7 @@ class Context(object):
     """
         An instance of this class is used to pass context to the plugin
     """
+
     __client: Optional[protocol.Client] = None
     __sync_client = None
 
@@ -103,7 +104,7 @@ class Context(object):
             self.__class__.__sync_client = protocol.SyncClient("compiler")
         return self.__class__.__sync_client
 
-    def run_sync(self, function: Callable[..., T], timeout: int=5) -> T:
+    def run_sync(self, function: Callable[..., T], timeout: int = 5) -> T:
         """
             Execute the async function and return its result. This method takes care of starting and stopping the ioloop. The
             main use for this function is to use the inmanta internal rpc to communicate with the server.
@@ -114,6 +115,7 @@ class Context(object):
             :raises ConnectionRefusedError: When the function timeouts this exception is raised.
         """
         from tornado.ioloop import IOLoop, TimeoutError
+
         try:
             return IOLoop.current().run_sync(function, timeout)
         except TimeoutError:
@@ -124,6 +126,7 @@ class PluginMeta(type):
     """
         A metaclass that registers subclasses in the parent class.
     """
+
     def __new__(cls, name, bases, dct):
         subclass = type.__new__(cls, name, bases, dct)
         if hasattr(subclass, "__function_name__"):
@@ -141,8 +144,7 @@ class PluginMeta(type):
         ns_parts = str(plugin_class.__module__).split(".")
         ns_parts.append(name)
         if ns_parts[0] != const.PLUGINS_PACKAGE:
-            raise Exception(
-                "All plugin modules should be loaded in the %s package" % const.PLUGINS_PACKAGE)
+            raise Exception("All plugin modules should be loaded in the %s package" % const.PLUGINS_PACKAGE)
 
         name = "::".join(ns_parts[1:])
         cls.__functions[name] = plugin_class
@@ -250,8 +252,10 @@ class Plugin(object, metaclass=PluginMeta):
             return None
 
         if not isinstance(arg_type, str):
-            raise CompilerException("bad annotation in plugin %s::%s, expected str but got %s (%s)" %
-                                    (self.ns, self.__class__.__function_name__, type(arg_type), arg_type))
+            raise CompilerException(
+                "bad annotation in plugin %s::%s, expected str but got %s (%s)"
+                % (self.ns, self.__class__.__function_name__, type(arg_type), arg_type)
+            )
 
         if arg_type == "any":
             return None
@@ -289,17 +293,20 @@ class Plugin(object, metaclass=PluginMeta):
         required = len([x for x in self.arguments if len(x) == 2])
 
         if len(args) < required or len(args) > max_arg:
-            raise Exception("Incorrect number of arguments for %s. Expected at least %d, got %d" %
-                            (self.get_signature(), required, len(args)))
+            raise Exception(
+                "Incorrect number of arguments for %s. Expected at least %d, got %d"
+                % (self.get_signature(), required, len(args))
+            )
 
         for i in range(len(args)):
             if isinstance(args[i], Unknown):
                 return False
 
             if self.arguments[i][0] is not None and not self._is_instance(args[i], self.argtypes[i]):
-                raise Exception(("Invalid type for argument %d of '%s', it should be "
-                                 "%s and %s given.") % (i + 1, self.__class__.__function_name__,
-                                                        self.arguments[i][1], args[i].__class__.__name__))
+                raise Exception(
+                    ("Invalid type for argument %d of '%s', it should be " "%s and %s given.")
+                    % (i + 1, self.__class__.__function_name__, self.arguments[i][1], args[i].__class__.__name__)
+                )
         return True
 
     def emit_statement(self) -> "DynamicStatement":
@@ -353,7 +360,7 @@ class Plugin(object, metaclass=PluginMeta):
             exception = None
 
             try:
-                valid = (value is None or self._is_instance(value, self.returntype))
+                valid = value is None or self._is_instance(value, self.returntype)
             except RuntimeException as e:
                 raise e
             except Exception as exp:
@@ -364,14 +371,17 @@ class Plugin(object, metaclass=PluginMeta):
                 if exception is not None:
                     msg = "\n\tException details: " + str(exception)
 
-                raise Exception("Plugin %s should return value of type %s ('%s' was returned) %s" %
-                                (self.__class__.__function_name__, self.returntype, value, msg))
+                raise Exception(
+                    "Plugin %s should return value of type %s ('%s' was returned) %s"
+                    % (self.__class__.__function_name__, self.returntype, value, msg)
+                )
 
         return value
 
 
-def plugin(function: Callable=None, commands: List[str]=None, emits_statements: bool=False,
-           allow_unknown: bool=False) -> None:  # noqa: H801
+def plugin(
+    function: Callable = None, commands: List[str] = None, emits_statements: bool = False, allow_unknown: bool = False
+) -> None:  # noqa: H801
     """
         Python decorator to register functions with inmanta as plugin
 
@@ -382,10 +392,12 @@ def plugin(function: Callable=None, commands: List[str]=None, emits_statements: 
                                  required for complex plugins such as integrating a template engine.
         :param allow_unknown: Set to true if this plugin accepts Unknown values as valid input.
     """
+
     def curry_name(name=None, commands=None, emits_statements=False, allow_unknown=False):
         """
             Function to curry the name of the function
         """
+
         def call(fnc):
             """
                 Create class to register the function and return the function itself

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -416,7 +416,7 @@ def gzipped_json(value: JsonType) -> Tuple[bool, Union[bytes, str]]:
 def shorten(msg: str, max_len: int = 10) -> str:
     if len(msg) < max_len:
         return msg
-    return msg[0:max_len - 3] + "..."
+    return msg[0 : max_len - 3] + "..."
 
 
 def encode_token(client_types: List[str], environment: str = None, idempotent: bool = False, expire: float = None) -> str:

--- a/src/inmanta/reporter.py
+++ b/src/inmanta/reporter.py
@@ -23,11 +23,7 @@ DEFAULT_INFLUX_PROTOCOL = "http"
 
 
 class AsyncReporter(object):
-    def __init__(
-        self,
-        registry: MetricsRegistry = None,
-        reporting_interval: int = 30
-    ) -> None:
+    def __init__(self, registry: MetricsRegistry = None, reporting_interval: int = 30) -> None:
         self.registry = registry or global_registry()
         self.reporting_interval = reporting_interval
         self._stopped = False
@@ -56,9 +52,7 @@ class AsyncReporter(object):
             wait = max(0, next_loop_time - loop.time())
             await asyncio.sleep(wait)
 
-    async def report_now(
-        self, registry: MetricsRegistry = None, timestamp: float = None
-    ) -> None:
+    async def report_now(self, registry: MetricsRegistry = None, timestamp: float = None) -> None:
         raise NotImplementedError(self.report_now)
 
 
@@ -94,9 +88,7 @@ class InfluxReporter(AsyncReporter):
         self.tags = tags
         self.key = "metrics"
         if self.tags:
-            tagstring = ",".join(
-                "%s=%s" % (key, value) for key, value in self.tags.items()
-            )
+            tagstring = ",".join("%s=%s" % (key, value) for key, value in self.tags.items())
             self.key = "%s,%s" % (self.key, tagstring)
         self.key = "%s,key=" % self.key
 
@@ -113,18 +105,9 @@ class InfluxReporter(AsyncReporter):
             # Only set if we actually were able to get a successful response
             self._did_create_database = True
         except Exception:
-            LOGGER.warning(
-                "Cannot create database %s to %s",
-                self.database,
-                self.server,
-                exc_info=True
-            )
+            LOGGER.warning("Cannot create database %s to %s", self.database, self.server, exc_info=True)
 
-    async def report_now(
-        self,
-        registry: Optional[MetricsRegistry] = None,
-        timestamp: Optional[float] = None,
-    ):
+    async def report_now(self, registry: Optional[MetricsRegistry] = None, timestamp: Optional[float] = None):
         http_client = AsyncHTTPClient()
 
         if self.autocreate_database and not self._did_create_database:
@@ -135,10 +118,7 @@ class InfluxReporter(AsyncReporter):
         for key, metric_values in metrics.items():
             table = self.key + key
             values = ",".join(
-                [
-                    "%s=%s" % (k, v if type(v) is not str else '"{}"'.format(v))
-                    for (k, v) in metric_values.items()
-                ]
+                ["%s=%s" % (k, v if type(v) is not str else '"{}"'.format(v)) for (k, v) in metric_values.items()]
             )
             line = "%s %s %s" % (table, values, timestamp)
             post_data.append(line)

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -49,6 +49,7 @@ class resource(object):  # noqa: N801
                       but it can navigate relations (this value cannot be mapped). For example, the agent argument could be
                       ``host.name``
     """
+
     _resources: Dict[str, Tuple[Type["Resource"], Dict[str, str]]] = {}
 
     def __init__(self, name: str, id_attribute: str, agent: str):
@@ -135,7 +136,6 @@ def to_id(entity: runtime.Instance) -> Optional[str]:
 
 
 class ResourceMeta(type):
-
     @classmethod
     def _get_parent_fields(cls, bases: Type["Resource"]) -> List[str]:
         fields: List[str] = []
@@ -184,6 +184,7 @@ class Resource(metaclass=ResourceMeta):
         itself and all superclasses. If a field it not available directly in the model object the serializer will look for
         static methods in the class with the name "get_$fieldname".
     """
+
     fields: Tuple[str, ...] = ("send_event",)
     model: DynamicProxy
     map: Dict[str, Callable[["export.Exporter", DynamicProxy], Any]]
@@ -218,9 +219,12 @@ class Resource(metaclass=ResourceMeta):
                         initial_requires.remove(r)
 
                 if len(initial_requires) > 0:
-                    LOGGER.warning("The resource %s had requirements before flattening, but not after flattening."
-                                   " Initial set was %s. Perhaps provides relation is not wired through correctly?",
-                                   res, initial_requires)
+                    LOGGER.warning(
+                        "The resource %s had requirements before flattening, but not after flattening."
+                        " Initial set was %s. Perhaps provides relation is not wired through correctly?",
+                        res,
+                        initial_requires,
+                    )
 
             res.requires = final_requires
 
@@ -250,8 +254,10 @@ class Resource(metaclass=ResourceMeta):
             except UnknownException as e:
                 raise e
             except Exception:
-                raise Exception("Unable to get the name of agent %s belongs to. In path %s, '%s' does not exist"
-                                % (model_object, agent_attribute, el))
+                raise Exception(
+                    "Unable to get the name of agent %s belongs to. In path %s, '%s' does not exist"
+                    % (model_object, agent_attribute, el)
+                )
 
         attribute_value = cls.map_field(None, entity_name, attribute_name, model_object)
         if isinstance(attribute_value, util.Unknown):
@@ -336,8 +342,9 @@ class Resource(metaclass=ResourceMeta):
             if field.startswith("_"):
                 raise ResourceException("Resource field names can not start with _, reported in %s" % cls.__name__)
             if field in RESERVED_FOR_RESOURCE:
-                raise ResourceException("Resource %s is a reserved keyword and not a valid field name, reported in %s" %
-                                        (field, cls.__name__))
+                raise ResourceException(
+                    "Resource %s is a reserved keyword and not a valid field name, reported in %s" % (field, cls.__name__)
+                )
 
     def __init__(self, _id: "Id") -> None:
         self.id = _id
@@ -406,6 +413,7 @@ class PurgeableResource(Resource):
     """
         See :inmanta:entity:`std::PurgeableResource` for more information.
     """
+
     fields = ("purged", "purge_on_delete")
 
 
@@ -413,6 +421,7 @@ class ManagedResource(Resource):
     """
         See :inmanta:entity:`std::ManagedResource` for more information.
     """
+
     fields = ("managed",)
 
     @staticmethod
@@ -435,12 +444,13 @@ class Id(object):
         self._version = version
 
     def to_dict(self) -> JsonType:
-        return {"entity_type": self._entity_type,
-                "agent_name": self.agent_name,
-                "attribute": self.attribute,
-                "attribute_value": self.attribute_value,
-                "version": self.version
-                }
+        return {
+            "entity_type": self._entity_type,
+            "agent_name": self.agent_name,
+            "attribute": self.attribute,
+            "attribute_value": self.attribute_value,
+            "version": self.version,
+        }
 
     def get_entity_type(self) -> str:
         return self._entity_type
@@ -512,8 +522,11 @@ class Id(object):
             Parse the resource id and return the type, the hostname and the
             resource identifier.
         """
-        result = re.search(r"^(?P<id>(?P<type>(?P<ns>[\w-]+::)+(?P<class>[\w-]+))\[(?P<hostname>[^,]+),"
-                           r"(?P<attr>[^=]+)=(?P<value>[^\]]+)\])(,v=(?P<version>[0-9]+))?$", resource_id)
+        result = re.search(
+            r"^(?P<id>(?P<type>(?P<ns>[\w-]+::)+(?P<class>[\w-]+))\[(?P<hostname>[^,]+),"
+            r"(?P<attr>[^=]+)=(?P<value>[^\]]+)\])(,v=(?P<version>[0-9]+))?$",
+            resource_id,
+        )
 
         if result is None:
             raise Exception("Invalid id for resource %s" % resource_id)
@@ -555,6 +568,7 @@ class HostNotFoundException(Exception):
 
     def to_action(self):
         from inmanta.data import ResourceAction
+
         ra = ResourceAction()  # @UndefinedVariable
         ra.message = "Failed to access host %s as user %s over ssh." % (self.hostname, self.user)
         ra.data = {"host": self.hostname, "user": self.user, "error": self.error}

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -51,11 +51,7 @@ influxdb_password = Option("influxdb", "password", None, "The password that belo
 
 influxdb_interval = Option("influxdb", "interval", 30, "Interval with which to report to influxdb", is_int)
 influxdb_tags = Option(
-    "influxdb",
-    "tags",
-    "",
-    "a dict of tags to attach to all influxdb records in the form tag=value,tag=value",
-    is_map
+    "influxdb", "tags", "", "a dict of tags to attach to all influxdb records in the form tag=value,tag=value", is_map
 )
 
 #############################
@@ -63,20 +59,27 @@ influxdb_tags = Option(
 #############################
 server_enable_auth = Option("server", "auth", False, "Enable authentication on the server API", is_bool)
 
-server_ssl_key = Option("server", "ssl_key_file", None,
-                        "Server private key to use for this server Leave blank to disable SSL", is_str_opt)
+server_ssl_key = Option(
+    "server", "ssl_key_file", None, "Server private key to use for this server Leave blank to disable SSL", is_str_opt
+)
 
-server_ssl_cert = Option("server", "ssl_cert_file", None,
-                         "SSL certificate file for the server key. Leave blank to disable SSL", is_str_opt)
+server_ssl_cert = Option(
+    "server", "ssl_cert_file", None, "SSL certificate file for the server key. Leave blank to disable SSL", is_str_opt
+)
 
-server_ssl_ca_cert = Option("server", "ssl_ca_cert_file", None,
-                            "The CA cert file required to validate the server ssl cert. This setting is used by the server"
-                            "to correctly configure the compiler and agents that the server starts itself. If not set and "
-                            "SSL is enabled, the server cert should be verifiable with the CAs installed in the OS.",
-                            is_str_opt)
+server_ssl_ca_cert = Option(
+    "server",
+    "ssl_ca_cert_file",
+    None,
+    "The CA cert file required to validate the server ssl cert. This setting is used by the server"
+    "to correctly configure the compiler and agents that the server starts itself. If not set and "
+    "SSL is enabled, the server cert should be verifiable with the CAs installed in the OS.",
+    is_str_opt,
+)
 
-server_fact_expire = Option("server", "fact-expire", 3600,
-                            "After how many seconds will discovered facts/parameters expire", is_time)
+server_fact_expire = Option(
+    "server", "fact-expire", 3600, "After how many seconds will discovered facts/parameters expire", is_time
+)
 
 
 def default_fact_renew():
@@ -88,55 +91,88 @@ def validate_fact_renew(value):
     """ time; < server.fact-expire """
     out = int(value)
     if not out < server_fact_expire.get():
-        LOGGER.warn("can not set fact_renew to %d, must be smaller than fact-expire (%d), using %d instead" %
-                    (out, server_fact_expire.get(), default_fact_renew()))
+        LOGGER.warn(
+            "can not set fact_renew to %d, must be smaller than fact-expire (%d), using %d instead"
+            % (out, server_fact_expire.get(), default_fact_renew())
+        )
         out = default_fact_renew()
     return out
 
 
-server_fact_renew = Option("server", "fact-renew", default_fact_renew,
-                           """After how many seconds will discovered facts/parameters be renewed?
-                              This value needs to be lower than fact-expire""", validate_fact_renew)
+server_fact_renew = Option(
+    "server",
+    "fact-renew",
+    default_fact_renew,
+    """After how many seconds will discovered facts/parameters be renewed?
+                              This value needs to be lower than fact-expire""",
+    validate_fact_renew,
+)
 
-server_fact_resource_block = Option("server", "fact-resource-block", 60,
-                                    "Minimal time between subsequent requests for the same fact", is_time)
+server_fact_resource_block = Option(
+    "server", "fact-resource-block", 60, "Minimal time between subsequent requests for the same fact", is_time
+)
 
-server_autrecompile_wait = Option("server", "auto-recompile-wait", 10,
-                                  """The number of seconds to wait before the server may attempt to do a new recompile.
-                                     Recompiles are triggered after facts updates for example.""", is_time)
+server_autrecompile_wait = Option(
+    "server",
+    "auto-recompile-wait",
+    10,
+    """The number of seconds to wait before the server may attempt to do a new recompile.
+                                     Recompiles are triggered after facts updates for example.""",
+    is_time,
+)
 
-server_purge_version_interval = Option("server", "purge-versions-interval", 3600,
-                                       """The number of seconds between version purging,
-                                          see :inmanta.config:option:`server.available-versions-to-keep`""", is_time)
+server_purge_version_interval = Option(
+    "server",
+    "purge-versions-interval",
+    3600,
+    """The number of seconds between version purging,
+                                          see :inmanta.config:option:`server.available-versions-to-keep`""",
+    is_time,
+)
 
-server_version_to_keep = Option("server", "available-versions-to-keep", 10,
-                                """On boot and at regular intervals the server will purge older versions.
-                                   This is the number of most recent versions to keep available.""", is_int)
+server_version_to_keep = Option(
+    "server",
+    "available-versions-to-keep",
+    10,
+    """On boot and at regular intervals the server will purge older versions.
+                                   This is the number of most recent versions to keep available.""",
+    is_int,
+)
 
-server_address = Option("server", "server_address", "localhost",
-                        """The public ip address of the server.
-                           This is required for example to inject the inmanta agent in virtual machines at boot time.""")
+server_address = Option(
+    "server",
+    "server_address",
+    "localhost",
+    """The public ip address of the server.
+                           This is required for example to inject the inmanta agent in virtual machines at boot time.""",
+)
 
-server_wait_after_param = Option("server", "wait-after-param", 5,
-                                 "Time to wait before recompile after new paramters have been received", is_time)
+server_wait_after_param = Option(
+    "server", "wait-after-param", 5, "Time to wait before recompile after new paramters have been received", is_time
+)
 
-agent_timeout = Option("server", "agent-timeout", 30,
-                       "Time before an agent is considered to be offline", is_time)
+agent_timeout = Option("server", "agent-timeout", 30, "Time before an agent is considered to be offline", is_time)
 
-server_delete_currupt_files = Option("server", "delete_currupt_files", True,
-                                     "The server logs an error when it detects a file got corrupted. When set to true, the "
-                                     "server will also delete the file, so on subsequent compiles the missing file will be "
-                                     "recreated.", is_bool)
+server_delete_currupt_files = Option(
+    "server",
+    "delete_currupt_files",
+    True,
+    "The server logs an error when it detects a file got corrupted. When set to true, the "
+    "server will also delete the file, so on subsequent compiles the missing file will be "
+    "recreated.",
+    is_bool,
+)
 
-server_purge_resource_action_logs_interval = Option("server", "purge-resource-action-logs-interval", 3600,
-                                                    "The number of seconds between resource-action log purging", is_time)
+server_purge_resource_action_logs_interval = Option(
+    "server", "purge-resource-action-logs-interval", 3600, "The number of seconds between resource-action log purging", is_time
+)
 
 server_resource_action_log_prefix = Option(
     "server",
     "resource_action_log_prefix",
     "resource-actions-",
     "File prefix in log-dir, containing the resource-action logs. The after the prefix the environment uuid and .log is added",
-    is_str_opt
+    is_str_opt,
 )
 
 
@@ -146,8 +182,9 @@ server_resource_action_log_prefix = Option(
 
 dash_enable = Option("dashboard", "enabled", True, "Determines whether the server should host the dashboard or not", is_bool)
 
-dash_path = Option("dashboard", "path", "/usr/share/inmanta/dashboard",
-                   "The path on the local file system where the dashboard can be found")
+dash_path = Option(
+    "dashboard", "path", "/usr/share/inmanta/dashboard", "The path on the local file system where the dashboard can be found"
+)
 
 dash_realm = Option("dashboard", "realm", "inmanta", "The realm to use for keycloak authentication.")
 dash_auth_url = Option("dashboard", "auth_url", None, "The auth url of the keycloak server to use.")
@@ -161,5 +198,6 @@ def default_hangtime():
     return str(int(agent_timeout.get() * 3 / 4))
 
 
-agent_hangtime = Option("server", "agent-hold", default_hangtime,
-                        "Maximal time the server will hold an agent heartbeat call", is_time)
+agent_hangtime = Option(
+    "server", "agent-hold", default_hangtime, "Maximal time the server will hold an agent heartbeat call", is_time
+)

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -84,7 +84,7 @@ class ResourceActionLogLine(logging.LogRecord):
             args=[],
             exc_info=None,
             func=None,
-            sinfo=None
+            sinfo=None,
         )
 
         self.created = created.timestamp()
@@ -98,7 +98,7 @@ class Server(protocol.ServerSlice):
         information
     """
 
-    def __init__(self, agent_no_log: bool=False) -> None:
+    def __init__(self, agent_no_log: bool = False) -> None:
         super().__init__(name=SLICE_SERVER)
         LOGGER.info("Starting server endpoint")
 
@@ -145,15 +145,16 @@ class Server(protocol.ServerSlice):
 
     def start_metric_reporters(self) -> None:
         if opt.influxdb_host.get():
-            self._influx_db_reporter = InfluxReporter(server=opt.influxdb_host.get(),
-                                                      port=opt.influxdb_port.get(),
-                                                      database=opt.influxdb_name.get(),
-                                                      username=opt.influxdb_username.get(),
-                                                      password=opt.influxdb_password,
-                                                      reporting_interval=opt.influxdb_interval.get(),
-                                                      autocreate_database=True,
-                                                      tags=opt.influxdb_tags.get()
-                                                      )
+            self._influx_db_reporter = InfluxReporter(
+                server=opt.influxdb_host.get(),
+                port=opt.influxdb_port.get(),
+                database=opt.influxdb_name.get(),
+                username=opt.influxdb_username.get(),
+                password=opt.influxdb_password,
+                reporting_interval=opt.influxdb_interval.get(),
+                autocreate_database=True,
+                tags=opt.influxdb_tags.get(),
+            )
             self._influx_db_reporter.start()
 
     @staticmethod
@@ -162,10 +163,7 @@ class Server(protocol.ServerSlice):
         :param environment: The environment id to get the file for
         :return: The path to the logfile
         """
-        return os.path.join(
-            opt.log_dir.get(),
-            opt.server_resource_action_log_prefix.get() + str(environment) + ".log"
-        )
+        return os.path.join(opt.log_dir.get(), opt.server_resource_action_log_prefix.get() + str(environment) + ".log")
 
     def get_resource_action_logger(self, environment: uuid.UUID) -> logging.Logger:
         """Get the resource action logger for the given environment. If the logger was not created, create it.
@@ -177,7 +175,7 @@ class Server(protocol.ServerSlice):
 
         resource_action_log = self.get_resource_action_log_file(environment)
 
-        file_handler = logging.handlers.WatchedFileHandler(filename=resource_action_log, mode='a+')
+        file_handler = logging.handlers.WatchedFileHandler(filename=resource_action_log, mode="a+")
         # Most logs will come from agents. We need to use their level and timestamp and their formatted message
         file_handler.setFormatter(logging.Formatter(fmt="%(message)s"))
         file_handler.setLevel(logging.DEBUG)
@@ -253,20 +251,28 @@ class Server(protocol.ServerSlice):
         'realm': '%s',
         'url': '%s',
         'clientId': '%s'
-    }""" % (opt.dash_realm.get(), opt.dash_auth_url.get(), opt.dash_client_id.get())
+    }""" % (
+                opt.dash_realm.get(),
+                opt.dash_auth_url.get(),
+                opt.dash_client_id.get(),
+            )
 
         # LCM support should move to a server extension
         lcm = ""
         if opt.dash_lcm_enable.get():
             lcm = """,
     'lcm': '%s://' + window.location.hostname + ':8889/'
-""" % ("https" if opt.server_ssl_key.get() else "http")
+""" % (
+                "https" if opt.server_ssl_key.get() else "http"
+            )
 
         content = """
 angular.module('inmantaApi.config', []).constant('inmantaConfig', {
     'backend': window.location.origin+'/'%s
 });
-        """ % (lcm + auth)
+        """ % (
+            lcm + auth
+        )
         self.add_static_content("/dashboard/config.js", content=content)
         self.add_static_handler("/dashboard", dashboard_path, start=True)
 
@@ -297,6 +303,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         """
             Check if the server storage is configured and ready to use.
         """
+
         def _ensure_directory_exist(directory, *subdirs):
             directory = os.path.join(directory, *subdirs)
             if not os.path.exists(directory):
@@ -325,19 +332,25 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
 
         for param in expired_params:
             if param.environment is None:
-                LOGGER.warning("Found parameter without environment (%s for resource %s). Deleting it.",
-                               param.name, param.resource_id)
+                LOGGER.warning(
+                    "Found parameter without environment (%s for resource %s). Deleting it.", param.name, param.resource_id
+                )
                 await param.delete()
             else:
-                LOGGER.debug("Requesting new parameter value for %s of resource %s in env %s", param.name, param.resource_id,
-                             param.environment)
+                LOGGER.debug(
+                    "Requesting new parameter value for %s of resource %s in env %s",
+                    param.name,
+                    param.resource_id,
+                    param.environment,
+                )
                 await self.agentmanager._request_parameter(param.environment, param.resource_id)
 
         unknown_parameters = await data.UnknownParameter.get_list(resolved=False)
         for u in unknown_parameters:
             if u.environment is None:
-                LOGGER.warning("Found unknown parameter without environment (%s for resource %s). Deleting it.",
-                               u.name, u.resource_id)
+                LOGGER.warning(
+                    "Found unknown parameter without environment (%s for resource %s). Deleting it.", u.name, u.resource_id
+                )
                 await u.delete()
             else:
                 LOGGER.debug("Requesting value for unknown parameter %s of resource %s in env %s", u.name, u.resource_id, u.id)
@@ -346,7 +359,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         LOGGER.info("Done renewing expired parameters")
 
     @protocol.handle(methods.get_param, param_id="id", env="tid")
-    async def get_param(self, env: data.Environment, param_id: str, resource_id: Optional[str]=None) -> Apireturn:
+    async def get_param(self, env: data.Environment, param_id: str, resource_id: Optional[str] = None) -> Apireturn:
         if resource_id is None:
             params = await data.Parameter.get_list(environment=env.id, name=param_id)
         else:
@@ -370,14 +383,14 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         return out
 
     async def _update_param(
-            self,
-            env: data.Environment,
-            name: str,
-            value: str,
-            source: str,
-            resource_id: str,
-            metadata: JsonType,
-            recompile: bool=False
+        self,
+        env: data.Environment,
+        name: str,
+        value: str,
+        source: str,
+        resource_id: str,
+        metadata: JsonType,
+        recompile: bool = False,
     ) -> bool:
         """
             Update or set a parameter.
@@ -397,8 +410,15 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
 
         value_updated = True
         if len(params) == 0:
-            param = data.Parameter(environment=env.id, name=name, resource_id=resource_id, value=value, source=source,
-                                   updated=datetime.datetime.now(), metadata=metadata)
+            param = data.Parameter(
+                environment=env.id,
+                name=name,
+                resource_id=resource_id,
+                value=value,
+                source=source,
+                updated=datetime.datetime.now(),
+                metadata=metadata,
+            )
             await param.insert()
         else:
             param = params[0]
@@ -408,25 +428,26 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         # check if the parameter is an unknown
         params = await data.UnknownParameter.get_list(environment=env.id, name=name, resource_id=resource_id, resolved=False)
         if len(params) > 0:
-            LOGGER.info("Received values for unknown parameters %s, triggering a recompile",
-                        ", ".join([x.name for x in params]))
+            LOGGER.info(
+                "Received values for unknown parameters %s, triggering a recompile", ", ".join([x.name for x in params])
+            )
             for p in params:
                 await p.update_fields(resolved=True)
 
             return True
 
-        return (recompile and value_updated)
+        return recompile and value_updated
 
     @protocol.handle(methods.set_param, param_id="id", env="tid")
     async def set_param(
-            self,
-            env: data.Environment,
-            param_id: str,
-            source: str,
-            value: str,
-            resource_id: str,
-            metadata: JsonType,
-            recompile: bool
+        self,
+        env: data.Environment,
+        param_id: str,
+        source: str,
+        value: str,
+        resource_id: str,
+        metadata: JsonType,
+        recompile: bool,
     ) -> Apireturn:
         result = await self._update_param(env, param_id, value, source, resource_id, metadata, recompile)
         if result:
@@ -450,7 +471,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         compile_metadata = {
             "message": "Recompile model because one or more parameters were updated",
             "type": "param",
-            "params": []
+            "params": [],
         }
         for param in parameters:
             name = param["id"]
@@ -484,7 +505,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         metadata = {
             "message": "Recompile model because one or more parameters were deleted",
             "type": "param",
-            "params": [(param.name, param.resource_id)]
+            "params": [(param.name, param.resource_id)],
         }
         await self._async_recompile(env, False, metadata=metadata)
 
@@ -493,10 +514,14 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
     @protocol.handle(methods.list_params, env="tid")
     async def list_param(self, env: data.Environment, query: Dict[str, str]) -> Apireturn:
         params = await data.Parameter.list_parameters(env.id, **query)
-        return 200, {"parameters": params,
-                     "expire": self._fact_expire,
-                     "now": datetime.datetime.now().isoformat(timespec='microseconds')
-                     }
+        return (
+            200,
+            {
+                "parameters": params,
+                "expire": self._fact_expire,
+                "now": datetime.datetime.now().isoformat(timespec="microseconds"),
+            },
+        )
 
     @protocol.handle(methods.put_form, form_id="id", env="tid")
     async def put_form(self, env: data.Environment, form_id: str, form: JsonType) -> Apireturn:
@@ -506,9 +531,14 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         field_options = {k: v["options"] for k, v in form["attributes"].items() if "options" in v}
 
         if form_doc is None:
-            form_doc = data.Form(environment=env.id, form_type=form_id, fields=fields,
-                                 defaults=defaults, options=form["options"],
-                                 field_options=field_options)
+            form_doc = data.Form(
+                environment=env.id,
+                form_type=form_id,
+                fields=fields,
+                defaults=defaults,
+                options=form["options"],
+                field_options=field_options,
+            )
             await form_doc.insert()
 
         else:
@@ -586,7 +616,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
             "message": "Recompile model because a form record was updated",
             "type": "form",
             "records": [str(record_id)],
-            "form": form
+            "form": form,
         }
 
         await self._async_recompile(env, False, metadata=metadata)
@@ -617,7 +647,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
             "message": "Recompile model because a form record was inserted",
             "type": "form",
             "records": [str(record.id)],
-            "form": form
+            "form": form,
         }
         await self._async_recompile(env, False, metadata=metadata)
 
@@ -634,7 +664,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
             "message": "Recompile model because a form record was removed",
             "type": "form",
             "records": [str(record.id)],
-            "form": record.form
+            "form": record.form,
         }
         await self._async_recompile(env, False, metadata=metadata)
 
@@ -690,22 +720,45 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
                 actualhash = hash_file(content)
                 if actualhash != file_hash:
                     if opt.server_delete_currupt_files.get():
-                        LOGGER.error("File corrupt, expected hash %s but found %s at %s, Deleting file" %
-                                     (file_hash, actualhash, file_name))
+                        LOGGER.error(
+                            "File corrupt, expected hash %s but found %s at %s, Deleting file"
+                            % (file_hash, actualhash, file_name)
+                        )
                         try:
                             os.remove(file_name)
                         except OSError:
                             LOGGER.exception("Failed to delete file %s" % (file_name))
-                            return 500, {"message": ("File corrupt, expected hash %s but found %s,"
-                                                     " Failed to delete file, please contact the server administrator"
-                                                     ) % (file_hash, actualhash)}
-                        return 500, {"message": ("File corrupt, expected hash %s but found %s, "
-                                                 "Deleting file, please re-upload the corrupt file"
-                                                 ) % (file_hash, actualhash)}
+                            return (
+                                500,
+                                {
+                                    "message": (
+                                        "File corrupt, expected hash %s but found %s,"
+                                        " Failed to delete file, please contact the server administrator"
+                                    )
+                                    % (file_hash, actualhash)
+                                },
+                            )
+                        return (
+                            500,
+                            {
+                                "message": (
+                                    "File corrupt, expected hash %s but found %s, "
+                                    "Deleting file, please re-upload the corrupt file"
+                                )
+                                % (file_hash, actualhash)
+                            },
+                        )
                     else:
                         LOGGER.error("File corrupt, expected hash %s but found %s at %s" % (file_hash, actualhash, file_name))
-                        return 500, {"message": ("File corrupt, expected hash %s but found %s,"
-                                                 " please contact the server administrator") % (file_hash, actualhash)}
+                        return (
+                            500,
+                            {
+                                "message": (
+                                    "File corrupt, expected hash %s but found %s," " please contact the server administrator"
+                                )
+                                % (file_hash, actualhash)
+                            },
+                        )
                 return 200, content
 
     @protocol.handle(methods.stat_files)
@@ -755,13 +808,13 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
 
     @protocol.handle(methods.get_resource, resource_id="id", env="tid")
     async def get_resource(
-            self,
-            env: data.Environment,
-            resource_id: str,
-            logs: bool,
-            status: bool,
-            log_action: const.ResourceAction,
-            log_limit: int
+        self,
+        env: data.Environment,
+        resource_id: str,
+        logs: bool,
+        status: bool,
+        log_action: const.ResourceAction,
+        log_limit: int,
     ) -> Apireturn:
         resv = await data.Resource.get(env.id, resource_id)
         if resv is None:
@@ -777,10 +830,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
                 action_name = log_action.name
 
             actions = await data.ResourceAction.get_log(
-                environment=env.id,
-                resource_version_id=resource_id,
-                action=action_name,
-                limit=log_limit
+                environment=env.id, resource_version_id=resource_id, action=action_name, limit=log_limit
             )
 
         return 200, {"resource": resv, "logs": actions}
@@ -824,8 +874,15 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
 
         log_line = data.LogLine.log(logging.INFO, "Resource version pulled by client for agent %(agent)s state", agent=agent)
         self.log_resource_action(env.id, resource_ids, logging.INFO, now, log_line.msg)
-        ra = data.ResourceAction(environment=env.id, resource_version_ids=resource_ids, action=const.ResourceAction.pull,
-                                 action_id=uuid.uuid4(), started=started, finished=now, messages=[log_line])
+        ra = data.ResourceAction(
+            environment=env.id,
+            resource_version_ids=resource_ids,
+            action=const.ResourceAction.pull,
+            action_id=uuid.uuid4(),
+            started=started,
+            finished=now,
+            messages=[log_line],
+        )
         await ra.insert()
 
         return 200, {"environment": env.id, "agent": agent, "version": version, "resources": deploy_model}
@@ -859,8 +916,8 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         logline = {
             "level": "INFO",
             "msg": "Setting deployed due to known good status",
-            "timestamp": now.isoformat(timespec='microseconds'),
-            "args": []
+            "timestamp": now.isoformat(timespec="microseconds"),
+            "args": [],
         }
         self.add_background_task(
             self.resource_action_update(
@@ -876,7 +933,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
                 messages=[logline],
                 change=const.Change.nochange,
                 send_events=False,
-                keep_increment_cache=True
+                keep_increment_cache=True,
             )
         )
 
@@ -899,17 +956,23 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
             deploy_model.append(rv.to_dict())
             resource_ids.append(rv.resource_version_id)
 
-        ra = data.ResourceAction(environment=env.id, resource_version_ids=resource_ids, action=const.ResourceAction.pull,
-                                 action_id=uuid.uuid4(), started=started, finished=now,
-                                 messages=[data.LogLine.log(logging.INFO,
-                                                            "Resource version pulled by client for agent %(agent)s state",
-                                                            agent=agent)])
+        ra = data.ResourceAction(
+            environment=env.id,
+            resource_version_ids=resource_ids,
+            action=const.ResourceAction.pull,
+            action_id=uuid.uuid4(),
+            started=started,
+            finished=now,
+            messages=[
+                data.LogLine.log(logging.INFO, "Resource version pulled by client for agent %(agent)s state", agent=agent)
+            ],
+        )
         await ra.insert()
 
         return 200, {"environment": env.id, "agent": agent, "version": version, "resources": deploy_model}
 
     @protocol.handle(methods.list_versions, env="tid")
-    async def list_version(self, env: data.Environment, start: Optional[int]=None, limit: Optional[int]=None) -> Apireturn:
+    async def list_version(self, env: data.Environment, start: Optional[int] = None, limit: Optional[int] = None) -> Apireturn:
         if (start is None and limit is not None) or (limit is None and start is not None):
             return 500, {"message": "Start and limit should always be set together."}
 
@@ -932,12 +995,12 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
 
     @protocol.handle(methods.get_version, version_id="id", env="tid")
     async def get_version(
-            self,
-            env: data.Environment,
-            version_id: int,
-            include_logs: Optional[bool]=None,
-            log_filter: Optional[str]=None,
-            limit: Optional[int]=0
+        self,
+        env: data.Environment,
+        version_id: int,
+        include_logs: Optional[bool] = None,
+        log_filter: Optional[str] = None,
+        limit: Optional[int] = 0,
     ) -> Apireturn:
         version = await data.ConfigurationModel.get_version(env.id, version_id)
         if version is None:
@@ -954,10 +1017,8 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         for res_dict in resources:
             if bool(include_logs):
                 res_dict["actions"] = await data.ResourceAction.get_log(
-                    env.id,
-                    res_dict["resource_version_id"],
-                    log_filter,
-                    limit)
+                    env.id, res_dict["resource_version_id"], log_filter, limit
+                )
 
             d["resources"].append(res_dict)
 
@@ -976,13 +1037,13 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
 
     @protocol.handle(methods.put_version, env="tid")
     async def put_version(
-            self,
-            env: data.Environment,
-            version: int,
-            resources: List[JsonType],
-            resource_state: Dict[str, const.ResourceState],
-            unknowns: List[str],
-            version_info: JsonType
+        self,
+        env: data.Environment,
+        version: int,
+        resources: List[JsonType],
+        resource_state: Dict[str, const.ResourceState],
+        unknowns: List[str],
+        version_info: JsonType,
     ) -> Apireturn:
         started = datetime.datetime.now()
 
@@ -1044,6 +1105,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
             if key not in input:
                 return default
             return input[key]
+
         metadata = safe_get(version_info, const.EXPORT_META_DATA, {})
         compile_state = safe_get(metadata, const.META_DATA_COMPILE_STATE, "")
         failed = compile_state == const.Compilestate.failed.name
@@ -1060,8 +1122,9 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
                 attributes = res.attributes.copy()
                 attributes["purged"] = "true"
                 attributes["requires"] = []
-                res_obj = data.Resource.new(env.id, resource_version_id="%s,v=%s" % (res.resource_id, version),
-                                            attributes=attributes)
+                res_obj = data.Resource.new(
+                    env.id, resource_version_id="%s,v=%s" % (res.resource_id, version), attributes=attributes
+                )
                 resource_objects.append(res_obj)
 
                 previous_requires[res_obj.resource_id] = res.attributes["requires"]
@@ -1095,9 +1158,15 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         skippeable = sorted(list(skippeable - set(undeployable_ids)))
 
         try:
-            cm = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(),
-                                         total=len(resources), version_info=version_info, undeployable=undeployable_ids,
-                                         skipped_for_undeployable=skippeable)
+            cm = data.ConfigurationModel(
+                environment=env.id,
+                version=version,
+                date=datetime.datetime.now(),
+                total=len(resources),
+                version_info=version_info,
+                undeployable=undeployable_ids,
+                skipped_for_undeployable=skippeable,
+            )
             await cm.insert()
         except asyncpg.exceptions.UniqueViolationError:
             return 500, {"message": "The given version is already defined. Versions should be unique."}
@@ -1112,9 +1181,14 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
             if "metadata" not in uk:
                 uk["metadata"] = {}
 
-            up = data.UnknownParameter(resource_id=uk["resource"], name=uk["parameter"],
-                                       source=uk["source"], environment=env.id,
-                                       version=version, metadata=uk["metadata"])
+            up = data.UnknownParameter(
+                resource_id=uk["resource"],
+                name=uk["parameter"],
+                source=uk["source"],
+                environment=env.id,
+                version=version,
+                metadata=uk["metadata"],
+            )
             await up.insert()
 
         for agent in agents:
@@ -1130,7 +1204,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
             action=const.ResourceAction.store,
             started=started,
             finished=now,
-            messages=[log_line]
+            messages=[log_line],
         )
         await ra.insert()
         LOGGER.debug("Successfully stored version %d", version)
@@ -1149,11 +1223,11 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
 
     @protocol.handle(methods.release_version, version_id="id", env="tid")
     async def release_version(
-            self,
-            env: data.Environment,
-            version_id: int,
-            push: bool,
-            agent_trigger_method: Optional[const.AgentTriggerMethod]=None
+        self,
+        env: data.Environment,
+        version_id: int,
+        push: bool,
+        agent_trigger_method: Optional[const.AgentTriggerMethod] = None,
     ) -> Apireturn:
         model = await data.ConfigurationModel.get_version(env.id, version_id)
         if model is None:
@@ -1172,18 +1246,36 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         now = datetime.datetime.now()
 
         # not checking error conditions
-        await self.resource_action_update(env, undep, action_id=uuid.uuid4(), started=now,
-                                          finished=now, status=const.ResourceState.undefined,
-                                          action=const.ResourceAction.deploy, changes={}, messages=[],
-                                          change=const.Change.nochange, send_events=False)
+        await self.resource_action_update(
+            env,
+            undep,
+            action_id=uuid.uuid4(),
+            started=now,
+            finished=now,
+            status=const.ResourceState.undefined,
+            action=const.ResourceAction.deploy,
+            changes={},
+            messages=[],
+            change=const.Change.nochange,
+            send_events=False,
+        )
 
         skippable = await model.get_skipped_for_undeployable()
         skippable = [rid + ",v=%s" % version_id for rid in skippable]
         # not checking error conditions
-        await self.resource_action_update(env, skippable, action_id=uuid.uuid4(),
-                                          started=now, finished=now, status=const.ResourceState.skipped_for_undefined,
-                                          action=const.ResourceAction.deploy, changes={}, messages=[],
-                                          change=const.Change.nochange, send_events=False)
+        await self.resource_action_update(
+            env,
+            skippable,
+            action_id=uuid.uuid4(),
+            started=now,
+            finished=now,
+            status=const.ResourceState.skipped_for_undefined,
+            action=const.ResourceAction.deploy,
+            changes={},
+            messages=[],
+            change=const.Change.nochange,
+            send_events=False,
+        )
 
         if push:
             # fetch all resource in this cm and create a list of distinct agents
@@ -1209,7 +1301,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         self,
         env: data.Environment,
         agent_trigger_method: const.AgentTriggerMethod = const.AgentTriggerMethod.push_full_deploy,
-        agents: List[str] = None
+        agents: List[str] = None,
     ) -> Apireturn:
         warnings = []
 
@@ -1227,10 +1319,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
             notfound = required - present
             if notfound:
                 warnings.append(
-                    "Model version %d does not contain agents named [%s]" % (
-                        version_id,
-                        ",".join(sorted(list(notfound)))
-                    )
+                    "Model version %d does not contain agents named [%s]" % (version_id, ",".join(sorted(list(notfound))))
                 )
 
         if not allagents:
@@ -1284,14 +1373,20 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         with (await self.dryrun_lock.acquire()):
             undeployableids = await model.get_undeployable()
             undeployableids = [rid + ",v=%s" % version_id for rid in undeployableids]
-            undeployable = await data.Resource.get_resources(environment=env.id,
-                                                             resource_version_ids=undeployableids)
+            undeployable = await data.Resource.get_resources(environment=env.id, resource_version_ids=undeployableids)
             for res in undeployable:
                 parsed_id = Id.parse_id(res.resource_version_id)
-                payload = {"changes": {}, "id_fields": {"entity_type": res.resource_type, "agent_name": res.agent,
-                                                        "attribute": parsed_id.attribute,
-                                                        "attribute_value": parsed_id.attribute_value,
-                                                        "version": res.model}, "id": res.resource_version_id}
+                payload = {
+                    "changes": {},
+                    "id_fields": {
+                        "entity_type": res.resource_type,
+                        "agent_name": res.agent,
+                        "attribute": parsed_id.attribute,
+                        "attribute_value": parsed_id.attribute_value,
+                        "version": res.model,
+                    },
+                    "id": res.resource_version_id,
+                }
                 await data.DryRun.update_resource(dryrun.id, res.resource_version_id, payload)
 
             skipundeployableids = await model.get_skipped_for_undeployable()
@@ -1299,16 +1394,23 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
             skipundeployable = await data.Resource.get_resources(environment=env.id, resource_version_ids=skipundeployableids)
             for res in skipundeployable:
                 parsed_id = Id.parse_id(res.resource_version_id)
-                payload = {"changes": {}, "id_fields": {"entity_type": res.resource_type, "agent_name": res.agent,
-                                                        "attribute": parsed_id.attribute,
-                                                        "attribute_value": parsed_id.attribute_value,
-                                                        "version": res.model}, "id": res.resource_version_id}
+                payload = {
+                    "changes": {},
+                    "id_fields": {
+                        "entity_type": res.resource_type,
+                        "agent_name": res.agent,
+                        "attribute": parsed_id.attribute,
+                        "attribute_value": parsed_id.attribute_value,
+                        "version": res.model,
+                    },
+                    "id": res.resource_version_id,
+                }
                 await data.DryRun.update_resource(dryrun.id, res.resource_version_id, payload)
 
         return 200, {"dryrun": dryrun}
 
     @protocol.handle(methods.dryrun_list, env="tid")
-    async def dryrun_list(self, env: data.Environment, version: Optional[int]=None) -> Apireturn:
+    async def dryrun_list(self, env: data.Environment, version: Optional[int] = None) -> Apireturn:
         query_args = {}
         query_args["environment"] = env.id
         if version is not None:
@@ -1320,8 +1422,10 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
 
         dryruns = await data.DryRun.get_list(**query_args)
 
-        return 200, {"dryruns": [{"id": x.id, "version": x.model, "date": x.date, "total": x.total, "todo": x.todo}
-                                 for x in dryruns]}
+        return (
+            200,
+            {"dryruns": [{"id": x.id, "version": x.model, "date": x.date, "total": x.total, "todo": x.todo} for x in dryruns]},
+        )
 
     @protocol.handle(methods.dryrun_report, dryrun_id="id", env="tid")
     async def dryrun_report(self, env: data.Environment, dryrun_id: uuid.UUID) -> Apireturn:
@@ -1379,12 +1483,16 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
                     return 400, {"message": "all keys in the sources map must be strings"}
                 if not isinstance(refs, (list, tuple)):
                     return 400, {"message": "all values in the sources map must be lists or tuple"}
-                if len(refs) != 3 or\
-                        not isinstance(refs[0], str) or \
-                        not isinstance(refs[1], str) or \
-                        not isinstance(refs[2], list):
-                    return 400, {"message": "The values in the source map should be of the"
-                                 " form (filename, module, [requirements])"}
+                if (
+                    len(refs) != 3
+                    or not isinstance(refs[0], str)
+                    or not isinstance(refs[1], str)
+                    or not isinstance(refs[2], list)
+                ):
+                    return (
+                        400,
+                        {"message": "The values in the source map should be of the" " form (filename, module, [requirements])"},
+                    )
 
         allrefs = [ref for sourcemap in resources.values() for ref in sourcemap.keys()]
 
@@ -1403,11 +1511,15 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         conflict = [k for k, v in resources.items() if k in oldmap and oldmap[k].source_refs != v]
 
         if len(conflict) > 0:
-            return 500, {"message": "Some of these items already exists, but with different source files",
-                         "references": conflict}
+            return (
+                500,
+                {"message": "Some of these items already exists, but with different source files", "references": conflict},
+            )
 
-        newcodes = [data.Code(environment=env.id, version=code_id, resource=resource, source_refs=hashes)
-                    for resource, hashes in new.items()]
+        newcodes = [
+            data.Code(environment=env.id, version=code_id, resource=resource, source_refs=hashes)
+            for resource, hashes in new.items()
+        ]
 
         await data.Code.insert_many(newcodes)
 
@@ -1443,7 +1555,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         changes: Dict[str, Any],
         change: const.Change,
         send_events: bool,
-        keep_increment_cache: bool=False
+        keep_increment_cache: bool = False,
     ) -> Apireturn:
         # can update resource state
         is_resource_state_update = action in STATE_UPDATE
@@ -1454,49 +1566,59 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
             # this resource action is finished
             if status is None:
                 error_and_log(
-                    "Cannot finish an action without a status.",
-                    resource_ids=resource_ids,
-                    action=action,
-                    action_id=action_id)
+                    "Cannot finish an action without a status.", resource_ids=resource_ids, action=action, action_id=action_id
+                )
 
         if is_resource_state_update:
             # if status update, status is required
             if status is None:
-                error_and_log("Cannot perform state update without a status.",
-                              resource_ids=resource_ids,
-                              action=action,
-                              action_id=action_id)
+                error_and_log(
+                    "Cannot perform state update without a status.",
+                    resource_ids=resource_ids,
+                    action=action,
+                    action_id=action_id,
+                )
             # and needs to be valid
             if status not in VALID_STATES_ON_STATE_UPDATE:
-                error_and_log("Status %s is not valid on action %s" % (status, action),
-                              resource_ids=resource_ids,
-                              action=action,
-                              action_id=action_id
-                              )
+                error_and_log(
+                    "Status %s is not valid on action %s" % (status, action),
+                    resource_ids=resource_ids,
+                    action=action,
+                    action_id=action_id,
+                )
             if status in TRANSIENT_STATES:
                 if not is_resource_action_finished:
                     pass
                 else:
-                    error_and_log("The finished field must not be set for transient states",
-                                  status=status,
-                                  resource_ids=resource_ids,
-                                  action=action,
-                                  action_id=action_id)
+                    error_and_log(
+                        "The finished field must not be set for transient states",
+                        status=status,
+                        resource_ids=resource_ids,
+                        action=action,
+                        action_id=action_id,
+                    )
             else:
                 if is_resource_action_finished:
                     pass
                 else:
-                    error_and_log("The finished field must be set for none transient states",
-                                  status=status,
-                                  resource_ids=resource_ids,
-                                  action=action,
-                                  action_id=action_id)
+                    error_and_log(
+                        "The finished field must be set for none transient states",
+                        status=status,
+                        resource_ids=resource_ids,
+                        action=action,
+                        action_id=action_id,
+                    )
 
         # validate resources
         resources = await data.Resource.get_resources(env.id, resource_ids)
         if len(resources) == 0 or (len(resources) != len(resource_ids)):
-            return 404, {"message": "The resources with the given ids do not exist in the given environment. "
-                         "Only %s of %s resources found." % (len(resources), len(resource_ids))}
+            return (
+                404,
+                {
+                    "message": "The resources with the given ids do not exist in the given environment. "
+                    "Only %s of %s resources found." % (len(resources), len(resource_ids))
+                },
+            )
 
         # validate transitions
         if is_resource_state_update:
@@ -1512,14 +1634,20 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
             if started is None:
                 return 500, {"message": "A resource action can only be created with a start datetime."}
 
-            resource_action = data.ResourceAction(environment=env.id, resource_version_ids=resource_ids,
-                                                  action_id=action_id, action=action, started=started)
+            resource_action = data.ResourceAction(
+                environment=env.id, resource_version_ids=resource_ids, action_id=action_id, action=action, started=started
+            )
             await resource_action.insert()
         else:
             # existing
             if resource_action.finished is not None:
-                return 500, {"message": "An resource action can only be updated when it has not been finished yet. This action "
-                                        "finished at %s" % resource_action.finished}
+                return (
+                    500,
+                    {
+                        "message": "An resource action can only be updated when it has not been finished yet. This action "
+                        "finished at %s" % resource_action.finished
+                    },
+                )
 
         if len(messages) > 0:
             resource_action.add_logs(messages)
@@ -1530,7 +1658,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
                     resource_ids,
                     const.LogLevel[msg["level"]].value,
                     datetime.datetime.strptime(msg["timestamp"], const.TIME_ISOFMT),
-                    msg["msg"]
+                    msg["msg"],
                 )
 
         if len(changes) > 0:
@@ -1573,8 +1701,13 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
 
                 await data.ConfigurationModel.mark_done_if_done(env.id, model_version)
 
-                waiting_agents = set([(Id.parse_id(prov).get_agent_name(), res.resource_version_id)
-                                      for res in resources for prov in res.provides])
+                waiting_agents = set(
+                    [
+                        (Id.parse_id(prov).get_agent_name(), res.resource_version_id)
+                        for res in resources
+                        for prov in res.provides
+                    ]
+                )
 
                 for agent, resource_id in waiting_agents:
                     aclient = self.get_agent_client(env.id, agent)
@@ -1651,7 +1784,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
     # Environment handlers
     @protocol.handle(methods.create_environment)
     async def create_environment(
-            self, project_id: uuid.UUID, name: str, repository: str, branch: str, environment_id: uuid.UUID
+        self, project_id: uuid.UUID, name: str, repository: str, branch: str, environment_id: uuid.UUID
     ) -> Apireturn:
         if environment_id is None:
             environment_id = uuid.uuid4()
@@ -1667,12 +1800,12 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         # check if an environment with this name is already defined in this project
         envs = await data.Environment.get_list(project=project_id, name=name)
         if len(envs) > 0:
-            return 500, {"message": "Project %s (id=%s) already has an environment with name %s" %
-                         (project.name, project.id, name)}
+            return (
+                500,
+                {"message": "Project %s (id=%s) already has an environment with name %s" % (project.name, project.id, name)},
+            )
 
-        env = data.Environment(
-            id=environment_id, name=name, project=project_id, repo_url=repository, repo_branch=branch
-        )
+        env = data.Environment(id=environment_id, name=name, project=project_id, repo_url=repository, repo_branch=branch)
         await env.insert()
         return 200, {"environment": env}
 
@@ -1699,7 +1832,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
 
     @protocol.handle(methods.get_environment, environment_id="id")
     async def get_environment(
-            self, environment_id: uuid.UUID, versions: Optional[int]=None, resources: Optional[int]=None
+        self, environment_id: uuid.UUID, versions: Optional[int] = None, resources: Optional[int] = None
     ) -> Apireturn:
         versions = 0 if versions is None else int(versions)
         resources = 0 if resources is None else int(resources)
@@ -1749,11 +1882,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         setting = env._settings[key]
         if setting.recompile:
             LOGGER.info("Environment setting %s changed. Recompiling with update = %s", key, setting.update)
-            metadata = {
-                "message": "Recompile for modified setting",
-                "type": "setting",
-                "setting": key
-            }
+            metadata = {"message": "Recompile for modified setting", "type": "setting", "setting": key}
             await self._async_recompile(env, setting.update, metadata=metadata)
 
         if setting.agent_restart:
@@ -1813,7 +1942,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
 
         return 200
 
-    async def _async_recompile(self, env: data.Environment, update_repo: bool, metadata: JsonType={}) -> None:
+    async def _async_recompile(self, env: data.Environment, update_repo: bool, metadata: JsonType = {}) -> None:
         """
             Recompile an environment in a different thread and taking wait time into account.
         """
@@ -1852,15 +1981,22 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
             err.seek(0)
 
             stop = datetime.datetime.now()
-            return data.Report(started=start, completed=stop, name=name, command=" ".join(cmd),
-                               errstream=err.read().decode(), outstream=out.read().decode(), returncode=returncode)
+            return data.Report(
+                started=start,
+                completed=stop,
+                name=name,
+                command=" ".join(cmd),
+                errstream=err.read().decode(),
+                outstream=out.read().decode(),
+                returncode=returncode,
+            )
 
         finally:
             out.close()
             err.close()
 
     async def _recompile_environment(
-            self, environment_id: uuid.UUID, update_repo: bool=False, wait=0, metadata: JsonType={}
+        self, environment_id: uuid.UUID, update_repo: bool = False, wait=0, metadata: JsonType = {}
     ) -> None:
         """
             Recompile an environment
@@ -1891,16 +2027,16 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
                 # checkout repo
                 if not os.path.exists(os.path.join(project_dir, ".git")):
                     LOGGER.info("Cloning repository into environment directory %s", project_dir)
-                    result = await self._run_compile_stage("Cloning repository", ["git", "clone", env.repo_url, "."],
-                                                           project_dir)
+                    result = await self._run_compile_stage(
+                        "Cloning repository", ["git", "clone", env.repo_url, "."], project_dir
+                    )
                     stages.append(result)
                     if result.returncode > 0:
                         return
 
                 elif update_repo:
                     LOGGER.info("Fetching changes from repo %s", env.repo_url)
-                    result = await self._run_compile_stage("Fetching changes", ["git", "fetch", env.repo_url],
-                                                           project_dir)
+                    result = await self._run_compile_stage("Fetching changes", ["git", "fetch", env.repo_url], project_dir)
                     stages.append(result)
                 if env.repo_branch:
                     # verify if branch is correct
@@ -1913,34 +2049,45 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
                     out, _, _ = await asyncio.gather(
                         sub_process.stdout.read_until_close(),
                         sub_process.stderr.read_until_close(),
-                        sub_process.wait_for_exit(raise_error=False)
+                        sub_process.wait_for_exit(raise_error=False),
                     )
 
                     o = re.search(r"\* ([^\s]+)$", out.decode(), re.MULTILINE)
                     if o is not None and env.repo_branch != o.group(1):
                         LOGGER.info("Repository is at %s branch, switching to %s", o.group(1), env.repo_branch)
-                        result = await self._run_compile_stage("switching branch", ["git", "checkout", env.repo_branch],
-                                                               project_dir)
+                        result = await self._run_compile_stage(
+                            "switching branch", ["git", "checkout", env.repo_branch], project_dir
+                        )
                         stages.append(result)
 
                 if update_repo:
                     result = await self._run_compile_stage("Pulling updates", ["git", "pull"], project_dir)
                     stages.append(result)
                     LOGGER.info("Installing and updating modules")
-                    result = await self._run_compile_stage("Installing modules", inmanta_path + ["modules", "install"],
-                                                           project_dir,
-                                                           env=os.environ.copy())
+                    result = await self._run_compile_stage(
+                        "Installing modules", inmanta_path + ["modules", "install"], project_dir, env=os.environ.copy()
+                    )
                     stages.append(result)
-                    result = await self._run_compile_stage("Updating modules", inmanta_path + ["modules", "update"],
-                                                           project_dir,
-                                                           env=os.environ.copy())
+                    result = await self._run_compile_stage(
+                        "Updating modules", inmanta_path + ["modules", "update"], project_dir, env=os.environ.copy()
+                    )
                     stages.append(result)
 
             LOGGER.info("Recompiling configuration model")
             server_address = opt.server_address.get()
             server_port = opt.transport_port.get()
-            cmd = inmanta_path + ["-vvv", "export", "-e", str(environment_id), "--server_address", server_address,
-                                  "--server_port", str(server_port), "--metadata", json.dumps(metadata)]
+            cmd = inmanta_path + [
+                "-vvv",
+                "export",
+                "-e",
+                str(environment_id),
+                "--server_address",
+                server_address,
+                "--server_port",
+                str(server_port),
+                "--metadata",
+                json.dumps(metadata),
+            ]
             if config.Config.get("server", "auth", False):
                 token = encode_token(["compiler", "api"], str(environment_id))
                 cmd.append("--token")
@@ -1981,7 +2128,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
 
     @protocol.handle(methods.get_reports, env="tid")
     async def get_reports(
-            self, env: data.Environment, start: Optional[str]=None, end: Optional[str]=None, limit: Optional[int]=None
+        self, env: data.Environment, start: Optional[str] = None, end: Optional[str] = None, limit: Optional[int] = None
     ) -> Apireturn:
         argscount = len([x for x in [start, end, limit] if x is not None])
         if argscount == 3:
@@ -2012,10 +2159,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
     async def decomission_environment(self, env: data.Environment, metadata: JsonType) -> Apireturn:
         version = int(time.time())
         if metadata is None:
-            metadata = {
-                "message": "Decommission of environment",
-                "type": "api"
-            }
+            metadata = {"message": "Decommission of environment", "type": "api"}
         result = await self.put_version(env, version, [], {}, [], {const.EXPORT_META_DATA: metadata})
         return result, {"version": version}
 

--- a/tests/compiler/test_defaults.py
+++ b/tests/compiler/test_defaults.py
@@ -198,12 +198,14 @@ typedef Server2 as Server(b="b")
 Server2()
 
 implement Server using std::none
-""")
+"""
+    )
     compiler.do_compile()
 
 
 def test_default_on_relation(snippetcompiler):
-    snippetcompiler.setup_for_snippet("""
+    snippetcompiler.setup_for_snippet(
+        """
 entity Server:
     string a="a"
     string b
@@ -222,5 +224,6 @@ Server2()
 
 implement Server using std::none
 implement Option using std::none
-""")
+"""
+    )
     compiler.do_compile()

--- a/tests/compiler/test_docs.py
+++ b/tests/compiler/test_docs.py
@@ -34,10 +34,7 @@ Each file needs to be associated with a host
 """
     )
     (types, _) = compiler.do_compile()
-    assert (
-        types["__config__::File"].get_attribute("host").comment.strip()
-        == "Each file needs to be associated with a host"
-    )
+    assert types["__config__::File"].get_attribute("host").comment.strip() == "Each file needs to be associated with a host"
 
 
 def test_doc_string_on_relation(snippetcompiler):
@@ -56,14 +53,8 @@ Each file needs to be associated with a host
 """
     )
     (types, _) = compiler.do_compile()
-    assert (
-        types["__config__::File"].get_attribute("host").comment.strip()
-        == "Each file needs to be associated with a host"
-    )
-    assert (
-        types["__config__::Host"].get_attribute("file").comment.strip()
-        == "Each file needs to be associated with a host"
-    )
+    assert types["__config__::File"].get_attribute("host").comment.strip() == "Each file needs to be associated with a host"
+    assert types["__config__::Host"].get_attribute("file").comment.strip() == "Each file needs to be associated with a host"
 
 
 def test_function_in_typedef(snippetcompiler):
@@ -96,10 +87,7 @@ typedef foo as string matching /^a+$/
 """
     )
     (types, _) = compiler.do_compile()
-    assert (
-        types["__config__::foo"].comment.strip()
-        == 'Foo is a stringtype that only allows "a"'
-    )
+    assert types["__config__::foo"].comment.strip() == 'Foo is a stringtype that only allows "a"'
 
 
 def test_doc_string_on_typedefault(snippetcompiler):
@@ -116,10 +104,7 @@ typedef Foo as File(x=5)
 """
     )
     (types, _) = compiler.do_compile()
-    assert (
-        types["__config__::Foo"].comment.strip()
-        == 'Foo is a stringtype that only allows "a"'
-    )
+    assert types["__config__::Foo"].comment.strip() == 'Foo is a stringtype that only allows "a"'
 
 
 def test_doc_string_on_impl(snippetcompiler):

--- a/tests/compiler/test_error_explainer.py
+++ b/tests/compiler/test_error_explainer.py
@@ -45,7 +45,9 @@ Thing(name="a")
     with pytest.raises(AttributeException) as e:
         compiler.do_compile()
 
-    assert ExplainerFactory().explain_and_format(e.value) == """
+    assert (
+        ExplainerFactory().explain_and_format(e.value)
+        == """
 Exception explanation
 =====================
 The compiler could not figure out how to execute this model.
@@ -72,7 +74,9 @@ The procedure to solve this is the following:
 2. Report a bug to the inmanta issue tracker at https://github.com/inmanta/inmanta/issues or directly contact inmanta. This is a priority issue to us, so you will be helped rapidly and by reporting the problem, we can fix it properly.
 3. [does not apply here] If the exception is on the reverse relation, try to give a hint by explicitly using the problematic relation.
 4. Simplify the model by relying less on `is defined` but use a boolean instead.
-""" % {"dir": snippetcompiler.project_dir}  # noqa: E501
+"""  # noqa: E501
+        % {"dir": snippetcompiler.project_dir}
+    )
 
 
 def test_optional_loop_forward_tty(snippetcompiler):
@@ -100,7 +104,9 @@ Thing(name="a")
 
     value = ExplainerFactory().explain_and_format(e.value, plain=False)
 
-    assert value == """
+    assert (
+        value
+        == """
 \033[1mException explanation
 =====================\033[0m
 The compiler could not figure out how to execute this model.
@@ -127,7 +133,9 @@ The procedure to solve this is the following:
 2. Report a bug to the inmanta issue tracker at https://github.com/inmanta/inmanta/issues or directly contact inmanta. This is a priority issue to us, so you will be helped rapidly and by reporting the problem, we can fix it properly.
 3. [does not apply here] If the exception is on the reverse relation, try to give a hint by explicitly using the problematic relation.
 4. Simplify the model by relying less on `is defined` but use a boolean instead.
-""" % {"dir": snippetcompiler.project_dir}  # noqa: E501
+"""  # noqa: E501
+        % {"dir": snippetcompiler.project_dir}
+    )
 
 
 def test_optional_loop_reverse(snippetcompiler):
@@ -154,7 +162,9 @@ Thing(name="a")
     with pytest.raises(AttributeException) as e:
         compiler.do_compile()
 
-    assert ExplainerFactory().explain_and_format(e.value) == """
+    assert (
+        ExplainerFactory().explain_and_format(e.value)
+        == """
 Exception explanation
 =====================
 The compiler could not figure out how to execute this model.
@@ -181,7 +191,9 @@ The procedure to solve this is the following:
 2. Report a bug to the inmanta issue tracker at https://github.com/inmanta/inmanta/issues or directly contact inmanta. This is a priority issue to us, so you will be helped rapidly and by reporting the problem, we can fix it properly.
 3. [applies] If the exception is on the reverse relation, try to give a hint by explicitly using the problematic relation: self.other = t.
 4. Simplify the model by relying less on `is defined` but use a boolean instead.
-""" % {"dir": snippetcompiler.project_dir}  # noqa: E501
+"""  # noqa: E501
+        % {"dir": snippetcompiler.project_dir}
+    )
 
 
 def test_optional_loop_list(snippetcompiler):
@@ -210,7 +222,9 @@ t.other = Thing(name="b")
         compiler.do_compile()
 
     print(ExplainerFactory().explain_and_format(e.value))
-    assert ExplainerFactory().explain_and_format(e.value) == """
+    assert (
+        ExplainerFactory().explain_and_format(e.value)
+        == """
 Exception explanation
 =====================
 The compiler could not figure out how to execute this model.
@@ -240,4 +254,6 @@ The procedure to solve this is the following
 3. [applies] If the exception is on the reverse relation, try to give a hint by explicitly using the problematic relation: self.other = t
 4. Simplify the model by reducing the number of implements calls that pass a list into a plugin function in their when clause.
 
-""" % {"dir": snippetcompiler.project_dir}  # noqa: E501
+"""  # noqa: E501
+        % {"dir": snippetcompiler.project_dir}
+    )

--- a/tests/compiler/test_execution.py
+++ b/tests/compiler/test_execution.py
@@ -154,22 +154,13 @@ a.requires = b.provides
     # a.requires = b  ==> b.provides = a
     # a.requires = b.provides => a.requires = a ==> a.provides = a
 
-    ab = [
-        alpha.get_attribute("name").get_value()
-        for alpha in a.get_attribute("requires").get_value()
-    ]
+    ab = [alpha.get_attribute("name").get_value() for alpha in a.get_attribute("requires").get_value()]
     assert sorted(ab) == ["a", "b"]
 
-    ab = [
-        alpha.get_attribute("name").get_value()
-        for alpha in a.get_attribute("provides").get_value()
-    ]
+    ab = [alpha.get_attribute("name").get_value() for alpha in a.get_attribute("provides").get_value()]
     assert sorted(ab) == ["a"]
 
-    ab = [
-        alpha.get_attribute("name").get_value()
-        for alpha in b.get_attribute("provides").get_value()
-    ]
+    ab = [alpha.get_attribute("name").get_value() for alpha in b.get_attribute("provides").get_value()]
     assert sorted(ab) == ["a"]
 
 
@@ -215,12 +206,7 @@ b.alink = a
     d = root.lookup("d").get_value()
 
     def get_names(a):
-        return sorted(
-            [
-                alpha.get_attribute("name").get_value()
-                for alpha in a.get_attribute("alink").get_value()
-            ]
-        )
+        return sorted([alpha.get_attribute("name").get_value() for alpha in a.get_attribute("alink").get_value()])
 
     assert get_names(a) == ["a", "b", "c", "d"]
     assert get_names(b) == ["a", "b", "c", "d"]
@@ -270,12 +256,7 @@ b.alink = a
     d = root.lookup("d").get_value()
 
     def get_names(a, name="alink"):
-        return sorted(
-            [
-                alpha.get_attribute("name").get_value()
-                for alpha in a.get_attribute(name).get_value()
-            ]
-        )
+        return sorted([alpha.get_attribute("name").get_value() for alpha in a.get_attribute(name).get_value()])
 
     assert get_names(a) == ["a", "b", "c", "d"]
     assert get_names(b) == ["a", "b", "c", "d"]
@@ -361,15 +342,7 @@ a = Thing(id=5, value=StringWrapper(value="{{a.id}}"))
     (_, scopes) = compiler.do_compile()
     root = scopes.get_child("__config__")
 
-    assert (
-        "5"
-        == root.lookup("a")
-        .get_value()
-        .lookup("value")
-        .get_value()
-        .lookup("value")
-        .get_value()
-    )
+    assert "5" == root.lookup("a").get_value().lookup("value").get_value().lookup("value").get_value()
 
 
 def test_veryhardsequencing(snippetcompiler):

--- a/tests/compiler/test_index.py
+++ b/tests/compiler/test_index.py
@@ -342,8 +342,10 @@ f1h1=File(host=h1,name="f1")
 f2h1=File(host=h1,name="f2")
 
 z = h1.files[name="f1"]
-""", "short index lookup is only possible on bi-drectional relations, __config__::Host.files is unidirectional"
-     " (reported in h1.files[[('name', 'f1')]] ({dir}/main.cf:31))")
+""",
+        "short index lookup is only possible on bi-drectional relations, __config__::Host.files is unidirectional"
+        " (reported in h1.files[[('name', 'f1')]] ({dir}/main.cf:31))",
+    )
 
 
 def test_511_index_on_default(snippetcompiler):

--- a/tests/compiler/test_relations.py
+++ b/tests/compiler/test_relations.py
@@ -208,9 +208,7 @@ std::print([c1,c2,lf1,lf2,lf3,lf4,lf5,lf6,lf7,lf8])
 
     (types, _) = compiler.do_compile()
     for lf in types["__config__::LogFile"].get_all_instances():
-        assert lf.get_attribute("members").get_value() == len(
-            lf.get_attribute("collectors").get_value()
-        )
+        assert lf.get_attribute("members").get_value() == len(lf.get_attribute("collectors").get_value())
 
 
 def test_new_relation_syntax(snippetcompiler):

--- a/tests/compiler/test_requires.py
+++ b/tests/compiler/test_requires.py
@@ -117,8 +117,7 @@ post.requires = inter
     warning = [
         x
         for x in caplog.records
-        if x.msg
-        == "The resource %s had requirements before flattening, but not after flattening."
+        if x.msg == "The resource %s had requirements before flattening, but not after flattening."
         " Initial set was %s. Perhaps provides relation is not wired through correctly?"
     ]
     assert len(warning) == 1
@@ -144,10 +143,4 @@ f4.requires = f1
         snippetcompiler.do_export()
 
     cyclenames = [r.id.resource_str() for r in e.value.cycle]
-    assert set(cyclenames) == set(
-        [
-            "std::File[Test,path=/f3]",
-            "std::File[Test,path=/f2]",
-            "std::File[Test,path=/f1]",
-        ]
-    )
+    assert set(cyclenames) == set(["std::File[Test,path=/f3]", "std::File[Test,path=/f2]", "std::File[Test,path=/f1]"])

--- a/tests/compiler/test_resolution.py
+++ b/tests/compiler/test_resolution.py
@@ -237,6 +237,5 @@ def test_672_missing_type(snippetcompiler):
         end
 
         """,
-        "could not find type Testt in namespace __config__"
-        " (reported in Implementation(test) ({dir}/main.cf:5))",
+        "could not find type Testt in namespace __config__" " (reported in Implementation(test) ({dir}/main.cf:5))",
     )

--- a/tests/data/compile_138/libs/lma/plugins/__init__.py
+++ b/tests/data/compile_138/libs/lma/plugins/__init__.py
@@ -19,6 +19,7 @@
 from inmanta import ast
 from inmanta.plugins import plugin
 
+
 @plugin
 def get_lma(host: "std::Host") -> "bool":
     host.host_groups

--- a/tests/data/modules/exp/plugins/__init__.py
+++ b/tests/data/modules/exp/plugins/__init__.py
@@ -24,6 +24,7 @@ class Test(resources.ManagedResource):
     """
         This class represents a service on a system.
     """
+
     fields = ("name", "agent", "field1")
 
     @staticmethod
@@ -36,4 +37,5 @@ class Test2(resources.PurgeableResource):
     """
         This class represents a service on a system.
     """
+
     fields = ("name", "agent", "mydict", "mylist")

--- a/tests/data/project/libs/std/plugins/__init__.py
+++ b/tests/data/project/libs/std/plugins/__init__.py
@@ -47,7 +47,7 @@ import jinja2
 
 
 @plugin
-def unique_file(prefix: "string", seed: "string", suffix: "string", length: "number"=20) -> "string":
+def unique_file(prefix: "string", seed: "string", suffix: "string", length: "number" = 20) -> "string":
     return prefix + hashlib.md5(seed.encode("utf-8")).hexdigest() + suffix
 
 
@@ -57,7 +57,6 @@ engine_cache = None
 
 
 class JinjaDynamicProxy(DynamicProxy):
-
     def __init__(self, instance):
         super(JinjaDynamicProxy, self).__init__(instance)
 
@@ -100,7 +99,6 @@ class JinjaDynamicProxy(DynamicProxy):
 
 
 class SequenceProxy(JinjaDynamicProxy):
-
     def __init__(self, iterator):
         JinjaDynamicProxy.__init__(self, iterator)
 
@@ -151,7 +149,6 @@ class IteratorProxy(JinjaDynamicProxy):
 
 
 class ResolverContext(jinja2.runtime.Context):
-
     def resolve(self, key):
         resolver = self.parent["{{resolver"]
         try:
@@ -184,10 +181,13 @@ def _get_template_engine(ctx):
 
     # register all plugins as filters
     for name, cls in ctx.get_compiler().get_plugins().items():
+
         def curywrapper(func):
             def safewrapper(*args):
                 return JinjaDynamicProxy.return_value(func(*args))
+
             return safewrapper
+
         env.filters[name.replace("::", ".")] = curywrapper(cls)
 
     engine_cache = env
@@ -236,7 +236,7 @@ def dir_before_file(model, resources):
     for host, files in per_host.items():
         for hfile in files:
             for pdir in per_host_dirs[host]:
-                if hfile.path != pdir.path and hfile.path[:len(pdir.path)] == pdir.path:
+                if hfile.path != pdir.path and hfile.path[: len(pdir.path)] == pdir.path:
                     # Make the File resource require the directory
                     hfile.requires.add(pdir)
 
@@ -252,7 +252,7 @@ def get_passwords(pw_file):
                     i = line.index("=")
 
                     try:
-                        records[line[:i].strip()] = line[i + 1:].strip()
+                        records[line[:i].strip()] = line[i + 1 :].strip()
                     except ValueError:
                         pass
 
@@ -266,7 +266,7 @@ def save_passwords(pw_file, records):
 
 
 @plugin
-def generate_password(context: Context, pw_id: "string", length: "number"=20) -> "string":
+def generate_password(context: Context, pw_id: "string", length: "number" = 20) -> "string":
     """
     Generate a new random password and store it in the data directory of the
     project. On next invocations the stored password will be used.
@@ -335,7 +335,7 @@ def replace(string: "string", old: "string", new: "string") -> "string":
 
 
 @plugin
-def equals(arg1: "any", arg2: "any", desc: "string"=None):
+def equals(arg1: "any", arg2: "any", desc: "string" = None):
     """
         Compare arg1 and arg2
     """
@@ -347,7 +347,7 @@ def equals(arg1: "any", arg2: "any", desc: "string"=None):
 
 
 @plugin("assert")
-def assert_function(expression: "bool", message: "string"=""):
+def assert_function(expression: "bool", message: "string" = ""):
     """
         Raise assertion error is expression is false
     """
@@ -413,7 +413,7 @@ def key_sort(items: "list", key: "any") -> "list":
 
 
 @plugin
-def timestamp(dummy: "any"=None) -> "number":
+def timestamp(dummy: "any" = None) -> "number":
     """
         Return an integer with the current unix timestamp
 
@@ -437,7 +437,7 @@ def type(obj: "any") -> "any":
 
 
 @plugin
-def sequence(i: "number", start: "number"=0, offset: "number"=0) -> "list":
+def sequence(i: "number", start: "number" = 0, offset: "number" = 0) -> "list":
     """
         Return a sequence of i numbers, starting from zero or start if supplied.
     """
@@ -552,7 +552,7 @@ def each(item_list: "list", expression: "expression") -> "list":
 
 
 @plugin
-def order_by(item_list: "list", expression: "expression"=None, comparator: "expression"=None) -> "list":
+def order_by(item_list: "list", expression: "expression" = None, comparator: "expression" = None) -> "list":
     """
         This operation orders a list using the object returned by
         expression and optionally using the comparator function to determine
@@ -630,8 +630,7 @@ def select_attr(item_list: "list", attr: "string") -> "list":
 
 
 @plugin
-def select_many(item_list: "list", expression: "expression",
-                selector_expression: "expression"=None) -> "list":
+def select_many(item_list: "list", expression: "expression", selector_expression: "expression" = None) -> "list":
     """
         This query method is similar to the select query but it merges
         the results into one list.
@@ -741,8 +740,7 @@ def determine_path(ctx, module_dir, path):
     if parts[0] == "":
         module_path = Project.get().project_path
     elif parts[0] not in modules:
-        raise Exception("Module %s does not exist for path %s" %
-                        (parts[0], path))
+        raise Exception("Module %s does not exist for path %s" % (parts[0], path))
     else:
         module_path = modules[parts[0]]._path
 
@@ -761,7 +759,7 @@ def get_file_content(ctx, module_dir, path):
     if not os.path.isfile(filename):
         raise Exception("%s isn't a valid file (%s)" % (path, filename))
 
-    file_fd = open(filename, 'r')
+    file_fd = open(filename, "r")
     if file_fd is None:
         raise Exception("Unable to open file %s" % filename)
 
@@ -776,7 +774,7 @@ def source(ctx: Context, path: "string") -> "string":
     """
         Return the textual contents of the given file
     """
-    return get_file_content(ctx, 'files', path)
+    return get_file_content(ctx, "files", path)
 
 
 @plugin
@@ -784,7 +782,7 @@ def file(ctx: Context, path: "string") -> "string":
     """
         Return the textual contents of the given file
     """
-    filename = determine_path(ctx, 'files', path)
+    filename = determine_path(ctx, "files", path)
     any
     if filename is None:
         raise Exception("%s does not exist" % path)
@@ -817,7 +815,7 @@ def familyof(member: "std::OS", family: "string") -> "bool":
 
 
 @plugin
-def getfact(context: Context, resource: "any", fact_name: "string", default_value: "any"=None) -> "any":
+def getfact(context: Context, resource: "any", fact_name: "string", default_value: "any" = None) -> "any":
     """
         Retrieve a fact of the given resource
     """
@@ -859,8 +857,9 @@ def getfact(context: Context, resource: "any", fact_name: "string", default_valu
             unknown_parameters.append({"resource": resource_id, "parameter": fact_name, "source": "fact"})
 
     except ConnectionRefusedError:
-        logging.getLogger(__name__).warning("Param %s of resource %s is unknown because connection to server was refused",
-                                            fact_name, resource_id)
+        logging.getLogger(__name__).warning(
+            "Param %s of resource %s is unknown because connection to server was refused", fact_name, resource_id
+        )
         fact_value = Unknown(source=resource)
         unknown_parameters.append({"resource": resource_id, "parameter": fact_name, "source": "fact"})
 
@@ -892,6 +891,7 @@ def environment_name(ctx: Context) -> "string":
 
     def call():
         return ctx.get_client().get_environment(id=env)
+
     result = ctx.run_sync(call)
     if result.code != 200:
         return Unknown(source=env)
@@ -931,7 +931,7 @@ def server_ca() -> "string":
     if not os.path.isfile(filename):
         raise Exception("%s isn't a valid file" % filename)
 
-    file_fd = open(filename, 'r')
+    file_fd = open(filename, "r")
     if file_fd is None:
         raise Exception("Unable to open file %s" % filename)
 
@@ -977,7 +977,7 @@ def server_port() -> "number":
 
 
 @plugin
-def get_env(name: "string", default_value: "string"=None) -> "string":
+def get_env(name: "string", default_value: "string" = None) -> "string":
     env = os.environ
     if name in env:
         return env[name]
@@ -988,7 +988,7 @@ def get_env(name: "string", default_value: "string"=None) -> "string":
 
 
 @plugin
-def get_env_int(name: "string", default_value: "number"=None) -> "number":
+def get_env_int(name: "string", default_value: "number" = None) -> "number":
     env = os.environ
     if name in env:
         return int(env[name])

--- a/tests/data/project/libs/std/plugins/resources.py
+++ b/tests/data/project/libs/std/plugins/resources.py
@@ -52,7 +52,7 @@ def store_file(exporter, obj):
         return content
 
     elif content.startswith(FILE_SOURCE):
-        parts = urllib.parse.urlparse(content[len(FILE_SOURCE):])
+        parts = urllib.parse.urlparse(content[len(FILE_SOURCE) :])
 
         if parts.scheme == "file":
             with open(parts.path, "rb") as fd:
@@ -63,8 +63,7 @@ def store_file(exporter, obj):
                 content = fd.read()
 
         else:
-            raise Exception("%s scheme not support for file %s" %
-                            (parts.scheme, parts.path))
+            raise Exception("%s scheme not support for file %s" % (parts.scheme, parts.path))
 
     if len(obj.prefix_content) > 0:
         content = generate_content(obj.prefix_content, obj.content_seperator) + obj.content_seperator + content
@@ -79,6 +78,7 @@ class Service(Resource):
     """
         This class represents a service on a system.
     """
+
     fields = ("onboot", "state", "name", "reload")
 
 
@@ -87,6 +87,7 @@ class File(PurgeableResource):
     """
         A file on a filesystem
     """
+
     fields = ("path", "owner", "hash", "group", "permissions", "reload")
     map = {"hash": store_file, "permissions": lambda y, x: int(x.mode)}
 
@@ -96,6 +97,7 @@ class Directory(PurgeableResource):
     """
         A directory on a filesystem
     """
+
     fields = ("path", "owner", "group", "permissions", "reload")
     map = {"permissions": lambda y, x: int(x.mode)}
 
@@ -105,6 +107,7 @@ class Package(Resource):
     """
         A software package installed on an operating system.
     """
+
     fields = ("name", "state", "reload")
 
 
@@ -113,6 +116,7 @@ class Symlink(PurgeableResource):
     """
         A symbolic link on the filesystem
     """
+
     fields = ("source", "target", "reload")
 
 
@@ -121,6 +125,7 @@ class AgentConfig(PurgeableResource):
     """
         A resource that can modify the agentmap for autostarted agents
     """
+
     fields = ("agentname", "uri", "autostart")
 
     @staticmethod
@@ -139,6 +144,7 @@ class PosixFileProvider(ResourceHandler):
     """
         This handler can deploy files on a unix system
     """
+
     def check_resource(self, ctx: HandlerContext, resource: File) -> File:
         current = resource.clone(purged=False, reload=resource.reload, hash=0)
 
@@ -213,6 +219,7 @@ class SystemdService(ResourceHandler):
     """
         A handler for services on systems that use systemd
     """
+
     def __init__(self, agent, io=None):
         super().__init__(agent, io)
 
@@ -232,7 +239,7 @@ class SystemdService(ResourceHandler):
 
         exists = self._io.run(self._systemd_path, ["status", "%s.service" % resource.name])[0]
 
-        if re.search('Loaded: error', exists):
+        if re.search("Loaded: error", exists):
             raise ResourceNotFoundExcpetion("The %s service does not exist" % resource.name)
 
         running = self._io.run(self._systemd_path, ["is-active", "%s.service" % resource.name])[2] == 0
@@ -291,15 +298,19 @@ class ServiceService(ResourceHandler):
     """
         A handler for services on systems that use service
     """
+
     def available(self, resource):
-        return (self._io.file_exists("/sbin/chkconfig") and self._io.file_exists("/sbin/service") and
-                not self._io.file_exists("/usr/bin/systemctl"))
+        return (
+            self._io.file_exists("/sbin/chkconfig")
+            and self._io.file_exists("/sbin/service")
+            and not self._io.file_exists("/usr/bin/systemctl")
+        )
 
     def check_resource(self, ctx, resource):
         current = resource.clone()
         exists = self._io.run("/sbin/chkconfig", ["--list", resource.name])[0]
 
-        if re.search('error reading information on service', exists):
+        if re.search("error reading information on service", exists):
             raise ResourceNotFoundExcpetion("The %s service does not exist" % resource.name)
 
         enabled = ":on" in self._io.run("/sbin/chkconfig", ["--list", resource.name])[0]
@@ -357,9 +368,11 @@ class YumPackage(ResourceHandler):
     """
         A Package handler that uses yum
     """
+
     def available(self, resource):
-        return (self._io.file_exists("/usr/bin/rpm") or self._io.file_exists("/bin/rpm")) \
-            and (self._io.file_exists("/usr/bin/yum") or self._io.file_exists("/usr/bin/dnf"))
+        return (self._io.file_exists("/usr/bin/rpm") or self._io.file_exists("/bin/rpm")) and (
+            self._io.file_exists("/usr/bin/yum") or self._io.file_exists("/usr/bin/dnf")
+        )
 
     def _parse_fields(self, lines):
         props = {}
@@ -412,8 +425,7 @@ class YumPackage(ResourceHandler):
         yum_output = self._run_yum(["check-update", resource.name])
         lines = yum_output[0].split("\n")
 
-        data = {"state": state, "version": output["Version"],
-                "release": output["Release"], "update": None}
+        data = {"state": state, "version": output["Version"], "release": output["Release"], "update": None}
 
         if len(lines) > 0:
             parts = re.search("([^\s]+)\s+([^\s]+)\s+([^\s]+)", lines[0])
@@ -470,6 +482,7 @@ class DirectoryHandler(ResourceHandler):
 
         TODO: add recursive operations
     """
+
     def check_resource(self, ctx, resource):
         current = resource.clone(purged=False)
 
@@ -514,6 +527,7 @@ class SymlinkProvider(ResourceHandler):
     """
         This handler can deploy symlinks on unix systems
     """
+
     def available(self, resource):
         return self._io.file_exists("/usr/bin/ln") or self._io.file_exists("/bin/ln")
 

--- a/tests/miniapp.py
+++ b/tests/miniapp.py
@@ -29,7 +29,6 @@ inmanta.const.SHUTDOWN_GRACE_HARD = 2
 
 
 class MiniApp:
-
     def __init__(self):
         self.running = True
         self.lock = threading.Semaphore(0)
@@ -61,7 +60,7 @@ class MiniApp:
         print("DONE")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print("Start")
     a = MiniApp()
     setup_signal_handlers(a.stop)

--- a/tests/server/test_incremental_deploy.py
+++ b/tests/server/test_incremental_deploy.py
@@ -85,13 +85,7 @@ class MultiVersionSetup(object):
         assert False
 
     def make_resource(
-        self,
-        name: str,
-        value: str,
-        version: int,
-        agent: str = "agent1",
-        requires: List[str] = [],
-        send_event: bool = False,
+        self, name: str, value: str, version: int, agent: str = "agent1", requires: List[str] = [], send_event: bool = False
     ) -> str:
         """
             requires: list of resource identifiers
@@ -108,13 +102,7 @@ class MultiVersionSetup(object):
         return id
 
     def add_resource(
-        self,
-        name: str,
-        scenario: str,
-        increment: bool,
-        agent="agent1",
-        requires=[],
-        send_event: bool = False,
+        self, name: str, scenario: str, increment: bool, agent="agent1", requires=[], send_event: bool = False
     ) -> str:
         v = self.firstversion
         rid = "test::Resource[%s,key=%s]" % (agent, name)
@@ -141,12 +129,7 @@ class MultiVersionSetup(object):
         config.Config.set("config", "agent-deploy-interval", "0")
         config.Config.set("config", "agent-repair-interval", "0")
 
-        a = Agent(
-            hostname="node1",
-            environment=environment,
-            agent_map={e: "localhost" for e in endpoints},
-            code_loader=False,
-        )
+        a = Agent(hostname="node1", environment=environment, agent_map={e: "localhost" for e in endpoints}, code_loader=False)
         for e in endpoints:
             a.add_end_point_name(e)
         await a.start()
@@ -158,12 +141,7 @@ class MultiVersionSetup(object):
         for version in range(0, len(self.versions)):
             if self.versions[version]:
                 res = await serverdirect.put_version(
-                    env=env,
-                    version=version,
-                    resources=self.versions[version],
-                    unknowns=[],
-                    version_info={},
-                    resource_state={},
+                    env=env, version=version, resources=self.versions[version], unknowns=[], version_info={}, resource_state={}
                 )
                 assert res == 200
 
@@ -202,9 +180,7 @@ class MultiVersionSetup(object):
                 env, agent, version=None, incremental_deploy=True, sid=sid
             )
 
-            assert sorted([x["resource_id"] for x in payload["resources"]]) == sorted(
-                results
-            )
+            assert sorted([x["resource_id"] for x in payload["resources"]]) == sorted(results)
             allresources.update({r["resource_id"]: r for r in payload["resources"]})
 
         return allresources
@@ -248,22 +224,12 @@ async def test_deploy(server, agent: Agent, environment, caplog):
                     "requires": ["test::Resource[agent2,key=key4],v=%d" % version],
                     "purged": True,
                 },
-                {
-                    "key": "key4",
-                    "id": "test::Resource[agent2,key=key4],v=%d" % version,
-                    "send_event": False,
-                    "requires": [],
-                },
+                {"key": "key4", "id": "test::Resource[agent2,key=key4],v=%d" % version, "send_event": False, "requires": []},
             ]
 
         resources = make_resources(version)
         res = await serverdirect.put_version(
-            env=env,
-            version=version,
-            resources=resources,
-            unknowns=[],
-            version_info={},
-            resource_state={},
+            env=env, version=version, resources=resources, unknowns=[], version_info={}, resource_state={}
         )
         assert res == 200
 
@@ -298,12 +264,7 @@ async def test_deploy(server, agent: Agent, environment, caplog):
         v2 = version + 1
         resources = make_resources(v2)
         res = await serverdirect.put_version(
-            env=env,
-            version=v2,
-            resources=resources,
-            unknowns=[],
-            version_info={},
-            resource_state={},
+            env=env, version=v2, resources=resources, unknowns=[], version_info={}, resource_state={}
         )
         assert res == 200
 
@@ -313,13 +274,9 @@ async def test_deploy(server, agent: Agent, environment, caplog):
         assert len(payload["resources"]) == 0
 
         # Cannot request increment for specific version
-        result, _ = await serverdirect.get_resources_for_agent(
-            env, "agent1", version=version, incremental_deploy=True, sid=sid
-        )
+        result, _ = await serverdirect.get_resources_for_agent(env, "agent1", version=version, incremental_deploy=True, sid=sid)
         assert result == 500
-        result, _ = await serverdirect.get_resources_for_agent(
-            env, "agent1", version=v2, incremental_deploy=True, sid=sid
-        )
+        result, _ = await serverdirect.get_resources_for_agent(env, "agent1", version=v2, incremental_deploy=True, sid=sid)
         assert result == 500
 
     for record in caplog.records:
@@ -363,9 +320,7 @@ async def test_deploy_scenarios(server, agent: Agent, environment, caplog):
 
 
 @pytest.mark.asyncio
-async def test_deploy_scenarios_removed_req_by_increment(
-    server, agent: Agent, environment, caplog
-):
+async def test_deploy_scenarios_removed_req_by_increment(server, agent: Agent, environment, caplog):
     with caplog.at_level(logging.WARNING):
         # acquire raw server
         serverdirect = server.get_slice(SLICE_SERVER)
@@ -410,9 +365,7 @@ async def test_deploy_scenarios_removed_req_by_increment2(server, environment, c
             resources = await setup.setup(serverdirect, env, sid)
             print(sorted(resources[id2]["attributes"]["requires"]))
             print(sorted(sorted([id3, id4])))
-            assert sorted(
-                [strip_version(r) for r in resources[id2]["attributes"]["requires"]]
-            ) == sorted([id3, id4])
+            assert sorted([strip_version(r) for r in resources[id2]["attributes"]["requires"]]) == sorted([id3, id4])
 
         finally:
             await agent.stop()
@@ -422,9 +375,7 @@ async def test_deploy_scenarios_removed_req_by_increment2(server, environment, c
 
 
 @pytest.mark.asyncio
-async def test_deploy_scenarios_added_by_send_event(
-    server, agent: Agent, environment, caplog
-):
+async def test_deploy_scenarios_added_by_send_event(server, agent: Agent, environment, caplog):
     with caplog.at_level(logging.WARNING):
         # acquire raw server
         serverdirect = server.get_slice(SLICE_SERVER)
@@ -448,9 +399,7 @@ async def test_deploy_scenarios_added_by_send_event(
 
 
 @pytest.mark.asyncio
-async def test_deploy_scenarios_added_by_send_event_cad(
-    server, agent: Agent, environment, caplog
-):
+async def test_deploy_scenarios_added_by_send_event_cad(server, agent: Agent, environment, caplog):
     # ensure CAD does not change send_event
     with caplog.at_level(logging.WARNING):
         # acquire raw server

--- a/tests/test_2way_protocol.py
+++ b/tests/test_2way_protocol.py
@@ -48,7 +48,6 @@ from inmanta import protocol  # NOQA
 
 
 class SessionSpy(SessionListener, ServerSlice):
-
     def __init__(self):
         ServerSlice.__init__(self, "sessionspy")
         self.expires = 0
@@ -78,7 +77,6 @@ class SessionSpy(SessionListener, ServerSlice):
 
 
 class Agent(protocol.SessionEndpoint):
-
     def __init__(self, name: str, timeout: int = 120, reconnect_delay: int = 5):
         super(Agent, self).__init__(name, timeout, reconnect_delay)
         self.reconnect = 0

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -27,7 +27,6 @@ from utils import assert_equal_ish, UNKWN
 
 
 class Collector(object):
-
     def __init__(self):
         self.values = []
 
@@ -202,44 +201,80 @@ async def test_api(init_dataclasses_and_load_schema):
     code, all_agents = await am.list_agent_processes(None, None)
     assert code == 200
 
-    shouldbe = {'processes': [{'first_seen': UNKWN, 'expired': None, 'hostname': 'ts1',
-                               'last_seen': UNKWN, 'endpoints':
-                               [{'id': UNKWN, 'name': 'agent1', 'process': UNKWN},
-                                {'id': UNKWN, 'name': 'agent2', 'process': UNKWN}],
-                               'environment': env.id},
-                              {'first_seen': UNKWN, 'expired': None, 'hostname': 'ts2',
-                               'last_seen': UNKWN, 'endpoints':
-                               [{'id': UNKWN, 'name': 'agent2', 'process': UNKWN},
-                                {'id': UNKWN, 'name': 'agent3', 'process': UNKWN}],
-                               'environment': env.id},
-                              {'first_seen': UNKWN, 'expired': None, 'hostname': 'ts3',
-                               'last_seen': UNKWN, 'endpoints':
-                               [{'id': UNKWN, 'name': 'agentx', 'process': UNKWN}],
-                               'environment': env3.id}]}
+    shouldbe = {
+        "processes": [
+            {
+                "first_seen": UNKWN,
+                "expired": None,
+                "hostname": "ts1",
+                "last_seen": UNKWN,
+                "endpoints": [
+                    {"id": UNKWN, "name": "agent1", "process": UNKWN},
+                    {"id": UNKWN, "name": "agent2", "process": UNKWN},
+                ],
+                "environment": env.id,
+            },
+            {
+                "first_seen": UNKWN,
+                "expired": None,
+                "hostname": "ts2",
+                "last_seen": UNKWN,
+                "endpoints": [
+                    {"id": UNKWN, "name": "agent2", "process": UNKWN},
+                    {"id": UNKWN, "name": "agent3", "process": UNKWN},
+                ],
+                "environment": env.id,
+            },
+            {
+                "first_seen": UNKWN,
+                "expired": None,
+                "hostname": "ts3",
+                "last_seen": UNKWN,
+                "endpoints": [{"id": UNKWN, "name": "agentx", "process": UNKWN}],
+                "environment": env3.id,
+            },
+        ]
+    }
 
     assert_equal_ish(shouldbe, all_agents, sortby=["hostname", "name"])
-    agentid = all_agents['processes'][0]['sid']
+    agentid = all_agents["processes"][0]["sid"]
 
     code, all_agents = await am.list_agent_processes(env.id, None)
     assert code == 200
 
-    shouldbe = {'processes': [{'first_seen': UNKWN, 'expired': None, 'hostname': 'ts1',
-                               'last_seen': UNKWN, 'endpoints':
-                               [{'id': UNKWN, 'name': 'agent1', 'process': UNKWN},
-                                {'id': UNKWN, 'name': 'agent2', 'process': UNKWN}],
-                               'environment': env.id},
-                              {'first_seen': UNKWN, 'expired': None, 'hostname': 'ts2',
-                               'last_seen': UNKWN, 'endpoints':
-                               [{'id': UNKWN, 'name': 'agent2', 'process': UNKWN},
-                                {'id': UNKWN, 'name': 'agent3', 'process': UNKWN}],
-                               'environment': env.id}]}
+    shouldbe = {
+        "processes": [
+            {
+                "first_seen": UNKWN,
+                "expired": None,
+                "hostname": "ts1",
+                "last_seen": UNKWN,
+                "endpoints": [
+                    {"id": UNKWN, "name": "agent1", "process": UNKWN},
+                    {"id": UNKWN, "name": "agent2", "process": UNKWN},
+                ],
+                "environment": env.id,
+            },
+            {
+                "first_seen": UNKWN,
+                "expired": None,
+                "hostname": "ts2",
+                "last_seen": UNKWN,
+                "endpoints": [
+                    {"id": UNKWN, "name": "agent2", "process": UNKWN},
+                    {"id": UNKWN, "name": "agent3", "process": UNKWN},
+                ],
+                "environment": env.id,
+            },
+        ]
+    }
 
     assert_equal_ish(shouldbe, all_agents, sortby=["hostname", "name"])
 
     code, all_agents = await am.list_agent_processes(env2.id, None)
     assert code == 200
 
-    shouldbe = {'processes': []}
+    shouldbe = {"processes": []}
 
     assert_equal_ish(shouldbe, all_agents)
 
@@ -255,21 +290,23 @@ async def test_api(init_dataclasses_and_load_schema):
 
     code, all_agents = await am.list_agents(None)
     assert code == 200
-    shouldbe = {'agents': [{'name': 'agent1', 'paused': True, 'last_failover': '', 'primary': '',
-                            'environment': env.id, "state": "paused"},
-                           {'name': 'agent2', 'paused': False, 'last_failover': UNKWN,
-                               'primary': UNKWN, 'environment': env.id, "state": "up"},
-                           {'name': 'agent3', 'paused': False, 'last_failover': UNKWN,
-                               'primary': UNKWN, 'environment': env.id, "state": "up"},
-                           {'name': 'agent4', 'paused': False, 'last_failover': '', 'primary': '',
-                            'environment': env2.id, "state": "down"}]}
+    shouldbe = {
+        "agents": [
+            {"name": "agent1", "paused": True, "last_failover": "", "primary": "", "environment": env.id, "state": "paused"},
+            {"name": "agent2", "paused": False, "last_failover": UNKWN, "primary": UNKWN, "environment": env.id, "state": "up"},
+            {"name": "agent3", "paused": False, "last_failover": UNKWN, "primary": UNKWN, "environment": env.id, "state": "up"},
+            {"name": "agent4", "paused": False, "last_failover": "", "primary": "", "environment": env2.id, "state": "down"},
+        ]
+    }
     assert_equal_ish(shouldbe, all_agents, sortby=["name"])
 
     code, all_agents = await am.list_agents(env2)
     assert code == 200
     shouldbe = {
-        'agents': [{'name': 'agent4', 'paused': False, 'last_failover': '', 'primary': '',
-                    'environment': env2.id, "state": "down"}]}
+        "agents": [
+            {"name": "agent4", "paused": False, "last_failover": "", "primary": "", "environment": env2.id, "state": "down"}
+        ]
+    }
     assert_equal_ish(shouldbe, all_agents)
 
 

--- a/tests/test_anchors.py
+++ b/tests/test_anchors.py
@@ -19,7 +19,8 @@ from inmanta import compiler
 
 
 def test_anchors_basic(snippetcompiler):
-    snippetcompiler.setup_for_snippet("""
+    snippetcompiler.setup_for_snippet(
+        """
 entity Test:
     string a = "a"
     string b
@@ -46,7 +47,9 @@ implement Test using a
 typedef Test3 as Test(b="a")
 
 y = Test3(a="xx")
-""", autostd=False)
+""",
+        autostd=False,
+    )
     anchormap = compiler.anchormap()
 
     assert len(anchormap) == 13
@@ -74,7 +77,8 @@ y = Test3(a="xx")
 
 
 def test_anchors_two(snippetcompiler):
-    snippetcompiler.setup_for_snippet("""
+    snippetcompiler.setup_for_snippet(
+        """
 entity Test:
     list a = ["a"]
     dict b
@@ -89,7 +93,9 @@ implementation a for Test:
 end
 
 implement Test using a
-""", autostd=False)
+""",
+        autostd=False,
+    )
     anchormap = compiler.anchormap()
 
     assert len(anchormap) == 5

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,9 +29,7 @@ import signal
 from subprocess import TimeoutExpired
 
 
-def get_command(
-    tmp_dir, stdout_log_level=None, log_file=None, log_level_log_file=None, timed=False
-):
+def get_command(tmp_dir, stdout_log_level=None, log_file=None, log_level_log_file=None, timed=False):
     root_dir = tmp_dir.mkdir("root").strpath
     log_dir = os.path.join(root_dir, "log")
     state_dir = os.path.join(root_dir, "data")
@@ -65,9 +63,7 @@ def get_command(
 def do_run(args, env={}, cwd=None):
     baseenv = os.environ.copy()
     baseenv.update(env)
-    process = subprocess.Popen(
-        args, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=baseenv
-    )
+    process = subprocess.Popen(args, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=baseenv)
     return process
 
 
@@ -148,10 +144,7 @@ def test_verify_that_colorama_package_is_not_present():
             3,
             False,
             False,
-            [
-                r"[a-z.]*[ ]*INFO[\s]+Starting server endpoint",
-                r"[a-z.]*[ ]*DEBUG[\s]+Starting Server Rest Endpoint",
-            ],
+            [r"[a-z.]*[ ]*INFO[\s]+Starting server endpoint", r"[a-z.]*[ ]*DEBUG[\s]+Starting Server Rest Endpoint"],
             [],
         ),
         (
@@ -175,21 +168,14 @@ def test_verify_that_colorama_package_is_not_present():
             2,
             False,
             True,
-            [
-                r"\x1b\[32m[a-z.]*[ ]*INFO[\s]*\x1b\[0m \x1b\[34mStarting server endpoint"
-            ],
-            [
-                r"\x1b\[36m[a-z.]*[ ]*DEBUG[\s]*\x1b\[0m \x1b\[34mStarting Server Rest Endpoint"
-            ],
+            [r"\x1b\[32m[a-z.]*[ ]*INFO[\s]*\x1b\[0m \x1b\[34mStarting server endpoint"],
+            [r"\x1b\[36m[a-z.]*[ ]*DEBUG[\s]*\x1b\[0m \x1b\[34mStarting Server Rest Endpoint"],
         ),
         (
             3,
             True,
             False,
-            [
-                r"[a-z.]*[ ]*INFO[\s]+Starting server endpoint",
-                r"[a-z.]*[ ]*DEBUG[\s]+Starting Server Rest Endpoint",
-            ],
+            [r"[a-z.]*[ ]*INFO[\s]+Starting server endpoint", r"[a-z.]*[ ]*DEBUG[\s]+Starting Server Rest Endpoint"],
             [],
         ),
         (
@@ -213,19 +199,13 @@ def test_verify_that_colorama_package_is_not_present():
             2,
             True,
             True,
-            [
-                r"\x1b\[32m[a-z.]*[ ]*INFO[\s]*\x1b\[0m \x1b\[34mStarting server endpoint"
-            ],
-            [
-                r"\x1b\[36m[a-z.]*[ ]*DEBUG[\s]*\x1b\[0m \x1b\[34mStarting Server Rest Endpoint"
-            ],
+            [r"\x1b\[32m[a-z.]*[ ]*INFO[\s]*\x1b\[0m \x1b\[34mStarting server endpoint"],
+            [r"\x1b\[36m[a-z.]*[ ]*DEBUG[\s]*\x1b\[0m \x1b\[34mStarting Server Rest Endpoint"],
         ),
     ],
 )
 @pytest.mark.timeout(20)
-def test_no_log_file_set(
-    tmpdir, log_level, timed, with_tty, regexes_required_lines, regexes_forbidden_lines
-):
+def test_no_log_file_set(tmpdir, log_level, timed, with_tty, regexes_required_lines, regexes_forbidden_lines):
     if is_colorama_package_available() and with_tty:
         pytest.skip("Colorama is present")
 
@@ -276,19 +256,12 @@ def test_no_log_file_set(
     ],
 )
 @pytest.mark.timeout(60)
-def test_log_file_set(
-    tmpdir, log_level, with_tty, regexes_required_lines, regexes_forbidden_lines
-):
+def test_log_file_set(tmpdir, log_level, with_tty, regexes_required_lines, regexes_forbidden_lines):
     if is_colorama_package_available() and with_tty:
         pytest.skip("Colorama is present")
 
     log_file = "server.log"
-    (args, log_dir) = get_command(
-        tmpdir,
-        stdout_log_level=log_level,
-        log_file=log_file,
-        log_level_log_file=log_level,
-    )
+    (args, log_dir) = get_command(tmpdir, stdout_log_level=log_level, log_file=log_file, log_level_log_file=log_level)
     if with_tty:
         (stdout, _) = run_with_tty(args)
     else:
@@ -303,28 +276,20 @@ def test_log_file_set(
 
 
 def check_logs(log_lines, regexes_required_lines, regexes_forbidden_lines, timed):
-    compiled_regexes_requires_lines = get_compiled_regexes(
-        regexes_required_lines, timed
-    )
-    compiled_regexes_forbidden_lines = get_compiled_regexes(
-        regexes_forbidden_lines, timed
-    )
+    compiled_regexes_requires_lines = get_compiled_regexes(regexes_required_lines, timed)
+    compiled_regexes_forbidden_lines = get_compiled_regexes(regexes_forbidden_lines, timed)
     for line in log_lines:
         print(line)
     for regex in compiled_regexes_requires_lines:
         if not any(regex.match(line) for line in log_lines):
-            pytest.fail(
-                "Required pattern was not found in log lines: %s" % (regex.pattern,)
-            )
+            pytest.fail("Required pattern was not found in log lines: %s" % (regex.pattern,))
     for regex in compiled_regexes_forbidden_lines:
         if any(regex.match(line) for line in log_lines):
             pytest.fail("Forbidden pattern found in log lines: %s" % (regex.pattern,))
 
 
 def test_check_shutdown():
-    process = do_run(
-        [sys.executable, os.path.join(os.path.dirname(__file__), "miniapp.py")]
-    )
+    process = do_run([sys.executable, os.path.join(os.path.dirname(__file__), "miniapp.py")])
     # wait for handler to be in place
     try:
         process.communicate(timeout=2)
@@ -339,12 +304,8 @@ def test_check_shutdown():
 
 
 def test_check_bad_shutdown():
-    print(
-        [sys.executable, os.path.join(os.path.dirname(__file__), "miniapp.py"), "bad"]
-    )
-    process = do_run(
-        [sys.executable, os.path.join(os.path.dirname(__file__), "miniapp.py"), "bad"]
-    )
+    print([sys.executable, os.path.join(os.path.dirname(__file__), "miniapp.py"), "bad"])
+    process = do_run([sys.executable, os.path.join(os.path.dirname(__file__), "miniapp.py"), "bad"])
     out, err = do_kill(process, killtime=5, termtime=2)
     print(out, err)
     assert "----- Thread Dump ----" in out
@@ -365,17 +326,16 @@ o = Test(attr="1234")
 """
     )
 
-    output = """Could not set attribute `attr` on instance `__config__::Test (instantiated at ./main.cf:8)` """ \
+    output = (
+        """Could not set attribute `attr` on instance `__config__::Test (instantiated at ./main.cf:8)` """
         """(reported in Construct(Test) (./main.cf:8))
 caused by:
   Invalid value '1234', expected Number (reported in Construct(Test) (./main.cf:8))
 """
+    )
 
     def exec(*cmd):
-        process = do_run(
-            [sys.executable, "-m", "inmanta.app"] + list(cmd),
-            cwd=snippetcompiler.project_dir,
-        )
+        process = do_run([sys.executable, "-m", "inmanta.app"] + list(cmd), cwd=snippetcompiler.project_dir)
         out, err = process.communicate(timeout=5)
         assert out.decode() == ""
         assert err.decode() == output

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -84,9 +84,7 @@ def test_help_sub(inmanta_config, capsys):
     assert "update" in out
 
 
-@pytest.mark.parametrize("push_method", [([]),
-                                         (["-d"]),
-                                         (["-d", "--full"])])
+@pytest.mark.parametrize("push_method", [([]), (["-d"]), (["-d", "--full"])])
 @pytest.mark.asyncio
 async def test_export(tmpdir, server, client, push_method):
     server_port = Config.get("client_rest_transport", "port")
@@ -94,10 +92,10 @@ async def test_export(tmpdir, server, client, push_method):
 
     result = await client.create_project("test")
     assert result.code == 200
-    proj_id = result.result['project']['id']
+    proj_id = result.result["project"]["id"]
     result = await client.create_environment(proj_id, "test", None, None)
     assert result.code == 200
-    env_id = result.result['environment']['id']
+    env_id = result.result["environment"]["id"]
 
     workspace = tmpdir.mkdir("tmp")
     path_main_file = workspace.join("main.cf")
@@ -109,7 +107,10 @@ name: testproject
 modulepath: %s
 downloadpath: %s
 repo: https://github.com/inmanta/
-""" % (libs_dir, libs_dir)
+""" % (
+        libs_dir,
+        libs_dir,
+    )
     path_project_yml_file.write(content_project_yml_file)
 
     content_main_file = """
@@ -122,8 +123,18 @@ vm1=ip::Host(name="non-existing-machine", os=redhat::centos7, ip="127.0.0.1")
 
     os.chdir(workspace)
 
-    args = [sys.executable, "-m", "inmanta.app", "export", "-e", str(env_id), "--server_port", str(server_port),
-            "--server_address", str(server_host)]
+    args = [
+        sys.executable,
+        "-m",
+        "inmanta.app",
+        "export",
+        "-e",
+        str(env_id),
+        "--server_port",
+        str(server_port),
+        "--server_address",
+        str(server_host),
+    ]
     args += push_method
 
     process = await subprocess.create_subprocess_exec(*args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -139,12 +150,12 @@ vm1=ip::Host(name="non-existing-machine", os=redhat::centos7, ip="127.0.0.1")
 
     result = await client.list_versions(env_id)
     assert result.code == 200
-    assert len(result.result['versions']) == 1
+    assert len(result.result["versions"]) == 1
 
-    details_exported_version = result.result['versions'][0]
+    details_exported_version = result.result["versions"][0]
     if push_method:
-        assert details_exported_version['result'] == VersionState.deploying.name
+        assert details_exported_version["result"] == VersionState.deploying.name
     else:
-        assert details_exported_version['result'] == VersionState.pending.name
+        assert details_exported_version["result"] == VersionState.pending.name
 
     shutil.rmtree(workspace)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -33,11 +33,11 @@ def my_resource():
         """
             A file on a filesystem
         """
+
         fields = ("key", "value", "purged")
 
 
 class CacheTests(unittest.TestCase):
-
     def test_base(self):
         cache = AgentCache()
         value = "test too"
@@ -120,7 +120,6 @@ class CacheTests(unittest.TestCase):
 
     def test_multi_threaded(self):
         class Spy(object):
-
             def __init__(self):
                 self.created = 0
                 self.deleted = 0
@@ -143,10 +142,16 @@ class CacheTests(unittest.TestCase):
         beta = Spy()
         alpha.lock.acquire()
 
-        t1 = Thread(target=lambda: cache.get_or_else(
-            "test", lambda version: alpha.create(), version=version, call_on_delete=lambda x: x.delete()))
-        t2 = Thread(target=lambda: cache.get_or_else(
-            "test", lambda version: beta.create(), version=version, call_on_delete=lambda x: x.delete()))
+        t1 = Thread(
+            target=lambda: cache.get_or_else(
+                "test", lambda version: alpha.create(), version=version, call_on_delete=lambda x: x.delete()
+            )
+        )
+        t2 = Thread(
+            target=lambda: cache.get_or_else(
+                "test", lambda version: beta.create(), version=version, call_on_delete=lambda x: x.delete()
+            )
+        )
 
         t1.start()
         t2.start()
@@ -259,7 +264,6 @@ class CacheTests(unittest.TestCase):
             return param
 
         class Sequencer(object):
-
             def __init__(self, sequence):
                 self.seq = sequence
                 self.count = 0
@@ -299,7 +303,6 @@ class CacheTests(unittest.TestCase):
         xcache = AgentCache()
 
         class DT(object):
-
             def __init__(self, cache):
                 self.cache = cache
                 self.count = 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,34 +131,36 @@ async def test_agent(server, client, environment, cli):
     assert result.exit_code == 0
 
 
-@pytest.mark.parametrize("push_method", [([]),
-                                         (["-p"]),
-                                         (["-p", "--full"])])
+@pytest.mark.parametrize("push_method", [([]), (["-p"]), (["-p", "--full"])])
 @pytest.mark.asyncio
 async def test_version(server, client, environment, cli, push_method):
     version = "12345"
-    resources = [{'key': 'key1',
-                  'value': 'value1',
-                  'id': 'test::Resource[agent1,key=key1],v=' + version,
-                  'send_event': False,
-                  'purged': False,
-                  'requires': ['test::Resource[agent1,key=key2],v=' + version],
-                  },
-                 {'key': 'key2',
-                  'value': 'value2',
-                  'id': 'test::Resource[agent1,key=key2],v=' + version,
-                  'send_event': False,
-                  'requires': [],
-                  'purged': False,
-                  },
-                 {'key': 'key3',
-                  'value': None,
-                  'id': 'test::Resource[agent1,key=key3],v=' + version,
-                  'send_event': False,
-                  'requires': [],
-                  'purged': True,
-                  }
-                 ]
+    resources = [
+        {
+            "key": "key1",
+            "value": "value1",
+            "id": "test::Resource[agent1,key=key1],v=" + version,
+            "send_event": False,
+            "purged": False,
+            "requires": ["test::Resource[agent1,key=key2],v=" + version],
+        },
+        {
+            "key": "key2",
+            "value": "value2",
+            "id": "test::Resource[agent1,key=key2],v=" + version,
+            "send_event": False,
+            "requires": [],
+            "purged": False,
+        },
+        {
+            "key": "key3",
+            "value": None,
+            "id": "test::Resource[agent1,key=key3],v=" + version,
+            "send_event": False,
+            "requires": [],
+            "purged": True,
+        },
+    ]
 
     result = await client.put_version(tid=environment, version=version, resources=resources, unknowns=[], version_info={})
     assert result.code == 200
@@ -200,14 +202,19 @@ async def test_param(server, client, environment, cli):
 @pytest.mark.asyncio
 async def test_form_and_records(server, client, environment, cli):
     form_type = "FormType"
-    result = await client.put_form(tid=environment, id=form_type,
-                                   form={'attributes': {'field1': {'default': 1, 'options': {'min': 1, 'max': 100},
-                                                                   'type': 'number'},
-                                                        'field2': {'default': "", 'options': {}, 'type': 'string'}},
-                                         'options': {},
-                                         'type': form_type}
-                                   )
-    assert(result.code == 200)
+    result = await client.put_form(
+        tid=environment,
+        id=form_type,
+        form={
+            "attributes": {
+                "field1": {"default": 1, "options": {"min": 1, "max": 100}, "type": "number"},
+                "field2": {"default": "", "options": {}, "type": "string"},
+            },
+            "options": {},
+            "type": form_type,
+        },
+    )
+    assert result.code == 200
     form_id = result.result["form"]["id"]
 
     result = await cli.run("form", "list", "-e", environment)
@@ -251,13 +258,18 @@ async def test_form_and_records(server, client, environment, cli):
 @pytest.mark.asyncio
 async def test_import_export(server, client, environment, cli, tmpdir):
     form_type = "FormType"
-    result = await client.put_form(tid=environment, id=form_type,
-                                   form={'attributes': {'field1': {'default': 1, 'options': {'min': 1, 'max': 100},
-                                                                   'type': 'number'},
-                                                        'field2': {'default': "", 'options': {}, 'type': 'string'}},
-                                         'options': {},
-                                         'type': form_type}
-                                   )
+    result = await client.put_form(
+        tid=environment,
+        id=form_type,
+        form={
+            "attributes": {
+                "field1": {"default": 1, "options": {"min": 1, "max": 100}, "type": "number"},
+                "field2": {"default": "", "options": {}, "type": "string"},
+            },
+            "options": {},
+            "type": form_type,
+        },
+    )
     form_id = result.result["form"]["id"]
 
     result = await cli.run("record", "create", "-e", environment, "-t", form_type, "-p", "field1=1234", "-p", "field2=test456")

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -33,7 +33,6 @@ from inmanta.module import Project
 
 
 class CompilerBaseTest(object):
-
     def __init__(self, name, mainfile=None):
         config.Config.load_config()
         self.project_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", name)
@@ -54,8 +53,7 @@ class CompilerBaseTest(object):
 
 
 class TestBaseCompile(CompilerBaseTest, unittest.TestCase):
-
-    def __init__(self, methodName='runTest'):  # noqa: N803
+    def __init__(self, methodName="runTest"):  # noqa: N803
         unittest.TestCase.__init__(self, methodName)
         CompilerBaseTest.__init__(self, "compile_test_1")
 
@@ -69,8 +67,7 @@ class TestBaseCompile(CompilerBaseTest, unittest.TestCase):
 
 
 class TestForCompile(CompilerBaseTest, unittest.TestCase):
-
-    def __init__(self, methodName='runTest'):  # noqa: N803
+    def __init__(self, methodName="runTest"):  # noqa: N803
         unittest.TestCase.__init__(self, methodName)
         CompilerBaseTest.__init__(self, "compile_test_2")
 
@@ -81,8 +78,7 @@ class TestForCompile(CompilerBaseTest, unittest.TestCase):
 
 
 class TestIndexCompileCollision(CompilerBaseTest, unittest.TestCase):
-
-    def __init__(self, methodName='runTest'):  # noqa: N803
+    def __init__(self, methodName="runTest"):  # noqa: N803
         unittest.TestCase.__init__(self, methodName)
         CompilerBaseTest.__init__(self, "compile_test_index_collission")
 
@@ -92,8 +88,7 @@ class TestIndexCompileCollision(CompilerBaseTest, unittest.TestCase):
 
 
 class TestIndexCompile(CompilerBaseTest, unittest.TestCase):
-
-    def __init__(self, methodName='runTest'):  # noqa: N803
+    def __init__(self, methodName="runTest"):  # noqa: N803
         unittest.TestCase.__init__(self, methodName)
         CompilerBaseTest.__init__(self, "compile_test_index")
 
@@ -101,10 +96,11 @@ class TestIndexCompile(CompilerBaseTest, unittest.TestCase):
         (_, scopes) = compiler.do_compile()
         variables = {k: x.get_value() for k, x in scopes.get_child("__config__").scope.slots.items()}
 
-        p = re.compile(r'(f\d+h\d+)(a\d+)?')
+        p = re.compile(r"(f\d+h\d+)(a\d+)?")
 
-        items = [(m.groups()[0], m.groups()[1], v)
-                 for m, v in [(re.search(p, k), v)for k, v in variables.items()] if m is not None]
+        items = [
+            (m.groups()[0], m.groups()[1], v) for m, v in [(re.search(p, k), v) for k, v in variables.items()] if m is not None
+        ]
         groups = groupby(sorted(items, key=lambda x: x[0]), lambda x: x[0])
         firsts = []
         for k, v in groups:
@@ -117,13 +113,15 @@ class TestIndexCompile(CompilerBaseTest, unittest.TestCase):
         for i in range(len(firsts)):
             for j in range(len(firsts)):
                 if not i == j:
-                    self.assertNotEqual(firsts[i][2], firsts[j][2], "Variable %s%s should not be equal to %s%s" % (
-                        firsts[i][0], firsts[i][1], firsts[j][0], firsts[j][1]))
+                    self.assertNotEqual(
+                        firsts[i][2],
+                        firsts[j][2],
+                        "Variable %s%s should not be equal to %s%s" % (firsts[i][0], firsts[i][1], firsts[j][0], firsts[j][1]),
+                    )
 
 
 class TestDoubleSet(CompilerBaseTest, unittest.TestCase):
-
-    def __init__(self, methodName='runTest'):  # noqa: N803
+    def __init__(self, methodName="runTest"):  # noqa: N803
         unittest.TestCase.__init__(self, methodName)
         CompilerBaseTest.__init__(self, "compile_test_double_assign")
 
@@ -133,20 +131,20 @@ class TestDoubleSet(CompilerBaseTest, unittest.TestCase):
 
 
 class TestCompileIssue138(CompilerBaseTest, unittest.TestCase):
-
-    def __init__(self, methodName='runTest'):  # noqa: N803
+    def __init__(self, methodName="runTest"):  # noqa: N803
         unittest.TestCase.__init__(self, methodName)
         CompilerBaseTest.__init__(self, "compile_138")
 
     def test_compile(self):
         (types, _) = compiler.do_compile()
-        assert (types['std::Host'].get_all_instances()[0].get_attribute("agent").get_value().
-                get_attribute("names").get_value() is not None)
+        assert (
+            types["std::Host"].get_all_instances()[0].get_attribute("agent").get_value().get_attribute("names").get_value()
+            is not None
+        )
 
 
 class TestCompileluginTyping(CompilerBaseTest, unittest.TestCase):
-
-    def __init__(self, methodName='runTest'):  # noqa: N803
+    def __init__(self, methodName="runTest"):  # noqa: N803
         unittest.TestCase.__init__(self, methodName)
         CompilerBaseTest.__init__(self, "compile_plugin_typing")
 
@@ -171,8 +169,7 @@ class TestCompileluginTyping(CompilerBaseTest, unittest.TestCase):
 
 
 class TestCompileluginTypingErr(CompilerBaseTest, unittest.TestCase):
-
-    def __init__(self, methodName='runTest'):  # noqa: N803
+    def __init__(self, methodName="runTest"):  # noqa: N803
         unittest.TestCase.__init__(self, methodName)
         CompilerBaseTest.__init__(self, "compile_plugin_typing", "invalid.cf")
 
@@ -181,7 +178,11 @@ class TestCompileluginTypingErr(CompilerBaseTest, unittest.TestCase):
             compiler.do_compile()
         text = e.value.format_trace(indent="  ")
         print(text)
-        assert text == """Exception in plugin test::badtype (reported in test::badtype(c1.items) ({dir}/invalid.cf:16))
+        assert (
+            text
+            == """Exception in plugin test::badtype (reported in test::badtype(c1.items) ({dir}/invalid.cf:16))
 caused by:
   Invalid type for value 'a', should be type test::Item (reported in test::badtype(c1.items) ({dir}/invalid.cf:16))""".format(
-            dir=self.project_dir)
+                dir=self.project_dir
+            )
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,8 +3,10 @@ import inmanta.agent.config as cfg
 
 
 def test_environment_deprecated_options(caplog):
-    for (deprecated_option, new_option) in [(cfg.agent_interval, cfg.agent_deploy_interval),
-                                            (cfg.agent_splay, cfg.agent_deploy_splay_time)]:
+    for (deprecated_option, new_option) in [
+        (cfg.agent_interval, cfg.agent_deploy_interval),
+        (cfg.agent_splay, cfg.agent_deploy_splay_time),
+    ]:
 
         Config.set(deprecated_option.section, deprecated_option.name, "22")
         caplog.clear()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -37,9 +37,9 @@ async def test_postgres_client(postgresql_client):
     records = await postgresql_client.fetch("SELECT * FROM test")
     assert len(records) == 1
     first_record = records[0]
-    assert first_record['id'] == 5
-    assert first_record['name'] == "jef"
-    await postgresql_client.execute("DELETE FROM test WHERE test.id = " + str(first_record['id']))
+    assert first_record["id"] == 5
+    assert first_record["name"] == "jef"
+    await postgresql_client.execute("DELETE FROM test WHERE test.id = " + str(first_record["id"]))
     records = await postgresql_client.fetch("SELECT * FROM test")
     assert len(records) == 0
 
@@ -75,7 +75,6 @@ def test_project_no_project_name(init_dataclasses_and_load_schema):
 
 @pytest.mark.asyncio
 async def test_project_cascade_delete(init_dataclasses_and_load_schema):
-
     async def create_full_environment(project_name, environment_name):
         project = data.Project(name=project_name)
         await project.insert()
@@ -83,11 +82,13 @@ async def test_project_cascade_delete(init_dataclasses_and_load_schema):
         env = data.Environment(name=environment_name, project=project.id, repo_url="", repo_branch="")
         await env.insert()
 
-        agent_proc = data.AgentProcess(hostname="testhost",
-                                       environment=env.id,
-                                       first_seen=datetime.datetime.now(),
-                                       last_seen=datetime.datetime.now(),
-                                       sid=uuid.uuid4())
+        agent_proc = data.AgentProcess(
+            hostname="testhost",
+            environment=env.id,
+            first_seen=datetime.datetime.now(),
+            last_seen=datetime.datetime.now(),
+            sid=uuid.uuid4(),
+        )
         await agent_proc.insert()
 
         agi1 = data.AgentInstance(process=agent_proc.sid, name="agi1", tid=env.id)
@@ -95,8 +96,9 @@ async def test_project_cascade_delete(init_dataclasses_and_load_schema):
         agi2 = data.AgentInstance(process=agent_proc.sid, name="agi2", tid=env.id)
         await agi2.insert()
 
-        agent = data.Agent(environment=env.id, name="agi1", last_failover=datetime.datetime.now(), paused=False,
-                           primary=agi1.id)
+        agent = data.Agent(
+            environment=env.id, name="agi1", last_failover=datetime.datetime.now(), paused=False, primary=agi1.id
+        )
         await agent.insert()
 
         version = int(time.time())
@@ -107,8 +109,7 @@ async def test_project_cascade_delete(init_dataclasses_and_load_schema):
         for i in range(5):
             path = "/etc/file" + str(i)
             key = "std::File[agent1,path=" + path + "]"
-            res1 = data.Resource.new(environment=env.id, resource_version_id=key + ",v=%d" % version,
-                                     attributes={"path": path})
+            res1 = data.Resource.new(environment=env.id, resource_version_id=key + ",v=%d" % version, attributes={"path": path})
             await res1.insert()
             resource_ids.append((res1.environment, res1.resource_version_id))
 
@@ -120,13 +121,15 @@ async def test_project_cascade_delete(init_dataclasses_and_load_schema):
 
         return project, env, agent_proc, [agi1, agi2], agent, resource_ids, code, unknown_parameter
 
-    async def assert_project_exists(project, env, agent_proc, agent_instances, agent, resource_ids, code, unknown_parameter,
-                                    exists):
+    async def assert_project_exists(
+        project, env, agent_proc, agent_instances, agent, resource_ids, code, unknown_parameter, exists
+    ):
         def func(x):
             if exists:
                 return x is not None
             else:
                 return x is None
+
         assert func(await data.Project.get_by_id(project.id))
         assert func(await data.Environment.get_by_id(env.id))
         assert func(await data.AgentProcess.get_one(sid=agent_proc.sid))
@@ -196,11 +199,13 @@ async def test_environment_cascade_content_only(init_dataclasses_and_load_schema
     env = data.Environment(name="dev", project=project.id, repo_url="", repo_branch="")
     await env.insert()
 
-    agent_proc = data.AgentProcess(hostname="testhost",
-                                   environment=env.id,
-                                   first_seen=datetime.datetime.now(),
-                                   last_seen=datetime.datetime.now(),
-                                   sid=uuid.uuid4())
+    agent_proc = data.AgentProcess(
+        hostname="testhost",
+        environment=env.id,
+        first_seen=datetime.datetime.now(),
+        last_seen=datetime.datetime.now(),
+        sid=uuid.uuid4(),
+    )
     await agent_proc.insert()
 
     agi1 = data.AgentInstance(process=agent_proc.sid, name="agi1", tid=env.id)
@@ -219,8 +224,7 @@ async def test_environment_cascade_content_only(init_dataclasses_and_load_schema
     for i in range(5):
         path = "/etc/file" + str(i)
         key = "std::File[agent1,path=" + path + "]"
-        res1 = data.Resource.new(environment=env.id, resource_version_id=key + ",v=%d" % version,
-                                 attributes={"path": path})
+        res1 = data.Resource.new(environment=env.id, resource_version_id=key + ",v=%d" % version, attributes={"path": path})
         await res1.insert()
         resource_ids.append((res1.environment, res1.resource_version_id))
 
@@ -289,8 +293,10 @@ async def test_environment_deprecated_setting(init_dataclasses_and_load_schema, 
     env = data.Environment(name="dev", project=project.id, repo_url="", repo_branch="")
     await env.insert()
 
-    for (deprecated_option, new_option) in [(data.AUTOSTART_AGENT_INTERVAL, data.AUTOSTART_AGENT_DEPLOY_INTERVAL),
-                                            (data.AUTOSTART_SPLAY, data.AUTOSTART_AGENT_DEPLOY_SPLAY_TIME)]:
+    for (deprecated_option, new_option) in [
+        (data.AUTOSTART_AGENT_INTERVAL, data.AUTOSTART_AGENT_DEPLOY_INTERVAL),
+        (data.AUTOSTART_SPLAY, data.AUTOSTART_AGENT_DEPLOY_SPLAY_TIME),
+    ]:
         await env.set(deprecated_option, 22)
         caplog.clear()
         assert (await env.get(new_option)) == 22
@@ -316,11 +322,9 @@ async def test_agent_process(init_dataclasses_and_load_schema):
     await env.insert()
 
     sid = uuid.uuid4()
-    agent_proc = data.AgentProcess(hostname="testhost",
-                                   environment=env.id,
-                                   first_seen=datetime.datetime.now(),
-                                   last_seen=datetime.datetime.now(),
-                                   sid=sid)
+    agent_proc = data.AgentProcess(
+        hostname="testhost", environment=env.id, first_seen=datetime.datetime.now(), last_seen=datetime.datetime.now(), sid=sid
+    )
     await agent_proc.insert()
 
     agi1 = data.AgentInstance(process=agent_proc.sid, name="agi1", tid=env.id)
@@ -367,11 +371,9 @@ async def test_agent_instance(init_dataclasses_and_load_schema):
     await env.insert()
 
     sid = uuid.uuid4()
-    agent_proc = data.AgentProcess(hostname="testhost",
-                                   environment=env.id,
-                                   first_seen=datetime.datetime.now(),
-                                   last_seen=datetime.datetime.now(),
-                                   sid=sid)
+    agent_proc = data.AgentProcess(
+        hostname="testhost", environment=env.id, first_seen=datetime.datetime.now(), last_seen=datetime.datetime.now(), sid=sid
+    )
     await agent_proc.insert()
 
     agi1_name = "agi1"
@@ -416,19 +418,18 @@ async def test_agent(init_dataclasses_and_load_schema):
     await env.insert()
 
     sid = uuid.uuid4()
-    agent_proc = data.AgentProcess(hostname="testhost",
-                                   environment=env.id,
-                                   first_seen=datetime.datetime.now(),
-                                   last_seen=datetime.datetime.now(),
-                                   sid=sid)
+    agent_proc = data.AgentProcess(
+        hostname="testhost", environment=env.id, first_seen=datetime.datetime.now(), last_seen=datetime.datetime.now(), sid=sid
+    )
     await agent_proc.insert()
 
     agi1_name = "agi1"
     agi1 = data.AgentInstance(process=agent_proc.sid, name=agi1_name, tid=env.id)
     await agi1.insert()
 
-    agent1 = data.Agent(environment=env.id, name="agi1_agent1", last_failover=datetime.datetime.now(), paused=False,
-                        primary=agi1.id)
+    agent1 = data.Agent(
+        environment=env.id, name="agi1_agent1", last_failover=datetime.datetime.now(), paused=False, primary=agi1.id
+    )
     await agent1.insert()
     agent2 = data.Agent(environment=env.id, name="agi1_agent2", paused=False)
     await agent2.insert()
@@ -476,8 +477,7 @@ async def test_config_model(init_dataclasses_and_load_schema):
     await env.insert()
 
     version = int(time.time())
-    cm = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(),
-                                 total=1, version_info={})
+    cm = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1, version_info={})
     await cm.insert()
 
     # create resources
@@ -499,8 +499,9 @@ async def test_model_list(init_dataclasses_and_load_schema):
     await env.insert()
 
     for version in range(1, 20):
-        cm = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=0,
-                                     version_info={})
+        cm = data.ConfigurationModel(
+            environment=env.id, version=version, date=datetime.datetime.now(), total=0, version_info={}
+        )
         await cm.insert()
 
     versions = await data.ConfigurationModel.get_versions(env.id, 0, 1)
@@ -532,8 +533,9 @@ async def test_model_get_latest_version(init_dataclasses_and_load_schema):
 
     cms = []
     for version in range(1, 5):
-        cm = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=0,
-                                     version_info={})
+        cm = data.ConfigurationModel(
+            environment=env.id, version=version, date=datetime.datetime.now(), total=0, version_info={}
+        )
         await cm.insert()
         cms.append(cm)
 
@@ -565,8 +567,7 @@ async def test_model_set_ready(init_dataclasses_and_load_schema):
 
     path = "/etc/file"
     key = "std::File[agent1,path=" + path + "]"
-    resource = data.Resource.new(environment=env.id, resource_version_id=key + ",v=%d" % version,
-                                 attributes={"path": path})
+    resource = data.Resource.new(environment=env.id, resource_version_id=key + ",v=%d" % version, attributes={"path": path})
     await resource.insert()
 
     assert cm.done == 0
@@ -575,18 +576,21 @@ async def test_model_set_ready(init_dataclasses_and_load_schema):
     assert cm.done == 1
 
 
-@pytest.mark.parametrize("resource_state, should_be_deployed", [
-    (const.ResourceState.unavailable, True),
-    (const.ResourceState.skipped, True),
-    (const.ResourceState.deployed, True),
-    (const.ResourceState.failed, True),
-    (const.ResourceState.deploying, False),
-    (const.ResourceState.available, False),
-    (const.ResourceState.cancelled, True),
-    (const.ResourceState.undefined, True),
-    (const.ResourceState.skipped_for_undefined, True),
-    (const.ResourceState.processing_events, False),
-])
+@pytest.mark.parametrize(
+    "resource_state, should_be_deployed",
+    [
+        (const.ResourceState.unavailable, True),
+        (const.ResourceState.skipped, True),
+        (const.ResourceState.deployed, True),
+        (const.ResourceState.failed, True),
+        (const.ResourceState.deploying, False),
+        (const.ResourceState.available, False),
+        (const.ResourceState.cancelled, True),
+        (const.ResourceState.undefined, True),
+        (const.ResourceState.skipped_for_undefined, True),
+        (const.ResourceState.processing_events, False),
+    ],
+)
 @pytest.mark.asyncio
 async def test_model_mark_done_if_done(init_dataclasses_and_load_schema, resource_state, should_be_deployed):
     project = data.Project(name="test")
@@ -603,8 +607,7 @@ async def test_model_mark_done_if_done(init_dataclasses_and_load_schema, resourc
 
     path = "/etc/file"
     key = "std::File[agent1,path=" + path + "]"
-    resource = data.Resource.new(environment=env.id, resource_version_id=key + ",v=%d" % version,
-                                 attributes={"path": path})
+    resource = data.Resource.new(environment=env.id, resource_version_id=key + ",v=%d" % version, attributes={"path": path})
     await resource.insert()
 
     assert not cm.deployed
@@ -643,13 +646,20 @@ async def test_model_get_list(init_dataclasses_and_load_schema):
 
             for r in range(3):
                 if r % 2 == 0:
-                    res = data.Resource.new(environment=env.id, status=const.ResourceState.deployed,
-                                            resource_version_id=f"std::File[agent1,path=/etc/file{r}],v={i}",
-                                            attributes={"purge_on_delete": False}, last_deploy=datetime.datetime.now())
+                    res = data.Resource.new(
+                        environment=env.id,
+                        status=const.ResourceState.deployed,
+                        resource_version_id=f"std::File[agent1,path=/etc/file{r}],v={i}",
+                        attributes={"purge_on_delete": False},
+                        last_deploy=datetime.datetime.now(),
+                    )
                 else:
-                    res = data.Resource.new(environment=env.id, status=const.ResourceState.deploying,
-                                            resource_version_id=f"std::File[agent1,path=/etc/file{r}],v={i}",
-                                            attributes={"purge_on_delete": False})
+                    res = data.Resource.new(
+                        environment=env.id,
+                        status=const.ResourceState.deploying,
+                        resource_version_id=f"std::File[agent1,path=/etc/file{r}],v={i}",
+                        attributes={"purge_on_delete": False},
+                    )
                 await res.insert()
 
     for env in [env1, env2]:
@@ -680,22 +690,26 @@ async def test_model_serialization(init_dataclasses_and_load_schema):
 
     path = "/etc/file"
     key = "std::File[agent1,path=" + path + "]"
-    resource = data.Resource.new(environment=env.id, resource_version_id=key + ",v=%d" % version,
-                                 attributes={"path": path}, status=const.ResourceState.deployed)
+    resource = data.Resource.new(
+        environment=env.id,
+        resource_version_id=key + ",v=%d" % version,
+        attributes={"path": path},
+        status=const.ResourceState.deployed,
+    )
     await resource.insert()
 
     cm = await data.ConfigurationModel.get_one(environment=env.id, version=version)
     dct = cm.to_dict()
-    assert dct['version'] == version
-    assert dct['environment'] == env.id
-    assert dct['date'] == now
-    assert not dct['released']
-    assert not dct['deployed']
-    assert dct['result'] == const.VersionState.pending
-    assert dct['version_info'] == {}
-    assert dct['total'] == 1
-    assert dct['done'] == 1
-    assert dct['status'] == {str(uuid.uuid5(env.id, key)): {"id": key, "status": const.ResourceState.deployed.name}}
+    assert dct["version"] == version
+    assert dct["environment"] == env.id
+    assert dct["date"] == now
+    assert not dct["released"]
+    assert not dct["deployed"]
+    assert dct["result"] == const.VersionState.pending
+    assert dct["version_info"] == {}
+    assert dct["total"] == 1
+    assert dct["done"] == 1
+    assert dct["status"] == {str(uuid.uuid5(env.id, key)): {"id": key, "status": const.ResourceState.deployed.name}}
 
 
 @pytest.mark.asyncio
@@ -712,8 +726,7 @@ async def test_model_delete_cascade(init_dataclasses_and_load_schema):
 
     path = "/etc/file"
     key = "std::File[agent1,path=" + path + "]"
-    resource = data.Resource.new(environment=env.id, resource_version_id=key + ",v=%d" % version,
-                                 attributes={"path": path})
+    resource = data.Resource.new(environment=env.id, resource_version_id=key + ",v=%d" % version, attributes={"path": path})
     await resource.insert()
 
     code = data.Code(version=version, resource="std::File", environment=env.id)
@@ -725,11 +738,10 @@ async def test_model_delete_cascade(init_dataclasses_and_load_schema):
     await cm.delete_cascade()
 
     assert (await data.ConfigurationModel.get_list()) == []
-    assert (await data.Resource.get_one(environment=resource.environment,
-                                        resource_version_id=resource.resource_version_id)) is None
-    assert (await data.Code.get_one(environment=code.environment,
-                                    resource=code.resource,
-                                    version=code.version)) is None
+    assert (
+        await data.Resource.get_one(environment=resource.environment, resource_version_id=resource.resource_version_id)
+    ) is None
+    assert (await data.Code.get_one(environment=code.environment, resource=code.resource, version=code.version)) is None
     assert (await data.UnknownParameter.get_by_id(unknown_parameter.id)) is None
 
 
@@ -756,14 +768,17 @@ async def test_model_get_version_nr_latest_version(init_dataclasses_and_load_sch
     assert await data.ConfigurationModel.get_version_nr_latest_version(uuid.uuid4()) is None
 
 
-@pytest.mark.parametrize("resource_state, version_state", [
-    (const.ResourceState.deployed, const.VersionState.success),
-    (const.ResourceState.failed, const.VersionState.failed),
-    (const.ResourceState.undefined, const.VersionState.failed),
-    (const.ResourceState.skipped_for_undefined, const.VersionState.failed),
-    (const.ResourceState.cancelled, const.VersionState.failed),
-    (const.ResourceState.skipped, const.VersionState.failed)
-])
+@pytest.mark.parametrize(
+    "resource_state, version_state",
+    [
+        (const.ResourceState.deployed, const.VersionState.success),
+        (const.ResourceState.failed, const.VersionState.failed),
+        (const.ResourceState.undefined, const.VersionState.failed),
+        (const.ResourceState.skipped_for_undefined, const.VersionState.failed),
+        (const.ResourceState.cancelled, const.VersionState.failed),
+        (const.ResourceState.skipped, const.VersionState.failed),
+    ],
+)
 @pytest.mark.asyncio
 async def test_mark_done(init_dataclasses_and_load_schema, resource_state, version_state):
     project = data.Project(name="test")
@@ -780,14 +795,19 @@ async def test_mark_done(init_dataclasses_and_load_schema, resource_state, versi
 
     path1 = "/etc/file1"
     key1 = "std::File[agent1,path=" + path1 + "]"
-    resource1 = data.Resource.new(environment=env.id, resource_version_id=key1 + ",v=%d" % version,
-                                  attributes={"path": path1}, status=resource_state)
+    resource1 = data.Resource.new(
+        environment=env.id, resource_version_id=key1 + ",v=%d" % version, attributes={"path": path1}, status=resource_state
+    )
     await resource1.insert()
 
     path2 = "/etc/file2"
     key2 = "std::File[agent1,path=" + path2 + "]"
-    resource2 = data.Resource.new(environment=env.id, resource_version_id=key2 + ",v=%d" % version,
-                                  attributes={"path": path2}, status=const.ResourceState.deployed)
+    resource2 = data.Resource.new(
+        environment=env.id,
+        resource_version_id=key2 + ",v=%d" % version,
+        attributes={"path": path2},
+        status=const.ResourceState.deployed,
+    )
     await resource2.insert()
 
     assert cm.result == const.VersionState.pending
@@ -796,7 +816,6 @@ async def test_mark_done(init_dataclasses_and_load_schema, resource_state, versi
 
 
 async def populate_model(env_id, version):
-
     def get_path(n):
         return "/tmp/%d" % n
 
@@ -805,12 +824,12 @@ async def populate_model(env_id, version):
 
     def get_resource(n, depends, status=const.ResourceState.available):
         requires = [get_id(z) for z in depends]
-        return data.Resource.new(environment=env_id, resource_version_id=get_id(n),
-                                 status=status,
-                                 attributes={"path": get_path(n),
-                                             "purge_on_delete": False,
-                                             "purged": False,
-                                             "requires": requires})
+        return data.Resource.new(
+            environment=env_id,
+            resource_version_id=get_id(n),
+            status=status,
+            attributes={"path": get_path(n), "purge_on_delete": False, "purged": False, "requires": requires},
+        )
 
     res1 = get_resource(1, [])
     await res1.insert()
@@ -838,30 +857,53 @@ async def test_resource_purge_on_delete(init_dataclasses_and_load_schema):
 
     # model 1
     version = 1
-    cm1 = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=2,
-                                  version_info={}, released=True, deployed=True)
+    cm1 = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=2,
+        version_info={},
+        released=True,
+        deployed=True,
+    )
     await cm1.insert()
 
-    res11 = data.Resource.new(environment=env.id, resource_version_id="std::File[agent1,path=/etc/motd],v=%s" % version,
-                              status=const.ResourceState.deployed,
-                              attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False})
+    res11 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/motd],v=%s" % version,
+        status=const.ResourceState.deployed,
+        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+    )
     await res11.insert()
 
-    res12 = data.Resource.new(environment=env.id, resource_version_id="std::File[agent2,path=/etc/motd],v=%s" % version,
-                              status=const.ResourceState.deployed,
-                              attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": True})
+    res12 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent2,path=/etc/motd],v=%s" % version,
+        status=const.ResourceState.deployed,
+        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": True},
+    )
     await res12.insert()
 
     # model 2 (multiple undeployed versions)
     while version < 10:
         version += 1
-        cm2 = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                      version_info={}, released=False, deployed=False)
+        cm2 = data.ConfigurationModel(
+            environment=env.id,
+            version=version,
+            date=datetime.datetime.now(),
+            total=1,
+            version_info={},
+            released=False,
+            deployed=False,
+        )
         await cm2.insert()
 
-        res21 = data.Resource.new(environment=env.id, resource_version_id="std::File[agent5,path=/etc/motd],v=%s" % version,
-                                  status=const.ResourceState.available,
-                                  attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False})
+        res21 = data.Resource.new(
+            environment=env.id,
+            resource_version_id="std::File[agent5,path=/etc/motd],v=%s" % version,
+            status=const.ResourceState.available,
+            attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+        )
         await res21.insert()
 
     # model 3
@@ -886,24 +928,44 @@ async def test_issue_422(init_dataclasses_and_load_schema):
 
     # model 1
     version = 1
-    cm1 = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                  version_info={}, released=True, deployed=True)
+    cm1 = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=True,
+        deployed=True,
+    )
     await cm1.insert()
 
-    res11 = data.Resource.new(environment=env.id, resource_version_id="std::File[agent1,path=/etc/motd],v=%s" % version,
-                              status=const.ResourceState.deployed,
-                              attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False})
+    res11 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/motd],v=%s" % version,
+        status=const.ResourceState.deployed,
+        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+    )
     await res11.insert()
 
     # model 2 (multiple undeployed versions)
     version += 1
-    cm2 = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                  version_info={}, released=False, deployed=False)
+    cm2 = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=False,
+        deployed=False,
+    )
     await cm2.insert()
 
-    res21 = data.Resource.new(environment=env.id, resource_version_id="std::File[agent1,path=/etc/motd],v=%s" % version,
-                              status=const.ResourceState.available,
-                              attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False})
+    res21 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/motd],v=%s" % version,
+        status=const.ResourceState.available,
+        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+    )
     await res21.insert()
 
     # model 3
@@ -930,21 +992,41 @@ async def test_get_latest_resource(init_dataclasses_and_load_schema):
     assert (await data.Resource.get_latest_version(env.id, key)) is None
 
     version = 1
-    cm2 = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                  version_info={}, released=False, deployed=False)
+    cm2 = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=False,
+        deployed=False,
+    )
     await cm2.insert()
-    res11 = data.Resource.new(environment=env.id, resource_version_id=key + ",v=%d" % version,
-                              status=const.ResourceState.deployed,
-                              attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False})
+    res11 = data.Resource.new(
+        environment=env.id,
+        resource_version_id=key + ",v=%d" % version,
+        status=const.ResourceState.deployed,
+        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+    )
     await res11.insert()
 
     version = 2
-    cm2 = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                  version_info={}, released=False, deployed=False)
+    cm2 = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=False,
+        deployed=False,
+    )
     await cm2.insert()
-    res12 = data.Resource.new(environment=env.id, resource_version_id=key + ",v=%d" % version,
-                              status=const.ResourceState.deployed,
-                              attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": True})
+    res12 = data.Resource.new(
+        environment=env.id,
+        resource_version_id=key + ",v=%d" % version,
+        status=const.ResourceState.deployed,
+        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": True},
+    )
     await res12.insert()
 
     res = await data.Resource.get_latest_version(env.id, key)
@@ -960,16 +1042,25 @@ async def test_get_resources(init_dataclasses_and_load_schema):
     await env.insert()
 
     version = 1
-    cm1 = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                  version_info={}, released=True, deployed=True)
+    cm1 = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=True,
+        deployed=True,
+    )
     await cm1.insert()
 
     resource_ids = []
     for i in range(1, 11):
-        res = data.Resource.new(environment=env.id,
-                                resource_version_id="std::File[agent1,path=/tmp/file%d],v=%d" % (i, version),
-                                status=const.ResourceState.deployed,
-                                attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False})
+        res = data.Resource.new(
+            environment=env.id,
+            resource_version_id="std::File[agent1,path=/tmp/file%d],v=%d" % (i, version),
+            status=const.ResourceState.deployed,
+            attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+        )
         await res.insert()
         resource_ids.append(res.resource_version_id)
 
@@ -994,39 +1085,67 @@ async def test_model_get_resources_for_version(init_dataclasses_and_load_schema)
 
     resource_ids_version_one = []
     version = 1
-    cm = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                 version_info={}, released=True, deployed=True)
+    cm = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=True,
+        deployed=True,
+    )
     await cm.insert()
     for i in range(1, 11):
-        res = data.Resource.new(environment=env.id,
-                                resource_version_id="std::File[agent1,path=/tmp/file%d],v=%d" % (i, version),
-                                status=const.ResourceState.deployed,
-                                attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False})
+        res = data.Resource.new(
+            environment=env.id,
+            resource_version_id="std::File[agent1,path=/tmp/file%d],v=%d" % (i, version),
+            status=const.ResourceState.deployed,
+            attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+        )
         await res.insert()
         resource_ids_version_one.append(res.resource_version_id)
 
     resource_ids_version_two = []
     version += 1
-    cm = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                 version_info={}, released=True, deployed=True)
+    cm = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=True,
+        deployed=True,
+    )
     await cm.insert()
     for i in range(11, 21):
-        res = data.Resource.new(environment=env.id,
-                                resource_version_id="std::File[agent2,path=/tmp/file%d],v=%d" % (i, version),
-                                status=const.ResourceState.deployed,
-                                attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False})
+        res = data.Resource.new(
+            environment=env.id,
+            resource_version_id="std::File[agent2,path=/tmp/file%d],v=%d" % (i, version),
+            status=const.ResourceState.deployed,
+            attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+        )
         await res.insert()
         resource_ids_version_two.append(res.resource_version_id)
 
     for version in range(3, 5):
-        cm = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                     version_info={}, released=True, deployed=True)
+        cm = data.ConfigurationModel(
+            environment=env.id,
+            version=version,
+            date=datetime.datetime.now(),
+            total=1,
+            version_info={},
+            released=True,
+            deployed=True,
+        )
         await cm.insert()
 
     async def make_with_status(i, status):
-        res = data.Resource.new(environment=env.id, resource_version_id="std::File[agent3,path=/tmp/file%d],v=3" % i,
-                                status=status,
-                                attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False})
+        res = data.Resource.new(
+            environment=env.id,
+            resource_version_id="std::File[agent3,path=/tmp/file%d],v=3" % i,
+            status=status,
+            attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+        )
         await res.insert()
         return res.resource_version_id
 
@@ -1063,10 +1182,9 @@ async def test_model_get_resources_for_version_optional_args(init_dataclasses_an
 
     async def insert_resource(env_id, version, agent_name, path, status):
         resource_version_id = f"std::File[{agent_name},path={path}],v={version}"
-        resource = data.Resource.new(environment=env_id,
-                                     resource_version_id=resource_version_id,
-                                     attributes={"path": path},
-                                     status=status)
+        resource = data.Resource.new(
+            environment=env_id, resource_version_id=resource_version_id, attributes={"path": path}, status=status
+        )
         await resource.insert()
 
     await insert_resource(env.id, version, "agent1", "path1", const.ResourceState.deployed)
@@ -1099,14 +1217,24 @@ async def test_escaped_resources(init_dataclasses_and_load_schema):
     await env.insert()
 
     version = 1
-    cm1 = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                  version_info={}, released=True, deployed=True)
+    cm1 = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=True,
+        deployed=True,
+    )
     await cm1.insert()
 
     routes = {"8.0.0.0/8": "1.2.3.4", "0.0.0.0/0": "127.0.0.1"}
-    res = data.Resource.new(environment=env.id, resource_version_id="std::File[agent1,name=router],v=%d" % version,
-                            status=const.ResourceState.deployed,
-                            attributes={"name": "router", "purge_on_delete": True, "purged": False, "routes": routes})
+    res = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,name=router],v=%d" % version,
+        status=const.ResourceState.deployed,
+        attributes={"name": "router", "purge_on_delete": True, "purged": False, "routes": routes},
+    )
     await res.insert()
     resource_id = res.resource_version_id
 
@@ -1125,16 +1253,29 @@ async def test_resource_provides(init_dataclasses_and_load_schema):
     await env.insert()
 
     version = 1
-    cm1 = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                  version_info={}, released=True, deployed=True)
+    cm1 = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=True,
+        deployed=True,
+    )
     await cm1.insert()
 
-    res1 = data.Resource.new(environment=env.id, resource_version_id="std::File[agent1,path=/etc/file1],v=%d" % version,
-                             status=const.ResourceState.deployed,
-                             attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False})
-    res2 = data.Resource.new(environment=env.id, resource_version_id="std::File[agent1,path=/etc/file2],v=%d" % version,
-                             status=const.ResourceState.deployed,
-                             attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False})
+    res1 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file1],v=%d" % version,
+        status=const.ResourceState.deployed,
+        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+    )
+    res2 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file2],v=%d" % version,
+        status=const.ResourceState.deployed,
+        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+    )
     res1.provides.append(res2.resource_version_id)
 
     assert len(res1.provides) == 1
@@ -1163,19 +1304,35 @@ async def test_resource_hash(init_dataclasses_and_load_schema):
     await env.insert()
 
     for version in range(1, 4):
-        cm1 = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                      version_info={}, released=True, deployed=True)
+        cm1 = data.ConfigurationModel(
+            environment=env.id,
+            version=version,
+            date=datetime.datetime.now(),
+            total=1,
+            version_info={},
+            released=True,
+            deployed=True,
+        )
         await cm1.insert()
 
-    res1 = data.Resource.new(environment=env.id, resource_version_id="std::File[agent1,path=/etc/file1],v=1",
-                             status=const.ResourceState.deployed,
-                             attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False})
-    res2 = data.Resource.new(environment=env.id, resource_version_id="std::File[agent1,path=/etc/file1],v=2",
-                             status=const.ResourceState.deployed,
-                             attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False})
-    res3 = data.Resource.new(environment=env.id, resource_version_id="std::File[agent1,path=/etc/file1],v=3",
-                             status=const.ResourceState.deployed,
-                             attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": True})
+    res1 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file1],v=1",
+        status=const.ResourceState.deployed,
+        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+    )
+    res2 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file1],v=2",
+        status=const.ResourceState.deployed,
+        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+    )
+    res3 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file1],v=3",
+        status=const.ResourceState.deployed,
+        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": True},
+    )
     await res1.insert()
     await res2.insert()
     await res3.insert()
@@ -1185,8 +1342,9 @@ async def test_resource_hash(init_dataclasses_and_load_schema):
     assert res3.attribute_hash is not None
     assert res1.attribute_hash != res3.attribute_hash
 
-    readres = await data.Resource.get_resources(env.id,
-                                                [res1.resource_version_id, res2.resource_version_id, res3.resource_version_id])
+    readres = await data.Resource.get_resources(
+        env.id, [res1.resource_version_id, res2.resource_version_id, res3.resource_version_id]
+    )
 
     resource_map = {r.resource_version_id: r for r in readres}
     res1 = resource_map[res1.resource_version_id]
@@ -1209,42 +1367,81 @@ async def test_resources_report(init_dataclasses_and_load_schema):
 
     # model 1
     version = 1
-    cm1 = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                  version_info={}, released=True, deployed=True)
+    cm1 = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=True,
+        deployed=True,
+    )
     await cm1.insert()
 
-    res11 = data.Resource.new(environment=env.id, resource_version_id="std::File[agent1,path=/etc/file1],v=%s" % version,
-                              status=const.ResourceState.deployed, last_deploy=datetime.datetime(2018, 7, 14, 12, 30),
-                              attributes={"path": "/etc/file1"})
+    res11 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file1],v=%s" % version,
+        status=const.ResourceState.deployed,
+        last_deploy=datetime.datetime(2018, 7, 14, 12, 30),
+        attributes={"path": "/etc/file1"},
+    )
     await res11.insert()
-    res12 = data.Resource.new(environment=env.id, resource_version_id="std::File[agent1,path=/etc/file2],v=%s" % version,
-                              status=const.ResourceState.deployed, last_deploy=datetime.datetime(2018, 7, 14, 12, 30),
-                              attributes={"path": "/etc/file2"})
+    res12 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file2],v=%s" % version,
+        status=const.ResourceState.deployed,
+        last_deploy=datetime.datetime(2018, 7, 14, 12, 30),
+        attributes={"path": "/etc/file2"},
+    )
     await res12.insert()
 
     # model 2
     version += 1
-    cm2 = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                  version_info={}, released=False, deployed=False)
+    cm2 = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=False,
+        deployed=False,
+    )
     await cm2.insert()
-    res21 = data.Resource.new(environment=env.id, resource_version_id="std::File[agent1,path=/etc/file1],v=%s" % version,
-                              status=const.ResourceState.available,
-                              attributes={"path": "/etc/file1"})
+    res21 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file1],v=%s" % version,
+        status=const.ResourceState.available,
+        attributes={"path": "/etc/file1"},
+    )
     await res21.insert()
-    res22 = data.Resource.new(environment=env.id, resource_version_id="std::File[agent1,path=/etc/file3],v=%s" % version,
-                              status=const.ResourceState.available,
-                              attributes={"path": "/etc/file3"})
+    res22 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file3],v=%s" % version,
+        status=const.ResourceState.available,
+        attributes={"path": "/etc/file3"},
+    )
     await res22.insert()
 
     # model 3
     version += 1
-    cm3 = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                  version_info={}, released=True, deployed=True)
+    cm3 = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=True,
+        deployed=True,
+    )
     await cm3.insert()
 
-    res31 = data.Resource.new(environment=env.id, resource_version_id="std::File[agent1,path=/etc/file2],v=%s" % version,
-                              status=const.ResourceState.deployed, last_deploy=datetime.datetime(2018, 7, 14, 14, 30),
-                              attributes={"path": "/etc/file2"})
+    res31 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file2],v=%s" % version,
+        status=const.ResourceState.deployed,
+        last_deploy=datetime.datetime(2018, 7, 14, 14, 30),
+        attributes={"path": "/etc/file2"},
+    )
     await res31.insert()
 
     report = await data.Resource.get_resources_report(env.id)
@@ -1280,30 +1477,51 @@ async def test_resources_delete_cascade(init_dataclasses_and_load_schema):
     await env.insert()
 
     version = 1
-    cm = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                 version_info={}, released=True, deployed=True)
+    cm = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=True,
+        deployed=True,
+    )
     await cm.insert()
 
-    res1 = data.Resource.new(environment=env.id,
-                             resource_version_id="std::File[agent1,path=/etc/file1],v=%s" % version,
-                             status=const.ResourceState.deployed, last_deploy=datetime.datetime.now(),
-                             attributes={"path": "/etc/file1"})
+    res1 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file1],v=%s" % version,
+        status=const.ResourceState.deployed,
+        last_deploy=datetime.datetime.now(),
+        attributes={"path": "/etc/file1"},
+    )
     await res1.insert()
-    res2 = data.Resource.new(environment=env.id,
-                             resource_version_id="std::File[agent1,path=/etc/file2],v=%s" % version,
-                             status=const.ResourceState.deployed, last_deploy=datetime.datetime.now(),
-                             attributes={"path": "/etc/file1"})
+    res2 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file2],v=%s" % version,
+        status=const.ResourceState.deployed,
+        last_deploy=datetime.datetime.now(),
+        attributes={"path": "/etc/file1"},
+    )
     await res2.insert()
     action_id_resource_action_1 = uuid.uuid4()
-    resource_action1 = data.ResourceAction(environment=env.id, resource_version_ids=[res1.resource_version_id],
-                                           action_id=action_id_resource_action_1, action=const.ResourceAction.deploy,
-                                           started=datetime.datetime.now())
+    resource_action1 = data.ResourceAction(
+        environment=env.id,
+        resource_version_ids=[res1.resource_version_id],
+        action_id=action_id_resource_action_1,
+        action=const.ResourceAction.deploy,
+        started=datetime.datetime.now(),
+    )
     await resource_action1.insert()
 
     action_id_resource_action_2 = uuid.uuid4()
-    resource_action2 = data.ResourceAction(environment=env.id, resource_version_ids=[res2.resource_version_id],
-                                           action_id=action_id_resource_action_2, action=const.ResourceAction.deploy,
-                                           started=datetime.datetime.now())
+    resource_action2 = data.ResourceAction(
+        environment=env.id,
+        resource_version_ids=[res2.resource_version_id],
+        action_id=action_id_resource_action_2,
+        action=const.ResourceAction.deploy,
+        started=datetime.datetime.now(),
+    )
     await resource_action2.insert()
 
     await res1.delete_cascade()
@@ -1332,14 +1550,19 @@ async def test_resource_action(init_dataclasses_and_load_schema):
     now = datetime.datetime.now()
     action_id = uuid.uuid4()
     resource_version_ids = ["std::File[agent1,path=/etc/file1],v=1", "std::File[agent1,path=/etc/file2],v=1"]
-    resource_action = data.ResourceAction(environment=env.id, resource_version_ids=resource_version_ids, action_id=action_id,
-                                          action=const.ResourceAction.deploy, started=now)
+    resource_action = data.ResourceAction(
+        environment=env.id,
+        resource_version_ids=resource_version_ids,
+        action_id=action_id,
+        action=const.ResourceAction.deploy,
+        started=now,
+    )
     await resource_action.insert()
 
     resource_action.add_changes({"rid": {"field1": {"old": "a", "new": "b"}, "field2": {}}})
     await resource_action.save()
 
-    resource_action.add_changes({"rid": {"field2": {"old": "c", "new": "d"}, "field3": ['removed', 'installed']}})
+    resource_action.add_changes({"rid": {"field2": {"old": "c", "new": "d"}, "field3": ["removed", "installed"]}})
     await resource_action.save()
 
     resource_action.add_logs([{}, {}])
@@ -1370,7 +1593,7 @@ async def test_resource_action(init_dataclasses_and_load_schema):
         assert ra.changes["rid"]["field1"]["new"] == "b"
         assert ra.changes["rid"]["field2"]["old"] == "c"
         assert ra.changes["rid"]["field2"]["new"] == "d"
-        assert ra.changes["rid"]["field3"] == ['removed', 'installed']
+        assert ra.changes["rid"]["field3"] == ["removed", "installed"]
         assert ra.status == const.ResourceState.failed
 
         assert len(ra.messages) == 4
@@ -1388,29 +1611,32 @@ async def test_resource_action_get_logs(init_dataclasses_and_load_schema):
 
     for i in range(1, 11):
         action_id = uuid.uuid4()
-        resource_action = data.ResourceAction(environment=env.id,
-                                              resource_version_ids=["std::File[agent1,path=/etc/motd],v=%1"],
-                                              action_id=action_id,
-                                              action=const.ResourceAction.deploy,
-                                              started=datetime.datetime.now())
+        resource_action = data.ResourceAction(
+            environment=env.id,
+            resource_version_ids=["std::File[agent1,path=/etc/motd],v=%1"],
+            action_id=action_id,
+            action=const.ResourceAction.deploy,
+            started=datetime.datetime.now(),
+        )
         await resource_action.insert()
         resource_action.add_logs([data.LogLine.log(logging.INFO, "Successfully stored version %(version)d", version=i)])
         await resource_action.save()
 
     action_id = uuid.uuid4()
 
-    resource_action = data.ResourceAction(environment=env.id,
-                                          resource_version_ids=["std::File[agent1,path=/etc/motd],v=%1"],
-                                          action_id=action_id,
-                                          action=const.ResourceAction.dryrun,
-                                          started=datetime.datetime.now())
+    resource_action = data.ResourceAction(
+        environment=env.id,
+        resource_version_ids=["std::File[agent1,path=/etc/motd],v=%1"],
+        action_id=action_id,
+        action=const.ResourceAction.dryrun,
+        started=datetime.datetime.now(),
+    )
     await resource_action.insert()
     times = datetime.datetime.now()
     resource_action.add_logs([data.LogLine.log(logging.WARNING, "warning version %(version)d", version=100, timestamp=times)])
     await resource_action.save()
 
-    resource_actions = await data.ResourceAction.get_log(env.id,
-                                                         "std::File[agent1,path=/etc/motd],v=%1")
+    resource_actions = await data.ResourceAction.get_log(env.id, "std::File[agent1,path=/etc/motd],v=%1")
     assert len(resource_actions) == 11
     for i in range(len(resource_actions)):
         action = resource_actions[i]
@@ -1418,17 +1644,17 @@ async def test_resource_action_get_logs(init_dataclasses_and_load_schema):
             assert action.action == const.ResourceAction.dryrun
         else:
             assert action.action == const.ResourceAction.deploy
-    resource_actions = await data.ResourceAction.get_log(env.id,
-                                                         "std::File[agent1,path=/etc/motd],v=%1",
-                                                         const.ResourceAction.dryrun.name)
+    resource_actions = await data.ResourceAction.get_log(
+        env.id, "std::File[agent1,path=/etc/motd],v=%1", const.ResourceAction.dryrun.name
+    )
     assert len(resource_actions) == 1
     action = resource_actions[0]
     assert action.action == const.ResourceAction.dryrun
     assert action.messages[0]["level"] == LogLevel.WARNING.name
     assert action.messages[0]["timestamp"] == times
-    resource_actions = await data.ResourceAction.get_log(env.id,
-                                                         "std::File[agent1,path=/etc/motd],v=%1",
-                                                         const.ResourceAction.deploy.name, limit=2)
+    resource_actions = await data.ResourceAction.get_log(
+        env.id, "std::File[agent1,path=/etc/motd],v=%1", const.ResourceAction.deploy.name, limit=2
+    )
     assert len(resource_actions) == 2
     for action in resource_actions:
         assert len(action.messages) == 1
@@ -1444,13 +1670,15 @@ async def test_data_document_recursion(init_dataclasses_and_load_schema):
     await env.insert()
 
     now = datetime.datetime.now()
-    ra = data.ResourceAction(environment=env.id,
-                             resource_version_ids=["test"],
-                             action_id=uuid.uuid4(),
-                             action=const.ResourceAction.store,
-                             started=now,
-                             finished=now,
-                             messages=[data.LogLine.log(logging.INFO, "Successfully stored version %(version)d", version=2)])
+    ra = data.ResourceAction(
+        environment=env.id,
+        resource_version_ids=["test"],
+        action_id=uuid.uuid4(),
+        action=const.ResourceAction.store,
+        started=now,
+        finished=now,
+        messages=[data.LogLine.log(logging.INFO, "Successfully stored version %(version)d", version=2)],
+    )
     await ra.insert()
 
 
@@ -1485,8 +1713,9 @@ async def test_code(init_dataclasses_and_load_schema):
         assert code1.environment == code1.environment
         assert code1.resource == code2.resource
         assert code1.version == code2.version
-        shared_keys_source_refs = [k for k in code1.source_refs
-                                   if k in code2.source_refs and code1.source_refs[k] == code2.source_refs[k]]
+        shared_keys_source_refs = [
+            k for k in code1.source_refs if k in code2.source_refs and code1.source_refs[k] == code2.source_refs[k]
+        ]
         assert len(shared_keys_source_refs) == len(code1.source_refs.keys())
 
     code_file = await data.Code.get_version(env.id, version, "std::File")
@@ -1526,8 +1755,9 @@ async def test_parameter(init_dataclasses_and_load_schema):
     parameters = []
     for current_time in [time1, time2, time3]:
         t = current_time.strftime("%Y-%m-%dT%H:%M:%S.%f")
-        parameter = data.Parameter(name="param_" + t, value="test_val_" + t, environment=env.id, source="test",
-                                   updated=current_time)
+        parameter = data.Parameter(
+            name="param_" + t, value="test_val_" + t, environment=env.id, source="test", updated=current_time
+        )
         parameters.append(parameter)
         await parameter.insert()
 
@@ -1707,18 +1937,21 @@ async def test_compile_get_report(init_dataclasses_and_load_schema):
     report_of_compile = await data.Compile.get_report(compile1.id)
     assert report_of_compile["reports"] == []
 
-    report11 = data.Report(started=datetime.datetime.now(), completed=datetime.datetime.now(),
-                           command="cmd", name="test", compile=compile1.id)
+    report11 = data.Report(
+        started=datetime.datetime.now(), completed=datetime.datetime.now(), command="cmd", name="test", compile=compile1.id
+    )
     await report11.insert()
-    report12 = data.Report(started=datetime.datetime.now(), completed=datetime.datetime.now(),
-                           command="cmd", name="test", compile=compile1.id)
+    report12 = data.Report(
+        started=datetime.datetime.now(), completed=datetime.datetime.now(), command="cmd", name="test", compile=compile1.id
+    )
     await report12.insert()
 
     # Compile 2
     compile2 = data.Compile(environment=env.id)
     await compile2.insert()
-    report21 = data.Report(started=datetime.datetime.now(), completed=datetime.datetime.now(),
-                           command="cmd", name="test", compile=compile2.id)
+    report21 = data.Report(
+        started=datetime.datetime.now(), completed=datetime.datetime.now(), command="cmd", name="test", compile=compile2.id
+    )
     await report21.insert()
 
     report_of_compile = await data.Compile.get_report(compile1.id)
@@ -1737,10 +1970,12 @@ async def test_compile_get_report(init_dataclasses_and_load_schema):
 
 
 @pytest.mark.asyncio
-async def test_match_tables_in_db_against_table_definitions_in_orm(postgres_db, database_name, postgresql_client,
-                                                                   init_dataclasses_and_load_schema):
-    table_names = await postgresql_client.fetch("SELECT table_name FROM information_schema.tables "
-                                                "WHERE table_schema='public'")
+async def test_match_tables_in_db_against_table_definitions_in_orm(
+    postgres_db, database_name, postgresql_client, init_dataclasses_and_load_schema
+):
+    table_names = await postgresql_client.fetch(
+        "SELECT table_name FROM information_schema.tables " "WHERE table_schema='public'"
+    )
     table_names_in_database = [x["table_name"] for x in table_names]
     table_names_in_classes_list = [x.__name__.lower() for x in data._classes]
     assert len(table_names_in_classes_list) == len(table_names_in_database)
@@ -1786,8 +2021,11 @@ async def test_dbschema_update_db_schema_failure(postgresql_client, init_datacla
 
     # Assert rollback
     assert (await data.SchemaVersion.get_current_version()) == current_db_version
-    assert (await postgresql_client.fetchval("SELECT table_name FROM information_schema.tables "
-                                             "WHERE table_schema='public' AND table_name='tab'")) is None
+    assert (
+        await postgresql_client.fetchval(
+            "SELECT table_name FROM information_schema.tables " "WHERE table_schema='public' AND table_name='tab'"
+        )
+    ) is None
 
     async def update_function(connection):
         # Fix syntax issue
@@ -1803,8 +2041,9 @@ async def test_dbschema_update_db_schema_failure(postgresql_client, init_datacla
 
 @pytest.mark.asyncio
 async def test_dbschema_get_dct_with_update_functions():
-    module_names = [modname for _, modname, ispkg in pkgutil.iter_modules(data.DBSchema.PACKAGE_WITH_UPDATE_FILES.__path__)
-                    if not ispkg]
+    module_names = [
+        modname for _, modname, ispkg in pkgutil.iter_modules(data.DBSchema.PACKAGE_WITH_UPDATE_FILES.__path__) if not ispkg
+    ]
     all_versions = [int(mod_name[1:]) for mod_name in module_names]
 
     db_schema = data.DBSchema()
@@ -1837,18 +2076,30 @@ async def test_purgelog_test(init_dataclasses_and_load_schema):
     timestamp_ra1 = datetime.datetime.now() - datetime.timedelta(days=8)
     log_line_ra1 = data.LogLine.log(logging.INFO, "Successfully stored version %(version)d", version=1)
     action_id = uuid.uuid4()
-    ra1 = data.ResourceAction(environment=env.id, resource_version_ids=["id1"], action_id=action_id,
-                              action=const.ResourceAction.store, started=timestamp_ra1, finished=datetime.datetime.now(),
-                              messages=[log_line_ra1])
+    ra1 = data.ResourceAction(
+        environment=env.id,
+        resource_version_ids=["id1"],
+        action_id=action_id,
+        action=const.ResourceAction.store,
+        started=timestamp_ra1,
+        finished=datetime.datetime.now(),
+        messages=[log_line_ra1],
+    )
     await ra1.insert()
 
     # ResourceAction 2
     timestamp_ra2 = datetime.datetime.now() - datetime.timedelta(days=6)
     log_line_ra2 = data.LogLine.log(logging.INFO, "Successfully stored version %(version)d", version=2)
     action_id = uuid.uuid4()
-    ra2 = data.ResourceAction(environment=env.id, resource_version_ids=["id2"], action_id=action_id,
-                              action=const.ResourceAction.store, started=timestamp_ra2, finished=datetime.datetime.now(),
-                              messages=[log_line_ra2])
+    ra2 = data.ResourceAction(
+        environment=env.id,
+        resource_version_ids=["id2"],
+        action_id=action_id,
+        action=const.ResourceAction.store,
+        started=timestamp_ra2,
+        finished=datetime.datetime.now(),
+        messages=[log_line_ra2],
+    )
     await ra2.insert()
 
     assert len(await data.ResourceAction.get_list()) == 2
@@ -1880,14 +2131,24 @@ async def test_resources_json(init_dataclasses_and_load_schema):
     await env.insert()
 
     version = 1
-    cm = data.ConfigurationModel(environment=env.id, version=version, date=datetime.datetime.now(), total=1,
-                                 version_info={}, released=True, deployed=True)
+    cm = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=True,
+        deployed=True,
+    )
     await cm.insert()
 
-    res1 = data.Resource.new(environment=env.id,
-                             resource_version_id="std::File[agent1,path=/etc/file1],v=%s" % version,
-                             status=const.ResourceState.deployed, last_deploy=datetime.datetime.now(),
-                             attributes={"attr": [{"a": 1, "b": "c"}]})
+    res1 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file1],v=%s" % version,
+        status=const.ResourceState.deployed,
+        last_deploy=datetime.datetime.now(),
+        attributes={"attr": [{"a": 1, "b": "c"}]},
+    )
     await res1.insert()
 
     res = await data.Resource.get_one(environment=res1.environment, resource_version_id=res1.resource_version_id)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -35,6 +35,7 @@ def test_basic_install(tmpdir):
     venv1.use_virtual_env()
     venv1._install(["lorem"])
     import lorem  # NOQA
+
     lorem.sentence()
 
     with pytest.raises(ImportError):
@@ -54,7 +55,8 @@ def test_basic_install(tmpdir):
     venv1.use_virtual_env()
     try:
         venv1.install_from_list(
-            ["lorem == 0.1.1", "dummy-yummy", "iplib@git+https://github.com/bartv/python3-iplib", "lorem", "iplib >=0.0.1"])
+            ["lorem == 0.1.1", "dummy-yummy", "iplib@git+https://github.com/bartv/python3-iplib", "lorem", "iplib >=0.0.1"]
+        )
     except CalledProcessError as ep:
         print(ep.stdout)
         raise
@@ -68,16 +70,16 @@ def test_req_parser(tmpdir):
 
     e = env.VirtualEnv(tmpdir)
     name, u = e._parse_line(url)
-    assert(name is None)
-    assert(u == url)
+    assert name is None
+    assert u == url
 
     name, u = e._parse_line(at_url)
-    assert(name == "iplib")
-    assert(u == egg_url)
+    assert name == "iplib"
+    assert u == egg_url
 
     e._parse_line(egg_url)
-    assert(name == "iplib")
-    assert(u == egg_url)
+    assert name == "iplib"
+    assert u == egg_url
 
 
 def test_gen_req_file(tmpdir):
@@ -85,4 +87,4 @@ def test_gen_req_file(tmpdir):
     req = ["lorem == 0.1.1", "lorem > 0.1", "dummy-yummy", "iplib@git+https://github.com/bartv/python3-iplib", "lorem"]
 
     req_lines = [x for x in e._gen_requirements_file(req).split("\n") if len(x) > 0]
-    assert(len(req_lines) == 3)
+    assert len(req_lines) == 3

--- a/tests/test_export_model.py
+++ b/tests/test_export_model.py
@@ -1,4 +1,4 @@
-'''
+"""
   Copyright 2018 Inmanta
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
     limitations under the License.
 
     Contact: code@inmanta.com
-'''
+"""
 import inmanta.compiler as compiler
 from inmanta.export import ModelExporter
 import logging
@@ -22,7 +22,6 @@ import inmanta.model
 
 
 class EntityBuilder(object):
-
     def __init__(self):
         self._model = {}
 
@@ -61,7 +60,6 @@ class EntityBuilder(object):
 
 
 class TypeBuilder(object):
-
     def __init__(self):
         self._model = {}
 
@@ -69,32 +67,26 @@ class TypeBuilder(object):
         return self._model
 
     def entity(self, name, file, lnr, *parents):
-        self._instance = {"parents": list(parents),
-                          "attributes": {},
-                          "relations": {},
-                          "location": {"file": file, "lnr": lnr}}
+        self._instance = {"parents": list(parents), "attributes": {}, "relations": {}, "location": {"file": file, "lnr": lnr}}
         self._model[name] = self._instance
         return self
 
     def attribute(self, name, type, file, lnr, multi=False, nullable=False, comment=""):
-        x = {"location": {"file": file, "lnr": lnr},
-             "type": type,
-             "multi": multi,
-             "nullable": nullable,
-             "comment": comment}
+        x = {"location": {"file": file, "lnr": lnr}, "type": type, "multi": multi, "nullable": nullable, "comment": comment}
 
         self._instance["attributes"][name] = x
         return self
 
     def relation(self, name, type, file, lnr, multi, reverse="", comment=""):
-        x = {"location": {"file": file, "lnr": lnr},
-             "type": type,
-             "multi": multi,
-             "reverse": reverse,
-             "comment": comment,
-             "source_annotations": [],
-             "target_annotations": []
-             }
+        x = {
+            "location": {"file": file, "lnr": lnr},
+            "type": type,
+            "multi": multi,
+            "reverse": reverse,
+            "comment": comment,
+            "source_annotations": [],
+            "target_annotations": [],
+        }
         self._instance["relations"][name] = x
         self._relation = x
         return self
@@ -112,7 +104,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 def test_basic_model_export(snippetcompiler):
-    snippetcompiler.setup_for_snippet(r"""
+    snippetcompiler.setup_for_snippet(
+        r"""
 typedef hoststring as string matching /^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*$/
 
 entity One:
@@ -136,7 +129,9 @@ end
 
 implement One using none
 implement Two using none
-    """, autostd=False)
+    """,
+        autostd=False,
+    )
 
     (types, scopes) = compiler.do_compile()
 
@@ -145,20 +140,27 @@ implement Two using none
     model = exporter.export_model()
     types = exporter.export_types()
 
-#     LOGGER.debug(yaml.dump(model))
-#     LOGGER.debug(yaml.dump(types))
+    #     LOGGER.debug(yaml.dump(model))
+    #     LOGGER.debug(yaml.dump(types))
 
-    result = EntityBuilder().entity("__config__::One", 1).\
-        attribute("name").value("a").\
-        attribute("hostname").value("bazz").\
-        relation("provides").\
-        relation("requires").\
-        relation("two").value("__config__::Two_1").\
-        entity("__config__::Two", 1).\
-        relation("provides").\
-        relation("requires").\
-        relation("one").value("__config__::One_1").\
-        get_model()
+    result = (
+        EntityBuilder()
+        .entity("__config__::One", 1)
+        .attribute("name")
+        .value("a")
+        .attribute("hostname")
+        .value("bazz")
+        .relation("provides")
+        .relation("requires")
+        .relation("two")
+        .value("__config__::Two_1")
+        .entity("__config__::Two", 1)
+        .relation("provides")
+        .relation("requires")
+        .relation("one")
+        .value("__config__::One_1")
+        .get_model()
+    )
 
     assert model == result
 
@@ -167,17 +169,23 @@ implement Two using none
     annota = {"value": "a"}
     annotb = {"reference": "__config__::One_1"}
 
-    result = TypeBuilder().entity("std::Entity", "internal", 1).\
-        relation("requires", "std::Entity", "internal", 1, [0, -1], "std::Entity.provides").\
-        relation("provides", "std::Entity", "internal", 1, [0, -1], "std::Entity.requires").\
-        entity("__config__::Two", main, 9, 'std::Entity').\
-        relation("one", "__config__::One", main, 14, [0, -1], "__config__::One.two").\
-        target_annotate(annota).target_annotate(annotb).\
-        entity("__config__::One", main, 4, 'std::Entity').\
-        relation("two", "__config__::Two", main, 14, [1, 1], "__config__::Two.one").\
-        source_annotate(annota).source_annotate(annotb).\
-        attribute("hostname", "__config__::hoststring", main, 6).\
-        attribute("name", "string", main, 5).get_model()
+    result = (
+        TypeBuilder()
+        .entity("std::Entity", "internal", 1)
+        .relation("requires", "std::Entity", "internal", 1, [0, -1], "std::Entity.provides")
+        .relation("provides", "std::Entity", "internal", 1, [0, -1], "std::Entity.requires")
+        .entity("__config__::Two", main, 9, "std::Entity")
+        .relation("one", "__config__::One", main, 14, [0, -1], "__config__::One.two")
+        .target_annotate(annota)
+        .target_annotate(annotb)
+        .entity("__config__::One", main, 4, "std::Entity")
+        .relation("two", "__config__::Two", main, 14, [1, 1], "__config__::Two.one")
+        .source_annotate(annota)
+        .source_annotate(annotb)
+        .attribute("hostname", "__config__::hoststring", main, 6)
+        .attribute("name", "string", main, 5)
+        .get_model()
+    )
 
     assert result == types
 
@@ -187,7 +195,8 @@ implement Two using none
 
 
 def test_null_relation_model_export(snippetcompiler):
-    snippetcompiler.setup_for_snippet("""
+    snippetcompiler.setup_for_snippet(
+        """
 entity One:
 end
 
@@ -198,24 +207,23 @@ implementation none for std::Entity:
 
 end
 implement One using none
-""", autostd=False)
+""",
+        autostd=False,
+    )
     (types, scopes) = compiler.do_compile()
     exporter = ModelExporter(types)
 
     model = exporter.export_model()
     types = exporter.export_types()
 
-    result = EntityBuilder().entity("__config__::One", 1).\
-        relation("provides").\
-        relation("requires").\
-        relation("one").\
-        get_model()
+    result = EntityBuilder().entity("__config__::One", 1).relation("provides").relation("requires").relation("one").get_model()
 
     assert model == result
 
 
 def test_unknown_relation_model_export(snippetcompiler):
-    snippetcompiler.setup_for_snippet("""
+    snippetcompiler.setup_for_snippet(
+        """
 import tests
 entity One:
 end
@@ -227,25 +235,31 @@ implementation none for std::Entity:
 
 end
 implement One using none
-""", autostd=False)
+""",
+        autostd=False,
+    )
     (types, scopes) = compiler.do_compile()
     exporter = ModelExporter(types)
 
     model = exporter.export_model()
     types = exporter.export_types()
 
-    result = EntityBuilder().entity("__config__::One", 1).\
-        relation("provides").\
-        relation("requires").\
-        relation("one").\
-        value("_UNKNOWN_").\
-        get_model()
+    result = (
+        EntityBuilder()
+        .entity("__config__::One", 1)
+        .relation("provides")
+        .relation("requires")
+        .relation("one")
+        .value("_UNKNOWN_")
+        .get_model()
+    )
 
     assert model == result
 
 
 def test_complex_attributes_model_export(snippetcompiler):
-    snippetcompiler.setup_for_snippet("""
+    snippetcompiler.setup_for_snippet(
+        """
 import tests
 entity Two:
     string[] odds
@@ -261,37 +275,46 @@ implementation none for std::Entity:
 end
 implement Two using none
 
-""", autostd=False)
+""",
+        autostd=False,
+    )
     (types, scopes) = compiler.do_compile()
     exporter = ModelExporter(types)
 
     model = exporter.export_model()
     types = exporter.export_types()
 
-    result = EntityBuilder().entity("__config__::Two", 1).\
-        relation("provides").\
-        relation("requires").\
-        attribute("odds").\
-        value("a").\
-        value("d").\
-        unknown(1).\
-        unknown(2).\
-        attribute("b").\
-        null().\
-        attribute("c").\
-        null().\
-        get_model()
+    result = (
+        EntityBuilder()
+        .entity("__config__::Two", 1)
+        .relation("provides")
+        .relation("requires")
+        .attribute("odds")
+        .value("a")
+        .value("d")
+        .unknown(1)
+        .unknown(2)
+        .attribute("b")
+        .null()
+        .attribute("c")
+        .null()
+        .get_model()
+    )
 
     assert model == result
 
     main = snippetcompiler.main
 
-    result = TypeBuilder().entity("std::Entity", "internal", 1).\
-        relation("requires", "std::Entity", "internal", 1, [0, -1], "std::Entity.provides").\
-        relation("provides", "std::Entity", "internal", 1, [0, -1], "std::Entity.requires").\
-        entity("__config__::Two", main, 3, 'std::Entity').\
-        attribute("odds", "string", main, 4, multi=True).\
-        attribute("b", "string", main, 5, nullable=True).\
-        attribute("c", "string", main, 6, nullable=True).get_model()
+    result = (
+        TypeBuilder()
+        .entity("std::Entity", "internal", 1)
+        .relation("requires", "std::Entity", "internal", 1, [0, -1], "std::Entity.provides")
+        .relation("provides", "std::Entity", "internal", 1, [0, -1], "std::Entity.requires")
+        .entity("__config__::Two", main, 3, "std::Entity")
+        .attribute("odds", "string", main, 4, multi=True)
+        .attribute("b", "string", main, 5, nullable=True)
+        .attribute("c", "string", main, 6, nullable=True)
+        .get_model()
+    )
 
     assert result == types

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -70,7 +70,9 @@ async def test_update_form(client, environment):
     assert len(result.result["form"]["field_options"]) == 2
 
     form_data["attributes"]["sprout"] = {
-        "default": 1, "options": {"min": 1, "max": 100, "widget": "slider", "help": "help"}, "type": "number"
+        "default": 1,
+        "options": {"min": 1, "max": 100, "widget": "slider", "help": "help"},
+        "type": "number",
     }
     result = await client.put_form(tid=environment, id=form_id, form=form_data)
     assert result.code == 200

--- a/tests/test_influxdbreporting.py
+++ b/tests/test_influxdbreporting.py
@@ -83,9 +83,7 @@ def influxdb(event_loop, free_socket):
 
 @pytest.mark.asyncio
 async def test_influxdb(influxdb):
-    rep = InfluxReporter(
-        port=influxdb.port, tags={"mark": "X"}, autocreate_database=True
-    )
+    rep = InfluxReporter(port=influxdb.port, tags={"mark": "X"}, autocreate_database=True)
     with timer("test").time():
         pass
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -62,7 +62,7 @@ def test_check_read(io, testdir):
 
 @pytest.mark.parametrize("io", io_list)
 def test_check_read_binary(io, testdir):
-    test_str = b'\1\2\3\4\5\6'
+    test_str = b"\1\2\3\4\5\6"
     filename = os.path.join(testdir, "readbinaryfile")
     with open(filename, "wb+") as fd:
         fd.write(test_str)
@@ -76,7 +76,7 @@ def test_check_read_binary(io, testdir):
 @pytest.mark.parametrize("io", io_list, ids=io_names)
 def test_check_run_pipe_actual(io, testdir):
     filename = os.path.join(testdir, "testfile")
-    result = io.run('sh', ['-c', 'export PATH=$PATH:/usr/lib/jvm/jre-1.7.0-openjdk/bin; env >' + filename + ' 2>&1'])
+    result = io.run("sh", ["-c", "export PATH=$PATH:/usr/lib/jvm/jre-1.7.0-openjdk/bin; env >" + filename + " 2>&1"])
     print(result)
     assert "/usr/lib/jvm/jre-1.7.0-openjdk/bin" not in result[0]
     assert result[2] == 0
@@ -157,12 +157,12 @@ def test_check_mkdir(io, testdir):
 def test_check_rmdir(io, testdir):
     path = os.path.join(testdir, "rmdir" + str(io))
     os.mkdir(path)
-    assert(os.path.exists(path))
+    assert os.path.exists(path)
 
     path2 = os.path.join(path, "testfile" + str(io))
     with open(path2, "w+") as fd:
         fd.write("")
-    assert(os.path.exists(path2))
+    assert os.path.exists(path2)
 
     io.rmdir(path)
 

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -89,7 +89,8 @@ async def test_validate_rs256(jwks, tmp_path):
     port = str(list(jwks._sockets.values())[0].getsockname()[1])
     config_file = os.path.join(tmp_path, "auth.cfg")
     with open(config_file, "w+") as fd:
-        fd.write("""
+        fd.write(
+            """
 [auth_jwt_default]
 algorithm=HS256
 sign=true
@@ -107,9 +108,13 @@ issuer=https://localhost:{0}/auth/realms/inmanta
 audience=sodev
 jwks_uri=http://localhost:{0}/auth/realms/inmanta/protocol/openid-connect/certs
 validate_cert=false
-""".format(port))
+""".format(
+                port
+            )
+        )
 
     from inmanta.config import Config, AuthJWTConfig
+
     Config.load_config(config_file)
 
     cfg_list = await asyncio.get_event_loop().run_in_executor(None, AuthJWTConfig.list)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -84,11 +84,11 @@ def test():
     hv = sha1sum.hexdigest()
 
     with pytest.raises(ImportError):
-        import inmanta_unit_test # NOQA
+        import inmanta_unit_test  # NOQA
 
     cl.deploy_version(hv, "inmanta_unit_test", code)
 
-    import inmanta_unit_test # NOQA
+    import inmanta_unit_test  # NOQA
 
     assert inmanta_unit_test.test() == 10
 
@@ -111,7 +111,7 @@ def test():
     hv = sha1sum.hexdigest()
 
     with pytest.raises(ImportError):
-        import inmanta_bad_unit_test # NOQA
+        import inmanta_bad_unit_test  # NOQA
 
     cl.deploy_version(hv, "inmanta_bad_unit_test", code)
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -38,7 +38,7 @@ def test_bad_module():
 
 
 class TestModuleName(unittest.TestCase):
-    def __init__(self, methodName='runTest'):  # noqa: N803
+    def __init__(self, methodName="runTest"):  # noqa: N803
         unittest.TestCase.__init__(self, methodName)
 
         self.stream = None
@@ -60,7 +60,7 @@ class TestModuleName(unittest.TestCase):
         module.Module(project=mock.Mock(), path=mod_dir)
 
         self.handler.flush()
-        assert("The name in the module file (mod1) does not match the directory name (mod3)" in self.stream.getvalue().strip())
+        assert "The name in the module file (mod1) does not match the directory name (mod3)" in self.stream.getvalue().strip()
 
     def tearDown(self):
         self.log.removeHandler(self.handler)

--- a/tests/test_moduletool.py
+++ b/tests/test_moduletool.py
@@ -52,10 +52,13 @@ def makemodule(reporoot, name, deps=[], project=False, imports=None, install_mod
         projectfile.write("\nversion: '0.0.1'")
 
         if project:
-            projectfile.write("""
+            projectfile.write(
+                """
 modulepath: libs
 downloadpath: libs
-repo: %s""" % reporoot)
+repo: %s"""
+                % reporoot
+            )
 
         if install_mode is not None:
             projectfile.write("\ninstall_mode: %s" % install_mode)
@@ -81,7 +84,7 @@ repo: %s""" % reporoot)
 
     subprocess.check_output(["git", "init"], cwd=path, stderr=subprocess.STDOUT)
     subprocess.check_output(["git", "config", "user.email", '"test@test.example"'], cwd=path, stderr=subprocess.STDOUT)
-    subprocess.check_output(["git", "config", "user.name", 'Tester test'], cwd=path, stderr=subprocess.STDOUT)
+    subprocess.check_output(["git", "config", "user.name", "Tester test"], cwd=path, stderr=subprocess.STDOUT)
 
     return path
 
@@ -115,7 +118,7 @@ def add_file_and_compiler_constraint(modpath, file, content, msg, version, compi
 def commitmodule(modpath, mesg):
     subprocess.check_output(["git", "add", "*"], cwd=modpath, stderr=subprocess.STDOUT)
     subprocess.check_output(["git", "commit", "-a", "-m", mesg], cwd=modpath, stderr=subprocess.STDOUT)
-    rev = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=modpath, stderr=subprocess.STDOUT).decode("utf-8") .strip()
+    rev = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=modpath, stderr=subprocess.STDOUT).decode("utf-8").strip()
     return rev
 
 
@@ -142,8 +145,7 @@ def make_module_simple_deps(reporoot, name, depends=[], project=False, version="
 def install_project(modules_dir, name, config=True):
     subroot = tempfile.mkdtemp()
     coroot = os.path.join(subroot, name)
-    subprocess.check_output(["git", "clone", os.path.join(modules_dir, "repos", name)],
-                            cwd=subroot, stderr=subprocess.STDOUT)
+    subprocess.check_output(["git", "clone", os.path.join(modules_dir, "repos", name)], cwd=subroot, stderr=subprocess.STDOUT)
     os.chdir(coroot)
     os.curdir = coroot
     if config:
@@ -152,19 +154,20 @@ def install_project(modules_dir, name, config=True):
 
 
 def clone_repo(source_dir, repo_name, destination_dir):
-    subprocess.check_output(["git", "clone", os.path.join(source_dir, repo_name)],
-                            cwd=destination_dir,
-                            stderr=subprocess.STDOUT)
-    subprocess.check_output(["git", "config", "user.email", '"test@test.example"'],
-                            cwd=os.path.join(destination_dir, repo_name),
-                            stderr=subprocess.STDOUT)
-    subprocess.check_output(["git", "config", "user.name", 'Tester test'],
-                            cwd=os.path.join(destination_dir, repo_name),
-                            stderr=subprocess.STDOUT)
+    subprocess.check_output(
+        ["git", "clone", os.path.join(source_dir, repo_name)], cwd=destination_dir, stderr=subprocess.STDOUT
+    )
+    subprocess.check_output(
+        ["git", "config", "user.email", '"test@test.example"'],
+        cwd=os.path.join(destination_dir, repo_name),
+        stderr=subprocess.STDOUT,
+    )
+    subprocess.check_output(
+        ["git", "config", "user.name", "Tester test"], cwd=os.path.join(destination_dir, repo_name), stderr=subprocess.STDOUT
+    )
 
 
 class BadModProvider(object):
-
     def __init__(self, parent, badname):
         self.parent = parent
         self.badname = badname
@@ -174,6 +177,7 @@ class BadModProvider(object):
             if args[0] == self.badname:
                 raise CalledProcessError(128, "XX")
             return getattr(self.parent, method_name)(*args, **kw)
+
         return delegator
 
 
@@ -265,19 +269,18 @@ def modules_repo(modules_dir):
     mod7 = make_module_simple(reporoot, "mod7")
     add_file(mod7, "nsignal", "present", "third commit", version="3.2.1")
     add_file(mod7, "signal", "present", "fourth commit", version="3.2.2")
-    add_file_and_compiler_constraint(mod7, "badsignal", "present", "fifth commit",
-                                     version="4.0", compiler_version="1000000.4")
+    add_file_and_compiler_constraint(mod7, "badsignal", "present", "fifth commit", version="4.0", compiler_version="1000000.4")
     add_file(mod7, "badsignal", "present", "sixth commit", version="4.1")
-    add_file_and_compiler_constraint(mod7, "badsignal", "present", "fifth commit",
-                                     version="4.2", compiler_version="1000000.5")
+    add_file_and_compiler_constraint(mod7, "badsignal", "present", "fifth commit", version="4.2", compiler_version="1000000.5")
     add_file(mod7, "badsignal", "present", "sixth commit", version="4.3")
 
     mod8 = make_module_simple(reporoot, "mod8", [])
     add_file(mod8, "devsignal", "present", "third commit", version="3.3.dev2")
     add_file(mod8, "mastersignal", "present", "last commit")
 
-    proj = makemodule(reporoot, "testproject",
-                      [("mod1", None), ("mod2", ">2016"), ("mod5", None)], True, ["mod1", "mod2", "mod6", "mod7"])
+    proj = makemodule(
+        reporoot, "testproject", [("mod1", None), ("mod2", ">2016"), ("mod5", None)], True, ["mod1", "mod2", "mod6", "mod7"]
+    )
     # results in loading of 1,2,3,6
     commitmodule(proj, "first commit")
 
@@ -293,11 +296,9 @@ def modules_repo(modules_dir):
     masterproject = makemodule(reporoot, "masterproject", project=True, imports=["mod8"], install_mode=INSTALL_MASTER)
     commitmodule(masterproject, "first commit")
 
-    masterproject_multi_mod = makemodule(reporoot,
-                                         "masterproject_multi_mod",
-                                         project=True,
-                                         imports=["mod2", "mod8"],
-                                         install_mode=INSTALL_MASTER)
+    masterproject_multi_mod = makemodule(
+        reporoot, "masterproject_multi_mod", project=True, imports=["mod2", "mod8"], install_mode=INSTALL_MASTER
+    )
     commitmodule(masterproject_multi_mod, "first commit")
 
     nover = makemodule(reporoot, "nover", [])
@@ -366,8 +367,9 @@ def test_local_repo_bad(modules_dir, modules_repo):
 
 def test_bad_checkout(modules_dir, modules_repo):
     coroot = os.path.join(modules_dir, "badproject")
-    subprocess.check_output(["git", "clone", os.path.join(modules_dir, "repos", "badproject")],
-                            cwd=modules_dir, stderr=subprocess.STDOUT)
+    subprocess.check_output(
+        ["git", "clone", os.path.join(modules_dir, "repos", "badproject")], cwd=modules_dir, stderr=subprocess.STDOUT
+    )
     os.chdir(coroot)
     os.curdir = coroot
     Config.load_config()
@@ -378,16 +380,18 @@ def test_bad_checkout(modules_dir, modules_repo):
 
 def test_bad_setup(modules_dir, modules_repo):
     coroot = os.path.join(modules_dir, "badprojectx")
-    subprocess.check_output(["git", "clone", os.path.join(modules_dir, "repos", "badproject"), coroot],
-                            cwd=modules_dir, stderr=subprocess.STDOUT)
+    subprocess.check_output(
+        ["git", "clone", os.path.join(modules_dir, "repos", "badproject"), coroot], cwd=modules_dir, stderr=subprocess.STDOUT
+    )
     os.chdir(coroot)
     os.curdir = coroot
     Config.load_config()
 
     mod1 = os.path.join(coroot, "libs", "mod1")
     os.makedirs(mod1)
-    subprocess.check_output(["git", "clone", os.path.join(modules_dir, "repos", "mod2"), mod1],
-                            cwd=modules_dir, stderr=subprocess.STDOUT)
+    subprocess.check_output(
+        ["git", "clone", os.path.join(modules_dir, "repos", "mod2"), mod1], cwd=modules_dir, stderr=subprocess.STDOUT
+    )
 
     with pytest.raises(ModuleNotFoundException):
         ModuleTool().execute("verify", [])
@@ -395,8 +399,9 @@ def test_bad_setup(modules_dir, modules_repo):
 
 def test_complex_checkout(modules_dir, modules_repo):
     coroot = os.path.join(modules_dir, "testproject")
-    subprocess.check_output(["git", "clone", os.path.join(modules_dir, "repos", "testproject")],
-                            cwd=modules_dir, stderr=subprocess.STDOUT)
+    subprocess.check_output(
+        ["git", "clone", os.path.join(modules_dir, "repos", "testproject")], cwd=modules_dir, stderr=subprocess.STDOUT
+    )
     os.chdir(coroot)
     os.curdir = coroot
     Config.load_config()
@@ -419,8 +424,11 @@ def test_complex_checkout(modules_dir, modules_repo):
 
 def test_for_git_failures(modules_dir, modules_repo):
     coroot = os.path.join(modules_dir, "testproject2")
-    subprocess.check_output(["git", "clone", os.path.join(modules_dir, "repos", "testproject"), "testproject2"],
-                            cwd=modules_dir, stderr=subprocess.STDOUT)
+    subprocess.check_output(
+        ["git", "clone", os.path.join(modules_dir, "repos", "testproject"), "testproject2"],
+        cwd=modules_dir,
+        stderr=subprocess.STDOUT,
+    )
     os.chdir(coroot)
     os.curdir = coroot
     Config.load_config()
@@ -442,8 +450,11 @@ def test_for_git_failures(modules_dir, modules_repo):
 
 def test_install_for_git_failures(modules_dir, modules_repo):
     coroot = os.path.join(modules_dir, "testproject3")
-    subprocess.check_output(["git", "clone", os.path.join(modules_dir, "repos", "testproject"), "testproject3"],
-                            cwd=modules_dir, stderr=subprocess.STDOUT)
+    subprocess.check_output(
+        ["git", "clone", os.path.join(modules_dir, "repos", "testproject"), "testproject3"],
+        cwd=modules_dir,
+        stderr=subprocess.STDOUT,
+    )
     os.chdir(coroot)
     os.curdir = coroot
     Config.load_config()
@@ -459,8 +470,9 @@ def test_install_for_git_failures(modules_dir, modules_repo):
 
 def test_for_repo_without_versions(modules_dir, modules_repo):
     coroot = os.path.join(modules_dir, "noverproject")
-    subprocess.check_output(["git", "clone", os.path.join(modules_dir, "repos", "noverproject")],
-                            cwd=modules_dir, stderr=subprocess.STDOUT)
+    subprocess.check_output(
+        ["git", "clone", os.path.join(modules_dir, "repos", "noverproject")], cwd=modules_dir, stderr=subprocess.STDOUT
+    )
     os.chdir(coroot)
     os.curdir = coroot
     Config.load_config()
@@ -470,8 +482,9 @@ def test_for_repo_without_versions(modules_dir, modules_repo):
 
 def test_bad_dep_checkout(modules_dir, modules_repo):
     coroot = os.path.join(modules_dir, "baddep")
-    subprocess.check_output(["git", "clone", os.path.join(modules_dir, "repos", "baddep")],
-                            cwd=modules_dir, stderr=subprocess.STDOUT)
+    subprocess.check_output(
+        ["git", "clone", os.path.join(modules_dir, "repos", "baddep")], cwd=modules_dir, stderr=subprocess.STDOUT
+    )
     os.chdir(coroot)
     os.curdir = coroot
     Config.load_config()
@@ -492,8 +505,9 @@ def test_master_checkout(modules_dir, modules_repo):
 
 def test_dev_checkout(modules_dir, modules_repo):
     coroot = os.path.join(modules_dir, "devproject")
-    subprocess.check_output(["git", "clone", os.path.join(modules_dir, "repos", "devproject")],
-                            cwd=modules_dir, stderr=subprocess.STDOUT)
+    subprocess.check_output(
+        ["git", "clone", os.path.join(modules_dir, "repos", "devproject")], cwd=modules_dir, stderr=subprocess.STDOUT
+    )
     os.chdir(coroot)
     os.curdir = coroot
     Config.load_config()
@@ -549,12 +563,14 @@ def test_rewrite(tmpdir):
     model.join("_init.cf").write("\n")
 
     module_yml = module_path.join("module.yml")
-    module_yml.write("""
+    module_yml.write(
+        """
 name: mod
 license: ASL
 version: 1.2
 compiler_version: 2017.2
-    """)
+    """
+    )
 
     mod = module.Module(None, module_path.strpath)
 
@@ -572,7 +588,12 @@ def test_freeze_basic(modules_dir, modules_repo):
     cmod = modtool.get_module("modC")
     assert cmod.get_freeze("modC", recursive=False, mode="==") == {"std": "== 3.2", "modE": "== 3.2", "modF": "== 3.2"}
     assert cmod.get_freeze("modC", recursive=True, mode="==") == {
-        "std": "== 3.2", "modE": "== 3.2", "modF": "== 3.2", "modH": "== 3.2", "modJ": "== 3.2"}
+        "std": "== 3.2",
+        "modE": "== 3.2",
+        "modF": "== 3.2",
+        "modH": "== 3.2",
+        "modJ": "== 3.2",
+    }
 
     assert cmod.get_freeze("modC::a", recursive=False, mode="==") == {"std": "== 3.2", "modI": "== 3.2"}
 
@@ -581,8 +602,12 @@ def test_project_freeze_basic(modules_dir, modules_repo):
     install_project(modules_dir, "modA")
     modtool = ModuleTool()
     proj = modtool.get_project()
-    assert proj.get_freeze(recursive=False, mode="==") == {"std": "== 3.2",
-                                                           "modB": "== 3.2", "modC": "== 3.2", "modD": "== 3.2"}
+    assert proj.get_freeze(recursive=False, mode="==") == {
+        "std": "== 3.2",
+        "modB": "== 3.2",
+        "modC": "== 3.2",
+        "modD": "== 3.2",
+    }
     assert proj.get_freeze(recursive=True, mode="==") == {
         "std": "== 3.2",
         "modB": "== 3.2",
@@ -592,7 +617,8 @@ def test_project_freeze_basic(modules_dir, modules_repo):
         "modF": "== 3.2",
         "modG": "== 3.2",
         "modH": "== 3.2",
-        "modJ": "== 3.2"}
+        "modJ": "== 3.2",
+    }
 
 
 def test_project_freeze_bad(modules_dir, modules_repo, capsys, caplog):
@@ -622,7 +648,9 @@ def test_project_freeze(modules_dir, modules_repo, capsys):
 
     assert os.path.getsize(os.path.join(coroot, "project.yml")) != 0
     assert len(err) == 0, err
-    assert out == """name: modA
+    assert (
+        out
+        == """name: modA
 license: Apache 2.0
 version: 0.0.1
 modulepath: libs
@@ -633,7 +661,9 @@ requires:
 - modC ~= 3.2
 - modD ~= 3.2
 - std ~= 3.2
-""" % modules_repo
+"""
+        % modules_repo
+    )
 
 
 def test_project_freeze_odd_opperator(modules_dir, modules_repo, capsys, caplog):
@@ -645,7 +675,9 @@ def test_project_freeze_odd_opperator(modules_dir, modules_repo, capsys, caplog)
 
     assert os.path.getsize(os.path.join(coroot, "project.yml")) != 0
     assert len(err) == 0, err
-    assert out == """name: modA
+    assert (
+        out
+        == """name: modA
 license: Apache 2.0
 version: 0.0.1
 modulepath: libs
@@ -656,7 +688,9 @@ requires:
 - modC xxx 3.2
 - modD xxx 3.2
 - std xxx 3.2
-""" % modules_repo
+"""
+        % modules_repo
+    )
 
     assert "Operator xxx is unknown, expecting one of ['==', '~=', '>=']" in caplog.text
 
@@ -664,7 +698,8 @@ requires:
 def test_project_options_in_config(modules_dir, modules_repo, capsys):
     coroot = install_project(modules_dir, "modA")
     with open("project.yml", "w") as fh:
-        fh.write("""name: modA
+        fh.write(
+            """name: modA
 license: Apache 2.0
 version: 0.0.1
 modulepath: libs
@@ -672,7 +707,9 @@ downloadpath: libs
 repo: %s
 freeze_recursive: true
 freeze_operator: ==
-""" % modules_repo)
+"""
+            % modules_repo
+        )
 
     def verify():
         out, err = capsys.readouterr()
@@ -682,7 +719,8 @@ freeze_operator: ==
         assert len(out) == 0, out
 
         with open("project.yml", "r") as fh:
-            assert fh.read() == ("""name: modA
+            assert fh.read() == (
+                """name: modA
 license: Apache 2.0
 version: 0.0.1
 modulepath: libs
@@ -700,7 +738,9 @@ requires:
 - modH == 3.2
 - modJ == 3.2
 - std == 3.2
-""" % modules_repo)
+"""
+                % modules_repo
+            )
 
     app(["project", "freeze"])
     verify()
@@ -716,7 +756,8 @@ def test_module_freeze(modules_dir, modules_repo, capsys):
 
         assert os.path.getsize(os.path.join(coroot, "project.yml")) != 0
         assert len(err) == 0, err
-        assert out == ("""name: modC
+        assert out == (
+            """name: modC
 license: Apache 2.0
 version: '3.2'
 requires:
@@ -724,7 +765,8 @@ requires:
 - modF ~= 3.2
 - modI ~= 3.2
 - std ~= 3.2
-""")
+"""
+        )
 
     app(["module", "-m", "modC", "freeze", "-o", "-"])
     verify()
@@ -738,7 +780,8 @@ def test_module_freeze_self(modules_dir, modules_repo, capsys):
 
         assert os.path.getsize(os.path.join(coroot, "project.yml")) != 0
         assert len(err) == 0, err
-        assert out == ("""name: modC
+        assert out == (
+            """name: modC
 license: Apache 2.0
 version: '3.2'
 requires:
@@ -746,7 +789,9 @@ requires:
 - modF ~= 3.2
 - modI ~= 3.2
 - std ~= 3.2
-""")
+"""
+        )
+
     modp = os.path.join(coroot, "libs/modC")
     app(["module", "install"])
     os.chdir(modp)
@@ -755,12 +800,13 @@ requires:
     verify()
 
 
-@pytest.mark.parametrize("kwargs_update_method, mod2_should_be_updated, mod8_should_be_updated",
-                         [({}, True, True),
-                          ({"module": "mod2"}, True, False),
-                          ({"module": "mod8"}, False, True)])
-def test_module_update_with_install_mode_master(tmpdir, modules_dir, modules_repo,
-                                                kwargs_update_method, mod2_should_be_updated, mod8_should_be_updated):
+@pytest.mark.parametrize(
+    "kwargs_update_method, mod2_should_be_updated, mod8_should_be_updated",
+    [({}, True, True), ({"module": "mod2"}, True, False), ({"module": "mod8"}, False, True)],
+)
+def test_module_update_with_install_mode_master(
+    tmpdir, modules_dir, modules_repo, kwargs_update_method, mod2_should_be_updated, mod8_should_be_updated
+):
     # Make a copy of masterproject_multi_mod
     masterproject_multi_mod = tmpdir.join("masterproject_multi_mod")
     clone_repo(modules_repo, "masterproject_multi_mod", tmpdir)

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -30,7 +30,7 @@ async def test_param(client, environment):
     """
     fake_uuid = uuid.uuid4()
     result = await client.list_params(tid=fake_uuid)
-    assert(result.code == 404)
+    assert result.code == 404
 
     result = await client.list_params(tid=environment)
-    assert(result.code == 200)
+    assert result.code == 200

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -30,14 +30,7 @@ from inmanta.ast.statements.define import (
     DefineEntity,
     DefineImplementInherits,
 )
-from inmanta.ast.constraint.expression import (
-    GreaterThan,
-    Regex,
-    Not,
-    And,
-    IsDefined,
-    In,
-)
+from inmanta.ast.constraint.expression import GreaterThan, Regex, Not, And, IsDefined, In
 from inmanta.ast.statements.generator import Constructor
 from inmanta.ast.statements.call import FunctionCall
 from inmanta.ast.statements.assign import (
@@ -457,9 +450,7 @@ a = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}
     assert len(statements) == 1
     stmt = statements[0].value
     assert isinstance(stmt, Regex)
-    assert stmt.children[1].value == re.compile(
-        r"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
-    )
+    assert stmt.children[1].value == re.compile(r"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}")
 
 
 def test_regex_escape():
@@ -563,10 +554,7 @@ File(host = 5, path = "Jos")
     stmt = statements[0]
     assert isinstance(stmt, Constructor)
     assert str(stmt.class_type) == "File"
-    assert {k: v.value for k, v in stmt.attributes.items()} == {
-        "host": 5,
-        "path": "Jos",
-    }
+    assert {k: v.value for k, v in stmt.attributes.items()} == {"host": 5, "path": "Jos"}
 
 
 def test_indexlookup():
@@ -953,13 +941,7 @@ end"""
     assert len(stmt.attributes) == 5
 
     compare_attr(stmt.attributes[0], "bar", "bool", assert_is_none, multi=True)
-    compare_attr(
-        stmt.attributes[2],
-        "floom",
-        "string",
-        lambda x: assert_equals([], x.items),
-        multi=True,
-    )
+    compare_attr(stmt.attributes[2], "floom", "string", lambda x: assert_equals([], x.items), multi=True)
 
     def compare_default(list):
         def comp(x):
@@ -970,20 +952,9 @@ end"""
 
         return comp
 
-    compare_attr(
-        stmt.attributes[1], "ips", "ip::ip", compare_default(["a"]), multi=True
-    )
-    compare_attr(
-        stmt.attributes[3], "floomx", "string", compare_default(["a", "b"]), multi=True
-    )
-    compare_attr(
-        stmt.attributes[4],
-        "floomopt",
-        "string",
-        assert_is_non_value,
-        opt=True,
-        multi=True,
-    )
+    compare_attr(stmt.attributes[1], "ips", "ip::ip", compare_default(["a"]), multi=True)
+    compare_attr(stmt.attributes[3], "floomx", "string", compare_default(["a", "b"]), multi=True)
+    compare_attr(stmt.attributes[4], "floomopt", "string", assert_is_non_value, opt=True, multi=True)
 
 
 def test_define_dict_attribute():
@@ -1004,9 +975,7 @@ end"""
     assert len(stmt.attributes) == 5
 
     compare_attr(stmt.attributes[0], "bar", "dict", assert_is_none)
-    compare_attr(
-        stmt.attributes[1], "foo", "dict", lambda x: assert_equals([], x.items)
-    )
+    compare_attr(stmt.attributes[1], "foo", "dict", lambda x: assert_equals([], x.items))
 
     def compare_default(list):
         def comp(x):
@@ -1018,9 +987,7 @@ end"""
         return comp
 
     compare_attr(stmt.attributes[2], "blah", "dict", compare_default([("a", "a")]))
-    compare_attr(
-        stmt.attributes[3], "xxx", "dict", compare_default([("a", "a")]), opt=True
-    )
+    compare_attr(stmt.attributes[3], "xxx", "dict", compare_default([("a", "a")]), opt=True)
     compare_attr(stmt.attributes[4], "xxxx", "dict", assert_is_non_value, opt=True)
 
 

--- a/tests/test_postgres_proc.py
+++ b/tests/test_postgres_proc.py
@@ -49,7 +49,7 @@ def test_stop_already_stopped_process(postgres_proc):
 
 def assert_proc_state(proc, is_running):
     assert proc.running() == is_running
-    assert can_connect_to_tcp_port('localhost', proc.port) == is_running
+    assert can_connect_to_tcp_port("localhost", proc.port) == is_running
 
 
 def can_connect_to_tcp_port(host, port):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -37,25 +37,25 @@ async def test_project_api(client):
     assert "projects" in result.result
     assert len(result.result["projects"]) == 1
 
-    assert result.result["projects"][0]['id'] == project_id
+    assert result.result["projects"][0]["id"] == project_id
 
     result = await client.get_project(id=project_id)
     assert result.code == 200
     assert "project" in result.result
-    assert result.result["project"]['id'] == project_id
-    assert result.result["project"]['name'] == "project-test"
+    assert result.result["project"]["id"] == project_id
+    assert result.result["project"]["name"] == "project-test"
 
     result = await client.modify_project(id=project_id, name="project-test2")
     assert result.code == 200
     assert "project" in result.result
-    assert result.result["project"]['id'] == project_id
-    assert result.result["project"]['name'] == "project-test2"
+    assert result.result["project"]["id"] == project_id
+    assert result.result["project"]["name"] == "project-test2"
 
     result = await client.get_project(id=project_id)
     assert result.code == 200
     assert "project" in result.result
-    assert result.result["project"]['id'] == project_id
-    assert result.result["project"]['name'] == "project-test2"
+    assert result.result["project"]["id"] == project_id
+    assert result.result["project"]["name"] == "project-test2"
 
     result = await client.delete_project(id=project_id)
     assert result.code == 200
@@ -87,15 +87,15 @@ async def test_env_api(client):
     result = await client.modify_environment(id=env_id, name="dev2")
     assert result.code == 200
     assert "environment" in result.result
-    assert result.result["environment"]['id'] == env_id
-    assert result.result["environment"]['name'] == "dev2"
+    assert result.result["environment"]["id"] == env_id
+    assert result.result["environment"]["name"] == "dev2"
 
     result = await client.get_environment(id=env_id)
     assert result.code == 200
     assert "environment" in result.result
-    assert result.result["environment"]['id'] == env_id
-    assert result.result["environment"]['project'] == project_id
-    assert result.result["environment"]['name'] == "dev2"
+    assert result.result["environment"]["id"] == env_id
+    assert result.result["environment"]["project"] == project_id
+    assert result.result["environment"]["name"] == "dev2"
 
     project_result = await client.get_project(id=project_id)
     assert project_result.code == 200

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -233,7 +233,6 @@ async def test_gzip_encoding(server):
 
 
 class MainHandler(web.RequestHandler):
-
     def get(self):
         time.sleep(1.1)
 
@@ -278,6 +277,7 @@ async def test_method_properties():
     """
         Test method properties decorator and helper functions
     """
+
     @protocol.method(method_name="test", operation="PUT", client_types=["api"])
     def test_method(name):
         """
@@ -296,11 +296,13 @@ async def test_invalid_client_type():
         Test invalid client ype
     """
     with pytest.raises(Exception) as e:
+
         @protocol.method(method_name="test", operation="PUT", client_types=["invalid"])
         def test_method(name):
             """
                 Create a new project
             """
+
         assert "Invalid client type invalid specified for function" in str(e)
 
 
@@ -309,6 +311,7 @@ async def test_call_arguments_defaults():
     """
         Test processing RPC messages
     """
+
     @protocol.method(method_name="test", operation="PUT", client_types=["api"])
     def test_method(name: str, value: int = 10):
         """

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -32,14 +32,18 @@ def proxy_object(snippetcompiler, snippet, var):
 
 
 def test_basic_object(snippetcompiler):
-    px = proxy_object(snippetcompiler, """
+    px = proxy_object(
+        snippetcompiler,
+        """
 entity Test1:
 string x
 end
 implement Test1 using std::none
 
 a = Test1(x="a")
-""", "a")
+""",
+        "a",
+    )
 
     assert px.x == "a"
     with pytest.raises(Exception):
@@ -47,14 +51,18 @@ a = Test1(x="a")
 
 
 def test_dict_attr(snippetcompiler):
-    px = proxy_object(snippetcompiler, """
+    px = proxy_object(
+        snippetcompiler,
+        """
 entity Test1:
 dict x = {}
 end
 implement Test1 using std::none
 
 a = Test1(x={"a":"A"})
-""", "a")
+""",
+        "a",
+    )
 
     dic = px.x
     assert dic["a"] == "A"

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -36,19 +36,21 @@ class Resource(Base):
 
 
 def test_field_merge():
-    assert(len(Resource.fields) == 5)
+    assert len(Resource.fields) == 5
 
 
 def test_fields_type():
     with pytest.raises(Exception):
+
         class Test(resources.Resource):
-            fields = ("z")
+            fields = "z"
 
 
 def test_fields_parent_type():
     with pytest.raises(Exception):
+
         class Base(resources.Resource):
-            fields = ("y")
+            fields = "y"
 
         class Test(Base):
             fields = ("z",)
@@ -63,9 +65,11 @@ def test_resource_base(snippetcompiler):
         """
             A file on a filesystem
         """
+
         fields = ("key", "value", "agent")
 
-    snippetcompiler.setup_for_snippet("""
+    snippetcompiler.setup_for_snippet(
+        """
         entity XResource:
             string key
             string agent
@@ -78,7 +82,9 @@ def test_resource_base(snippetcompiler):
         end
 
         XResource(key="key", agent="agent", value="value")
-        """, autostd=False)
+        """,
+        autostd=False,
+    )
     _version, json_value = snippetcompiler.do_export()
 
     assert len(json_value) == 1
@@ -98,13 +104,15 @@ def test_resource_base_with_method_key(snippetcompiler):
         """
             A file on a filesystem
         """
+
         fields = ("key", "value", "agent", "serialize")
 
         @staticmethod
         def get_serialize(_exporter, resource):
             return resource.key
 
-    snippetcompiler.setup_for_snippet("""
+    snippetcompiler.setup_for_snippet(
+        """
         entity XResource:
             string key
             string agent
@@ -117,7 +125,9 @@ def test_resource_base_with_method_key(snippetcompiler):
         end
 
         XResource(key="key", agent="agent", value="value")
-        """, autostd=False)
+        """,
+        autostd=False,
+    )
     with pytest.raises(ResourceException):
         snippetcompiler.do_export()
 
@@ -131,13 +141,15 @@ def test_resource_with_keyword(snippetcompiler):
         """
             A file on a filesystem
         """
+
         fields = ("key", "value", "agent", "model")
 
         @staticmethod
         def get_model(_exporter, resource):
             return resource.key
 
-    snippetcompiler.setup_for_snippet("""
+    snippetcompiler.setup_for_snippet(
+        """
          entity YResource:
              string key
              string agent
@@ -150,7 +162,9 @@ def test_resource_with_keyword(snippetcompiler):
          end
 
          YResource(key="key", agent="agent", value="value")
-         """, autostd=False)
+         """,
+        autostd=False,
+    )
 
     with pytest.raises(ResourceException):
         snippetcompiler.do_export()
@@ -165,9 +179,11 @@ def test_resource_with_private_method(snippetcompiler):
         """
             A file on a filesystem
         """
+
         fields = ("__setattr__", "key", "value", "agent")
 
-    snippetcompiler.setup_for_snippet("""
+    snippetcompiler.setup_for_snippet(
+        """
         entity YResource:
             string key
             string agent
@@ -180,7 +196,9 @@ def test_resource_with_private_method(snippetcompiler):
         end
 
         YResource(key="key", agent="agent", value="value")
-        """, autostd=False)
+        """,
+        autostd=False,
+    )
 
     with pytest.raises(ResourceException):
         snippetcompiler.do_export()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -198,45 +198,56 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
 
     version = 1
 
-    resources = [{'group': 'root',
-                  'hash': '89bf880a0dc5ffc1156c8d958b4960971370ee6a',
-                  'id': 'std::File[vm1.dev.inmanta.com,path=/etc/sysconfig/network],v=%d' % version,
-                  'owner': 'root',
-                  'path': '/etc/sysconfig/network',
-                  'permissions': 644,
-                  'purged': False,
-                  'reload': False,
-                  'requires': [],
-                  'version': version},
-                 {'group': 'root',
-                  'hash': 'b4350bef50c3ec3ee532d4a3f9d6daedec3d2aba',
-                  'id': 'std::File[vm2.dev.inmanta.com,path=/etc/motd],v=%d' % version,
-                  'owner': 'root',
-                  'path': '/etc/motd',
-                  'permissions': 644,
-                  'purged': False,
-                  'reload': False,
-                  'requires': [],
-                  'version': version},
-                 {'group': 'root',
-                  'hash': '3bfcdad9ab7f9d916a954f1a96b28d31d95593e4',
-                  'id': 'std::File[vm1.dev.inmanta.com,path=/etc/hostname],v=%d' % version,
-                  'owner': 'root',
-                  'path': '/etc/hostname',
-                  'permissions': 644,
-                  'purged': False,
-                  'reload': False,
-                  'requires': [],
-                  'version': version},
-                 {'id': 'std::Service[vm1.dev.inmanta.com,name=network],v=%d' % version,
-                  'name': 'network',
-                  'onboot': True,
-                  'requires': ['std::File[vm1.dev.inmanta.com,path=/etc/sysconfig/network],v=%d' % version],
-                  'state': 'running',
-                  'version': version}]
+    resources = [
+        {
+            "group": "root",
+            "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
+            "id": "std::File[vm1.dev.inmanta.com,path=/etc/sysconfig/network],v=%d" % version,
+            "owner": "root",
+            "path": "/etc/sysconfig/network",
+            "permissions": 644,
+            "purged": False,
+            "reload": False,
+            "requires": [],
+            "version": version,
+        },
+        {
+            "group": "root",
+            "hash": "b4350bef50c3ec3ee532d4a3f9d6daedec3d2aba",
+            "id": "std::File[vm2.dev.inmanta.com,path=/etc/motd],v=%d" % version,
+            "owner": "root",
+            "path": "/etc/motd",
+            "permissions": 644,
+            "purged": False,
+            "reload": False,
+            "requires": [],
+            "version": version,
+        },
+        {
+            "group": "root",
+            "hash": "3bfcdad9ab7f9d916a954f1a96b28d31d95593e4",
+            "id": "std::File[vm1.dev.inmanta.com,path=/etc/hostname],v=%d" % version,
+            "owner": "root",
+            "path": "/etc/hostname",
+            "permissions": 644,
+            "purged": False,
+            "reload": False,
+            "requires": [],
+            "version": version,
+        },
+        {
+            "id": "std::Service[vm1.dev.inmanta.com,name=network],v=%d" % version,
+            "name": "network",
+            "onboot": True,
+            "requires": ["std::File[vm1.dev.inmanta.com,path=/etc/sysconfig/network],v=%d" % version],
+            "state": "running",
+            "version": version,
+        },
+    ]
 
-    res = await client_multi.put_version(tid=environment_multi, version=version, resources=resources, unknowns=[],
-                                         version_info={})
+    res = await client_multi.put_version(
+        tid=environment_multi, version=version, resources=resources, unknowns=[], version_info={}
+    )
     assert res.code == 200
 
     result = await client_multi.list_versions(environment_multi)
@@ -259,9 +270,17 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
 
     action_id = uuid.uuid4()
     now = datetime.now()
-    result = await aclient.resource_action_update(environment_multi,
-                                                  ["std::File[vm1.dev.inmanta.com,path=/etc/sysconfig/network],v=%d" % version],
-                                                  action_id, "deploy", now, now, "deployed", [], {})
+    result = await aclient.resource_action_update(
+        environment_multi,
+        ["std::File[vm1.dev.inmanta.com,path=/etc/sysconfig/network],v=%d" % version],
+        action_id,
+        "deploy",
+        now,
+        now,
+        "deployed",
+        [],
+        {},
+    )
 
     assert result.code == 200
 
@@ -271,9 +290,17 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
 
     action_id = uuid.uuid4()
     now = datetime.now()
-    result = await aclient.resource_action_update(environment_multi,
-                                                  ["std::File[vm1.dev.inmanta.com,path=/etc/hostname],v=%d" % version],
-                                                  action_id, "deploy", now, now, "deployed", [], {})
+    result = await aclient.resource_action_update(
+        environment_multi,
+        ["std::File[vm1.dev.inmanta.com,path=/etc/hostname],v=%d" % version],
+        action_id,
+        "deploy",
+        now,
+        now,
+        "deployed",
+        [],
+        {},
+    )
     assert result.code == 200
 
     result = await client_multi.get_version(environment_multi, version)
@@ -291,25 +318,28 @@ async def test_get_environment(client, server, environment):
 
         resources = []
         for j in range(i):
-            resources.append({
-                'group': 'root',
-                'hash': '89bf880a0dc5ffc1156c8d958b4960971370ee6a',
-                'id': 'std::File[vm1.dev.inmanta.com,path=/tmp/file%d],v=%d' % (j, version),
-                'owner': 'root',
-                'path': '/tmp/file%d' % j,
-                'permissions': 644,
-                'purged': False,
-                'reload': False,
-                'requires': [],
-                'version': version})
+            resources.append(
+                {
+                    "group": "root",
+                    "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
+                    "id": "std::File[vm1.dev.inmanta.com,path=/tmp/file%d],v=%d" % (j, version),
+                    "owner": "root",
+                    "path": "/tmp/file%d" % j,
+                    "permissions": 644,
+                    "purged": False,
+                    "reload": False,
+                    "requires": [],
+                    "version": version,
+                }
+            )
 
         res = await client.put_version(tid=environment, version=version, resources=resources, unknowns=[], version_info={})
         assert res.code == 200
 
     result = await client.get_environment(environment, versions=5, resources=1)
-    assert(result.code == 200)
-    assert(len(result.result["environment"]["versions"]) == 5)
-    assert(len(result.result["environment"]["resources"]) == 9)
+    assert result.code == 200
+    assert len(result.result["environment"]["versions"]) == 5
+    assert len(result.result["environment"]["resources"]) == 9
 
 
 @pytest.mark.asyncio
@@ -325,20 +355,23 @@ async def test_resource_update(postgresql_client, client, server, environment):
 
     resources = []
     for j in range(10):
-        resources.append({
-            'group': 'root',
-            'hash': '89bf880a0dc5ffc1156c8d958b4960971370ee6a',
-            'id': 'std::File[vm1,path=/tmp/file%d],v=%d' % (j, version),
-            'owner': 'root',
-            'path': '/tmp/file%d' % j,
-            'permissions': 644,
-            'purged': False,
-            'reload': False,
-            'requires': [],
-            'version': version})
+        resources.append(
+            {
+                "group": "root",
+                "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
+                "id": "std::File[vm1,path=/tmp/file%d],v=%d" % (j, version),
+                "owner": "root",
+                "path": "/tmp/file%d" % j,
+                "permissions": 644,
+                "purged": False,
+                "reload": False,
+                "requires": [],
+                "version": version,
+            }
+        )
 
     res = await client.put_version(tid=environment, version=version, resources=resources, unknowns=[], version_info={})
-    assert(res.code == 200)
+    assert res.code == 200
 
     result = await client.release_version(environment, version, False)
     assert result.code == 200
@@ -348,52 +381,57 @@ async def test_resource_update(postgresql_client, client, server, environment):
     # Start the deploy
     action_id = uuid.uuid4()
     now = datetime.now()
-    result = await aclient.resource_action_update(environment, resource_ids, action_id, "deploy", now,
-                                                  status=const.ResourceState.deploying)
-    assert(result.code == 200)
+    result = await aclient.resource_action_update(
+        environment, resource_ids, action_id, "deploy", now, status=const.ResourceState.deploying
+    )
+    assert result.code == 200
 
     # Get the status from a resource
     result = await client.get_resource(tid=environment, id=resource_ids[0], logs=True)
-    assert(result.code == 200)
+    assert result.code == 200
     logs = {x["action"]: x for x in result.result["logs"]}
 
-    assert("deploy" in logs)
-    assert("finished" not in logs["deploy"])
-    assert("messages" not in logs["deploy"])
-    assert("changes" not in logs["deploy"])
+    assert "deploy" in logs
+    assert "finished" not in logs["deploy"]
+    assert "messages" not in logs["deploy"]
+    assert "changes" not in logs["deploy"]
 
     # Send some logs
-    result = await aclient.resource_action_update(environment, resource_ids, action_id, "deploy",
-                                                  status=const.ResourceState.deploying,
-                                                  messages=[data.LogLine.log(const.LogLevel.INFO,
-                                                                             "Test log %(a)s %(b)s", a="a", b="b")])
-    assert(result.code == 200)
+    result = await aclient.resource_action_update(
+        environment,
+        resource_ids,
+        action_id,
+        "deploy",
+        status=const.ResourceState.deploying,
+        messages=[data.LogLine.log(const.LogLevel.INFO, "Test log %(a)s %(b)s", a="a", b="b")],
+    )
+    assert result.code == 200
 
     # Get the status from a resource
     result = await client.get_resource(tid=environment, id=resource_ids[0], logs=True)
-    assert(result.code == 200)
+    assert result.code == 200
     logs = {x["action"]: x for x in result.result["logs"]}
 
-    assert("deploy" in logs)
-    assert("messages" in logs["deploy"])
-    assert(len(logs["deploy"]["messages"]) == 1)
-    assert(logs["deploy"]["messages"][0]["msg"] == "Test log a b")
-    assert("finished" not in logs["deploy"])
-    assert("changes" not in logs["deploy"])
+    assert "deploy" in logs
+    assert "messages" in logs["deploy"]
+    assert len(logs["deploy"]["messages"]) == 1
+    assert logs["deploy"]["messages"][0]["msg"] == "Test log a b"
+    assert "finished" not in logs["deploy"]
+    assert "changes" not in logs["deploy"]
 
     # Finish the deploy
     now = datetime.now()
     changes = {x: {"owner": {"old": "root", "current": "inmanta"}} for x in resource_ids}
     result = await aclient.resource_action_update(environment, resource_ids, action_id, "deploy", finished=now, changes=changes)
-    assert(result.code == 400)
+    assert result.code == 400
 
-    result = await aclient.resource_action_update(environment, resource_ids, action_id, "deploy",
-                                                  status=const.ResourceState.deployed,
-                                                  finished=now, changes=changes)
-    assert (result.code == 200)
+    result = await aclient.resource_action_update(
+        environment, resource_ids, action_id, "deploy", status=const.ResourceState.deployed, finished=now, changes=changes
+    )
+    assert result.code == 200
 
     result = await client.get_version(environment, version)
-    assert(result.code == 200)
+    assert result.code == 200
     assert result.result["model"]["done"] == 10
     await agent.stop()
 
@@ -458,8 +496,9 @@ async def test_environment_settings(client, server, environment):
     result = await client.delete_setting(tid=environment, id=data.AUTOSTART_AGENT_DEPLOY_SPLAY_TIME)
     assert result.code == 200
 
-    result = await client.set_setting(tid=environment, id=data.AUTOSTART_AGENT_MAP, value={"agent1": "", "agent2": "localhost",
-                                                                                           "agent3": "user@agent3"})
+    result = await client.set_setting(
+        tid=environment, id=data.AUTOSTART_AGENT_MAP, value={"agent1": "", "agent2": "localhost", "agent3": "user@agent3"}
+    )
     assert result.code == 200
 
     result = await client.set_setting(tid=environment, id=data.AUTOSTART_AGENT_MAP, value="")
@@ -498,28 +537,34 @@ async def test_purge_on_delete_requires(client, server, environment):
 
     version = 1
 
-    resources = [{'group': 'root',
-                  'hash': '89bf880a0dc5ffc1156c8d958b4960971370ee6a',
-                  'id': 'std::File[vm1,path=/tmp/file1],v=%d' % version,
-                  'owner': 'root',
-                  'path': '/tmp/file1',
-                  'permissions': 644,
-                  'purged': False,
-                  'reload': False,
-                  'requires': [],
-                  'purge_on_delete': True,
-                  'version': version},
-                 {'group': 'root',
-                  'hash': 'b4350bef50c3ec3ee532d4a3f9d6daedec3d2aba',
-                  'id': 'std::File[vm2,path=/tmp/file2],v=%d' % version,
-                  'owner': 'root',
-                  'path': '/tmp/file2',
-                  'permissions': 644,
-                  'purged': False,
-                  'reload': False,
-                  'purge_on_delete': True,
-                  'requires': ['std::File[vm1,path=/tmp/file1],v=%d' % version],
-                  'version': version}]
+    resources = [
+        {
+            "group": "root",
+            "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
+            "id": "std::File[vm1,path=/tmp/file1],v=%d" % version,
+            "owner": "root",
+            "path": "/tmp/file1",
+            "permissions": 644,
+            "purged": False,
+            "reload": False,
+            "requires": [],
+            "purge_on_delete": True,
+            "version": version,
+        },
+        {
+            "group": "root",
+            "hash": "b4350bef50c3ec3ee532d4a3f9d6daedec3d2aba",
+            "id": "std::File[vm2,path=/tmp/file2],v=%d" % version,
+            "owner": "root",
+            "path": "/tmp/file2",
+            "permissions": 644,
+            "purged": False,
+            "reload": False,
+            "purge_on_delete": True,
+            "requires": ["std::File[vm1,path=/tmp/file1],v=%d" % version],
+            "version": version,
+        },
+    ]
 
     res = await client.put_version(tid=environment, version=version, resources=resources, unknowns=[], version_info={})
     assert res.code == 200
@@ -529,14 +574,14 @@ async def test_purge_on_delete_requires(client, server, environment):
     assert result.code == 200
 
     now = datetime.now()
-    result = await aclient.resource_action_update(environment,
-                                                  ['std::File[vm1,path=/tmp/file1],v=%d' % version],
-                                                  uuid.uuid4(), "deploy", now, now, "deployed", [], {})
+    result = await aclient.resource_action_update(
+        environment, ["std::File[vm1,path=/tmp/file1],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+    )
     assert result.code == 200
 
-    result = await aclient.resource_action_update(environment,
-                                                  ['std::File[vm2,path=/tmp/file2],v=%d' % version],
-                                                  uuid.uuid4(), "deploy", now, now, "deployed", [], {})
+    result = await aclient.resource_action_update(
+        environment, ["std::File[vm2,path=/tmp/file2],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+    )
     assert result.code == 200
 
     result = await client.get_version(environment, version)
@@ -582,19 +627,23 @@ async def test_purge_on_delete_requires(client, server, environment):
 async def test_purge_on_delete_compile_failed_with_compile(event_loop, client, server, environment, snippetcompiler):
     config.Config.set("compiler_rest_transport", "request_timeout", "1")
 
-    snippetcompiler.setup_for_snippet("""
+    snippetcompiler.setup_for_snippet(
+        """
     h = std::Host(name="test", os=std::linux)
     f = std::ConfigFile(host=h, path="/etc/motd", content="test", purge_on_delete=true)
-    """)
+    """
+    )
     version, _ = await snippetcompiler.do_export_and_deploy(do_raise=False)
 
     result = await client.get_version(environment, version)
     assert result.code == 200
     assert result.result["model"]["total"] == 1
 
-    snippetcompiler.setup_for_snippet("""
+    snippetcompiler.setup_for_snippet(
+        """
     h = std::Host(name="test")
-    """)
+    """
+    )
 
     # force deploy by having unknown
     unknown_parameters.append({"parameter": "a", "source": "b"})
@@ -619,39 +668,47 @@ async def test_purge_on_delete_compile_failed(client, server, environment):
 
     version = 1
 
-    resources = [{'group': 'root',
-                  'hash': '89bf880a0dc5ffc1156c8d958b4960971370ee6a',
-                  'id': 'std::File[vm1,path=/tmp/file1],v=%d' % version,
-                  'owner': 'root',
-                  'path': '/tmp/file1',
-                  'permissions': 644,
-                  'purged': False,
-                  'reload': False,
-                  'requires': [],
-                  'purge_on_delete': True,
-                  'version': version},
-                 {'group': 'root',
-                  'hash': 'b4350bef50c3ec3ee532d4a3f9d6daedec3d2aba',
-                  'id': 'std::File[vm1,path=/tmp/file2],v=%d' % version,
-                  'owner': 'root',
-                  'path': '/tmp/file2',
-                  'permissions': 644,
-                  'purged': False,
-                  'reload': False,
-                  'purge_on_delete': True,
-                  'requires': ['std::File[vm1,path=/tmp/file1],v=%d' % version],
-                  'version': version},
-                 {'group': 'root',
-                  'hash': '89bf880a0dc5ffc1156c8d958b4960971370ee6a',
-                  'id': 'std::File[vm1,path=/tmp/file3],v=%d' % version,
-                  'owner': 'root',
-                  'path': '/tmp/file3',
-                  'permissions': 644,
-                  'purged': False,
-                  'reload': False,
-                  'requires': [],
-                  'purge_on_delete': True,
-                  'version': version}]
+    resources = [
+        {
+            "group": "root",
+            "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
+            "id": "std::File[vm1,path=/tmp/file1],v=%d" % version,
+            "owner": "root",
+            "path": "/tmp/file1",
+            "permissions": 644,
+            "purged": False,
+            "reload": False,
+            "requires": [],
+            "purge_on_delete": True,
+            "version": version,
+        },
+        {
+            "group": "root",
+            "hash": "b4350bef50c3ec3ee532d4a3f9d6daedec3d2aba",
+            "id": "std::File[vm1,path=/tmp/file2],v=%d" % version,
+            "owner": "root",
+            "path": "/tmp/file2",
+            "permissions": 644,
+            "purged": False,
+            "reload": False,
+            "purge_on_delete": True,
+            "requires": ["std::File[vm1,path=/tmp/file1],v=%d" % version],
+            "version": version,
+        },
+        {
+            "group": "root",
+            "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
+            "id": "std::File[vm1,path=/tmp/file3],v=%d" % version,
+            "owner": "root",
+            "path": "/tmp/file3",
+            "permissions": 644,
+            "purged": False,
+            "reload": False,
+            "requires": [],
+            "purge_on_delete": True,
+            "version": version,
+        },
+    ]
 
     result = await client.put_version(tid=environment, version=version, resources=resources, unknowns=[], version_info={})
     assert result.code == 200
@@ -661,19 +718,19 @@ async def test_purge_on_delete_compile_failed(client, server, environment):
     assert result.code == 200
 
     now = datetime.now()
-    result = await aclient.resource_action_update(environment,
-                                                  ['std::File[vm1,path=/tmp/file1],v=%d' % version],
-                                                  uuid.uuid4(), "deploy", now, now, "deployed", [], {})
+    result = await aclient.resource_action_update(
+        environment, ["std::File[vm1,path=/tmp/file1],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+    )
     assert result.code == 200
 
-    result = await aclient.resource_action_update(environment,
-                                                  ['std::File[vm1,path=/tmp/file2],v=%d' % version],
-                                                  uuid.uuid4(), "deploy", now, now, "deployed", [], {})
+    result = await aclient.resource_action_update(
+        environment, ["std::File[vm1,path=/tmp/file2],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+    )
     assert result.code == 200
 
-    result = await aclient.resource_action_update(environment,
-                                                  ['std::File[vm1,path=/tmp/file3],v=%d' % version],
-                                                  uuid.uuid4(), "deploy", now, now, "deployed", [], {})
+    result = await aclient.resource_action_update(
+        environment, ["std::File[vm1,path=/tmp/file3],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+    )
     assert result.code == 200
 
     result = await client.get_version(environment, version)
@@ -686,9 +743,13 @@ async def test_purge_on_delete_compile_failed(client, server, environment):
 
     # New version with only file3
     version = 2
-    result = await client.put_version(tid=environment, version=version, resources=[],
-                                      unknowns=[{"parameter": "a", "source": "b"}], version_info={const.EXPORT_META_DATA:
-                                      {const.META_DATA_COMPILE_STATE: const.Compilestate.failed}})
+    result = await client.put_version(
+        tid=environment,
+        version=version,
+        resources=[],
+        unknowns=[{"parameter": "a", "source": "b"}],
+        version_info={const.EXPORT_META_DATA: {const.META_DATA_COMPILE_STATE: const.Compilestate.failed}},
+    )
     assert result.code == 200
 
     result = await client.get_version(environment, version)
@@ -709,39 +770,47 @@ async def test_purge_on_delete(client, server, environment):
 
     version = 1
 
-    resources = [{'group': 'root',
-                  'hash': '89bf880a0dc5ffc1156c8d958b4960971370ee6a',
-                  'id': 'std::File[vm1,path=/tmp/file1],v=%d' % version,
-                  'owner': 'root',
-                  'path': '/tmp/file1',
-                  'permissions': 644,
-                  'purged': False,
-                  'reload': False,
-                  'requires': [],
-                  'purge_on_delete': True,
-                  'version': version},
-                 {'group': 'root',
-                  'hash': 'b4350bef50c3ec3ee532d4a3f9d6daedec3d2aba',
-                  'id': 'std::File[vm1,path=/tmp/file2],v=%d' % version,
-                  'owner': 'root',
-                  'path': '/tmp/file2',
-                  'permissions': 644,
-                  'purged': False,
-                  'reload': False,
-                  'purge_on_delete': True,
-                  'requires': ['std::File[vm1,path=/tmp/file1],v=%d' % version],
-                  'version': version},
-                 {'group': 'root',
-                  'hash': '89bf880a0dc5ffc1156c8d958b4960971370ee6a',
-                  'id': 'std::File[vm1,path=/tmp/file3],v=%d' % version,
-                  'owner': 'root',
-                  'path': '/tmp/file3',
-                  'permissions': 644,
-                  'purged': False,
-                  'reload': False,
-                  'requires': [],
-                  'purge_on_delete': True,
-                  'version': version}]
+    resources = [
+        {
+            "group": "root",
+            "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
+            "id": "std::File[vm1,path=/tmp/file1],v=%d" % version,
+            "owner": "root",
+            "path": "/tmp/file1",
+            "permissions": 644,
+            "purged": False,
+            "reload": False,
+            "requires": [],
+            "purge_on_delete": True,
+            "version": version,
+        },
+        {
+            "group": "root",
+            "hash": "b4350bef50c3ec3ee532d4a3f9d6daedec3d2aba",
+            "id": "std::File[vm1,path=/tmp/file2],v=%d" % version,
+            "owner": "root",
+            "path": "/tmp/file2",
+            "permissions": 644,
+            "purged": False,
+            "reload": False,
+            "purge_on_delete": True,
+            "requires": ["std::File[vm1,path=/tmp/file1],v=%d" % version],
+            "version": version,
+        },
+        {
+            "group": "root",
+            "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
+            "id": "std::File[vm1,path=/tmp/file3],v=%d" % version,
+            "owner": "root",
+            "path": "/tmp/file3",
+            "permissions": 644,
+            "purged": False,
+            "reload": False,
+            "requires": [],
+            "purge_on_delete": True,
+            "version": version,
+        },
+    ]
 
     res = await client.put_version(tid=environment, version=version, resources=resources, unknowns=[], version_info={})
     assert res.code == 200
@@ -751,19 +820,19 @@ async def test_purge_on_delete(client, server, environment):
     assert result.code == 200
 
     now = datetime.now()
-    result = await aclient.resource_action_update(environment,
-                                                  ['std::File[vm1,path=/tmp/file1],v=%d' % version],
-                                                  uuid.uuid4(), "deploy", now, now, "deployed", [], {})
+    result = await aclient.resource_action_update(
+        environment, ["std::File[vm1,path=/tmp/file1],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+    )
     assert result.code == 200
 
-    result = await aclient.resource_action_update(environment,
-                                                  ['std::File[vm1,path=/tmp/file2],v=%d' % version],
-                                                  uuid.uuid4(), "deploy", now, now, "deployed", [], {})
+    result = await aclient.resource_action_update(
+        environment, ["std::File[vm1,path=/tmp/file2],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+    )
     assert result.code == 200
 
-    result = await aclient.resource_action_update(environment,
-                                                  ['std::File[vm1,path=/tmp/file3],v=%d' % version],
-                                                  uuid.uuid4(), "deploy", now, now, "deployed", [], {})
+    result = await aclient.resource_action_update(
+        environment, ["std::File[vm1,path=/tmp/file3],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+    )
     assert result.code == 200
 
     result = await client.get_version(environment, version)
@@ -776,17 +845,19 @@ async def test_purge_on_delete(client, server, environment):
 
     # New version with only file3
     version = 2
-    res3 = {'group': 'root',
-            'hash': '89bf880a0dc5ffc1156c8d958b4960971370ee6a',
-            'id': 'std::File[vm1,path=/tmp/file3],v=%d' % version,
-            'owner': 'root',
-            'path': '/tmp/file3',
-            'permissions': 644,
-            'purged': False,
-            'reload': False,
-            'requires': [],
-            'purge_on_delete': True,
-            'version': version}
+    res3 = {
+        "group": "root",
+        "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
+        "id": "std::File[vm1,path=/tmp/file3],v=%d" % version,
+        "owner": "root",
+        "path": "/tmp/file3",
+        "permissions": 644,
+        "purged": False,
+        "reload": False,
+        "requires": [],
+        "purge_on_delete": True,
+        "version": version,
+    }
     result = await client.put_version(tid=environment, version=version, resources=[res3], unknowns=[], version_info={})
     assert result.code == 200
 
@@ -817,17 +888,21 @@ async def test_purge_on_delete_ignore(client, server, environment):
     # Version 1 with purge_on_delete true
     version = 1
 
-    resources = [{'group': 'root',
-                  'hash': '89bf880a0dc5ffc1156c8d958b4960971370ee6a',
-                  'id': 'std::File[vm1,path=/tmp/file1],v=%d' % version,
-                  'owner': 'root',
-                  'path': '/tmp/file1',
-                  'permissions': 644,
-                  'purged': False,
-                  'reload': False,
-                  'requires': [],
-                  'purge_on_delete': True,
-                  'version': version}]
+    resources = [
+        {
+            "group": "root",
+            "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
+            "id": "std::File[vm1,path=/tmp/file1],v=%d" % version,
+            "owner": "root",
+            "path": "/tmp/file1",
+            "permissions": 644,
+            "purged": False,
+            "reload": False,
+            "requires": [],
+            "purge_on_delete": True,
+            "version": version,
+        }
+    ]
 
     res = await client.put_version(tid=environment, version=version, resources=resources, unknowns=[], version_info={})
     assert res.code == 200
@@ -837,9 +912,9 @@ async def test_purge_on_delete_ignore(client, server, environment):
     assert result.code == 200
 
     now = datetime.now()
-    result = await aclient.resource_action_update(environment,
-                                                  ['std::File[vm1,path=/tmp/file1],v=%d' % version],
-                                                  uuid.uuid4(), "deploy", now, now, "deployed", [], {})
+    result = await aclient.resource_action_update(
+        environment, ["std::File[vm1,path=/tmp/file1],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+    )
     assert result.code == 200
 
     result = await client.get_version(environment, version)
@@ -853,17 +928,21 @@ async def test_purge_on_delete_ignore(client, server, environment):
     # Version 2 with purge_on_delete false
     version = 2
 
-    resources = [{'group': 'root',
-                  'hash': '89bf880a0dc5ffc1156c8d958b4960971370ee6a',
-                  'id': 'std::File[vm1,path=/tmp/file1],v=%d' % version,
-                  'owner': 'root',
-                  'path': '/tmp/file1',
-                  'permissions': 644,
-                  'purged': False,
-                  'reload': False,
-                  'requires': [],
-                  'purge_on_delete': False,
-                  'version': version}]
+    resources = [
+        {
+            "group": "root",
+            "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
+            "id": "std::File[vm1,path=/tmp/file1],v=%d" % version,
+            "owner": "root",
+            "path": "/tmp/file1",
+            "permissions": 644,
+            "purged": False,
+            "reload": False,
+            "requires": [],
+            "purge_on_delete": False,
+            "version": version,
+        }
+    ]
 
     res = await client.put_version(tid=environment, version=version, resources=resources, unknowns=[], version_info={})
     assert res.code == 200
@@ -873,9 +952,9 @@ async def test_purge_on_delete_ignore(client, server, environment):
     assert result.code == 200
 
     now = datetime.now()
-    result = await aclient.resource_action_update(environment,
-                                                  ['std::File[vm1,path=/tmp/file1],v=%d' % version],
-                                                  uuid.uuid4(), "deploy", now, now, "deployed", [], {})
+    result = await aclient.resource_action_update(
+        environment, ["std::File[vm1,path=/tmp/file1],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+    )
     assert result.code == 200
 
     result = await client.get_version(environment, version)
@@ -937,16 +1016,20 @@ async def test_code_upload(server_multi, client_multi, agent_multi, environment_
     """
     version = 1
 
-    resources = [{'group': 'root',
-                  'hash': '89bf880a0dc5ffc1156c8d958b4960971370ee6a',
-                  'id': 'std::File[vm1.dev.inmanta.com,path=/etc/sysconfig/network],v=%d' % version,
-                  'owner': 'root',
-                  'path': '/etc/sysconfig/network',
-                  'permissions': 644,
-                  'purged': False,
-                  'reload': False,
-                  'requires': [],
-                  'version': version}]
+    resources = [
+        {
+            "group": "root",
+            "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
+            "id": "std::File[vm1.dev.inmanta.com,path=/etc/sysconfig/network],v=%d" % version,
+            "owner": "root",
+            "path": "/etc/sysconfig/network",
+            "permissions": 644,
+            "purged": False,
+            "reload": False,
+            "requires": [],
+            "version": version,
+        }
+    ]
 
     res = await client_multi.put_version(
         tid=environment_multi, version=version, resources=resources, unknowns=[], version_info={}
@@ -972,10 +1055,12 @@ async def test_batched_code_upload(
     """
     config.Config.set("compiler_rest_transport", "request_timeout", "1")
 
-    snippetcompiler.setup_for_snippet("""
+    snippetcompiler.setup_for_snippet(
+        """
     h = std::Host(name="test", os=std::linux)
     f = std::ConfigFile(host=h, path="/etc/motd", content="test", purge_on_delete=true)
-    """)
+    """
+    )
     version, _ = await snippetcompiler.do_export_and_deploy(do_raise=False)
 
     code_manager = loader.CodeManager()
@@ -1005,18 +1090,23 @@ async def test_batched_code_upload(
 @pytest.mark.asyncio(timeout=30)
 async def test_resource_action_log(server_multi, client_multi, environment_multi):
     version = 1
-    resources = [{'group': 'root',
-                  'hash': '89bf880a0dc5ffc1156c8d958b4960971370ee6a',
-                  'id': 'std::File[vm1.dev.inmanta.com,path=/etc/sysconfig/network],v=%d' % version,
-                  'owner': 'root',
-                  'path': '/etc/sysconfig/network',
-                  'permissions': 644,
-                  'purged': False,
-                  'reload': False,
-                  'requires': [],
-                  'version': version}]
-    res = await client_multi.put_version(tid=environment_multi, version=version, resources=resources, unknowns=[],
-                                         version_info={})
+    resources = [
+        {
+            "group": "root",
+            "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
+            "id": "std::File[vm1.dev.inmanta.com,path=/etc/sysconfig/network],v=%d" % version,
+            "owner": "root",
+            "path": "/etc/sysconfig/network",
+            "permissions": 644,
+            "purged": False,
+            "reload": False,
+            "requires": [],
+            "version": version,
+        }
+    ]
+    res = await client_multi.put_version(
+        tid=environment_multi, version=version, resources=resources, unknowns=[], version_info={}
+    )
     assert res.code == 200
 
     resource_action_log = server.Server.get_resource_action_log_file(environment_multi)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -95,12 +95,7 @@ async def test_scheduler_async_run_fail(caplog):
 
     print(caplog.messages)
 
-    log_contains(
-        caplog,
-        "inmanta.util",
-        logging.ERROR,
-        "Uncaught exception while executing scheduled action",
-    )
+    log_contains(caplog, "inmanta.util", logging.ERROR, "Uncaught exception while executing scheduled action")
 
 
 @pytest.mark.asyncio

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,7 +24,7 @@ import inspect
 async def retry_limited(fun, timeout):
     async def fun_wrapper():
         if inspect.iscoroutinefunction(fun):
-            return (await fun())
+            return await fun()
         else:
             return fun()
 
@@ -45,11 +45,13 @@ def assert_equal_ish(minimal, actual, sortby=[]):
     elif isinstance(minimal, list):
         assert len(minimal) == len(actual), "list not equal %s != %s" % (minimal, actual)
         if len(sortby) > 0:
+
             def keyfunc(val):
                 if not isinstance(val, dict):
                     return val
                 key = [str(val[x]) for x in sortby if x in val]
-                return '_'.join(key)
+                return "_".join(key)
+
             actual = sorted(actual, key=keyfunc)
         for (m, a) in zip(minimal, actual):
             assert_equal_ish(m, a, sortby)
@@ -70,7 +72,6 @@ def assert_graph(graph, expected):
 
 
 class AsyncClosing(object):
-
     def __init__(self, awaitable):
         self.awaitable = awaitable
 
@@ -132,7 +133,6 @@ def log_index(caplog, loggerpart, level, msg, after=0):
 
 
 class LogSequence(object):
-
     def __init__(self, caplog, index=0):
         self.caplog = caplog
         self.index = index

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT
 deps=
     flake8
     pep8-naming
+    flake8-black
 commands = flake8 src tests
 basepython = python3
 


### PR DESCRIPTION
The current code base has a number of files that are already black formatted. The changes in this PR:

- Use black in pep8 to check code format
- Set black options when black is invoked on the code base
- Some formatting so that when black run on the code, it still validates with pep8
- Make sure that black and flake8 do not disagree

Todo:
- [x] Merge latest changes
- [x] Run black src tests on the code