### PR TITLE
Allow methods to specify the api prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes in this release:
 - Abort server startup if the database can not be reached (#1153)
 - Use native coroutines everywhere (async def)
 - Updated dockerfile and docker-compose to use postgres and centos
-- Added extensions mechanism (#565)
+- Added extensions mechanism (#565, #1185)
 - Support to set environment variables on the Inmanta server and it's agents
 
 v 2019.2 (2019-04-30)

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -169,6 +169,7 @@ class MethodProperties(object):
         validate_sid: Optional[bool],
         client_types: List[str],
         api_version: int,
+        api_prefix: str,
     ) -> None:
         """
             Decorator to identify a method as a RPC call. The arguments of the decorator are used by each transport to build
@@ -187,7 +188,7 @@ class MethodProperties(object):
             :param arg_options: Options related to arguments passed to the method. The key of this dict is the name of the arg
                                 to which the options apply.
             :param api_version: The version of the api this method belongs to
-
+            :param api_prefix: The prefix of the method: /<prefix>/v<version>/<method_name>
         """
         if api is None:
             api = not server_agent and not agent_server
@@ -208,6 +209,7 @@ class MethodProperties(object):
         self._validate_sid: bool = validate_sid
         self._client_types = client_types
         self._api_version = api_version
+        self._api_prefix = api_prefix
         self.function = function
 
         MethodProperties.methods[function.__name__] = self
@@ -267,7 +269,7 @@ class MethodProperties(object):
         """
             Create a listen url for this method
         """
-        url = "/api/v%d" % self._api_version
+        url = "/%s/v%d" % (self._api_prefix, self._api_version)
 
         if self._id:
             url += "/%s/(?P<id>[^/]+)" % self._method_name
@@ -282,7 +284,7 @@ class MethodProperties(object):
         """
              Create a calling url for the client
         """
-        url = "/api/v%d" % self._api_version
+        url = "/%s/v%d" % (self._api_prefix, self._api_version)
 
         if self._id:
             url += "/%s/%s" % (self._method_name, parse.quote(str(msg["id"]), safe=""))

--- a/src/inmanta/protocol/decorators.py
+++ b/src/inmanta/protocol/decorators.py
@@ -56,6 +56,7 @@ def method(
     validate_sid: bool = None,
     client_types: List[str] = ["public"],
     api_version: int = 1,
+    api_prefix: str = "api",
 ) -> Callable[..., Callable]:
     """
         Decorator to identify a method as a RPC call. The arguments of the decorator are used by each transport to build
@@ -94,6 +95,7 @@ def method(
             validate_sid,
             client_types,
             api_version,
+            api_prefix,
         )
         return func
 

--- a/tests/inmanta_ext/testplugin/extension.py
+++ b/tests/inmanta_ext/testplugin/extension.py
@@ -1,5 +1,3 @@
-from builtins import super
-
 from typing import List
 
 from inmanta.server import SLICE_SERVER, SLICE_AGENT_MANAGER

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -278,7 +278,7 @@ async def test_method_properties():
         Test method properties decorator and helper functions
     """
 
-    @protocol.method(method_name="test", operation="PUT", client_types=["api"])
+    @protocol.method(method_name="test", operation="PUT", client_types=["api"], api_prefix="x", api_version=2)
     def test_method(name):
         """
             Create a new project
@@ -286,8 +286,8 @@ async def test_method_properties():
 
     props: protocol.common.MethodProperties = test_method.__method_properties__
     assert "Authorization" in props.get_call_headers()
-    assert props.get_listen_url() == "/api/v1/test"
-    assert props.get_call_url({}) == "/api/v1/test"
+    assert props.get_listen_url() == "/x/v2/test"
+    assert props.get_call_url({}) == "/x/v2/test"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
By default all methods are exposed under /api Extensions can now use
other prefixes if desired.

fixes #1185 