### PR TITLE
Run the rpm scriptlets on the correct inmanta service.

### DIFF
--- a/inmanta.spec
+++ b/inmanta.spec
@@ -152,13 +152,13 @@ rm -rf %{buildroot}
 %systemd_post inmanta-agent.service
 
 %preun agent
-%systemd_preun inmanta-server.service
+%systemd_preun inmanta-agent.service
 
 %postun agent
-%systemd_postun_with_restart inmanta-server.service
+%systemd_postun_with_restart inmanta-agent.service
 
 %post server
-%systemd_post inmanta-agent.service
+%systemd_post inmanta-server.service
 
 %preun server
 %systemd_preun inmanta-server.service


### PR DESCRIPTION
Fixes a bug, which:
* disables the inmanta-agent service when installing the python3-inmanta-server package. 
* disables the inmanta-server service when uninstalling the python3-inmanta-agent package