### PR TITLE
Add support for List and Dict types to protocol

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ pydantic==0.26
 isort==4.3.20
 flake8-isort==2.7.0
 black==19.3b0
+typing_inspect

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ requires = [
     "pyformance",
     "pymongo",
     "pydantic",
+    "typing_inspect",
 ]
 
 # Package a dummy extensions so that the namespace package for extensions is not empty

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -168,7 +168,7 @@ class ReturnValue(Generic[T]):
     def headers(self) -> MutableMapping[str, str]:
         return self._headers
 
-    def get_body(self, wrap_data: bool = False) -> Optional[JsonType]:
+    def get_body(self, wrap_data: bool = False) -> Optional[BaseModel]:
         """ Get the response body
 
             :param wrap_data: Should the response be mapped into a data key
@@ -276,7 +276,7 @@ class InvalidMethodDefinition(Exception):
     """
 
 
-VALID_SIMPLE_ARG_TYPES = (BaseModel, datetime, Enum, uuid.UUID, str, float, int, bool, datetime)
+VALID_SIMPLE_ARG_TYPES = (BaseModel, Enum, uuid.UUID, str, float, int, bool, datetime)
 
 
 class MethodProperties(object):
@@ -351,7 +351,7 @@ class MethodProperties(object):
 
         self._validate_function_types(typed)
 
-    def _validate_function_types(self, typed) -> None:
+    def _validate_function_types(self, typed: bool) -> None:
         """ Validate the type hints used in the method definition.
 
             For arguments the following types are supported:
@@ -385,7 +385,7 @@ class MethodProperties(object):
 
         self._validate_return_type(type_hints["return"])
 
-    def _validate_return_type(self, arg_type):
+    def _validate_return_type(self, arg_type: Type) -> None:
         """ Validate the return type
         """
         # Note: we cannot call issubclass on a generic type!

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -378,9 +378,6 @@ class MethodProperties(object):
     def _validate_type_arg(self, arg: Any, arg_type: Type) -> None:
         """ Validate the given type arg recursively
         """
-        if isinstance(arg_type, type(None)):
-            return
-
         if typing_inspect.is_generic_type(arg_type) and issubclass(typing_inspect.get_origin(arg_type), ReturnValue):
             self._validate_type_arg(arg, typing_inspect.get_args(arg_type)[0])
 
@@ -425,6 +422,9 @@ class MethodProperties(object):
 
             elif len(args) > 2:
                 raise InvalidMethodDefinition(f"Failed to validate type {arg_type} of argument {arg}.")
+
+        elif issubclass(arg_type, type(None)):
+            pass
 
         elif issubclass(arg_type, VALID_PRIMITIVE_ARG_TYPES):
             pass

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -275,7 +275,7 @@ class InvalidMethodDefinition(Exception):
     """
 
 
-VALID_PRIMITIVE_ARG_TYPES = (BaseModel, Enum, str, float, int, bool)
+VALID_PRIMITIVE_ARG_TYPES = (BaseModel, Enum, uuid.UUID, str, float, int, bool)
 
 
 class MethodProperties(object):

--- a/src/inmanta/protocol/decorators.py
+++ b/src/inmanta/protocol/decorators.py
@@ -92,7 +92,7 @@ def method(
     """
 
     def wrapper(func: MethodT) -> MethodT:
-        common.MethodProperties(
+        properties = common.MethodProperties(
             func,
             path,
             operation,
@@ -108,6 +108,8 @@ def method(
             api_prefix,
             wrap_data,
         )
+        common.MethodProperties.methods[func.__name__] = properties
+        func.__method_properties__ = properties
         return func
 
     return wrapper
@@ -148,11 +150,10 @@ def typedmethod(
                         type of the argument. This method can raise an HTTPException to return a 404 for example.
         :param api_version: The version of the api this method belongs to
         :param api_prefix: The prefix of the method: /<prefix>/v<version>/<method_name>
-        :param wrap_data: Put the response of the call under a "data" key.
     """
 
     def wrapper(func: MethodT) -> MethodT:
-        common.MethodProperties(
+        properties = common.MethodProperties(
             func,
             path,
             operation,
@@ -167,7 +168,10 @@ def typedmethod(
             api_version,
             api_prefix,
             True,
+            True,
         )
+        common.MethodProperties.methods[func.__name__] = properties
+        func.__method_properties__ = properties
         return func
 
     return wrapper

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -144,7 +144,7 @@ class CallArguments(object):
         """ Process a union type
         """
         matching_type = None
-        for t in typing_inspect.get_args(arg_type):
+        for t in typing_inspect.get_args(arg_type, evaluate=True):
             instanceof_type = t
             if typing_inspect.is_generic_type(t):
                 instanceof_type = typing_inspect.get_origin(t)
@@ -178,7 +178,7 @@ class CallArguments(object):
                     f"Invalid argument {arg_name}, type needs to be a list. Argument type should be {arg_type}"
                 )
 
-            el_type = typing_inspect.get_args(arg_type)[0]
+            el_type = typing_inspect.get_args(arg_type, evaluate=True)[0]
             if typing_inspect.is_union_type(el_type):
                 return [self._process_union(el_type, arg_name, el) for el in value]
 
@@ -193,7 +193,7 @@ class CallArguments(object):
                     f"Invalid argument {arg_name}, type needs to be a dict. Argument type should be {arg_type}"
                 )
 
-            el_type = typing_inspect.get_args(arg_type)[1]
+            el_type = typing_inspect.get_args(arg_type, evaluate=True)[1]
             result = {}
             for k, v in value.items():
                 if not isinstance(k, str):
@@ -218,7 +218,7 @@ class CallArguments(object):
         """ Validate a return with a union type
         """
         matching_type = None
-        for t in typing_inspect.get_args(arg_type):
+        for t in typing_inspect.get_args(arg_type, evaluate=True):
             instanceof_type = t
             if typing_inspect.is_generic_type(t):
                 instanceof_type = typing_inspect.get_origin(t)
@@ -250,7 +250,7 @@ class CallArguments(object):
                     f"Invalid return value, type needs to be a list. Argument type should be {arg_type}"
                 )
 
-            el_type = typing_inspect.get_args(arg_type)[0]
+            el_type = typing_inspect.get_args(arg_type, evaluate=True)[0]
             for el in value:
                 if typing_inspect.is_union_type(el_type):
                     self._validate_union_return(el_type, el)
@@ -263,7 +263,7 @@ class CallArguments(object):
                     f"Invalid return value, type needs to be a dict. Argument type should be {arg_type}"
                 )
 
-            el_type = typing_inspect.get_args(arg_type)[1]
+            el_type = typing_inspect.get_args(arg_type, evaluate=True)[1]
             for k, v in value.items():
                 if not isinstance(k, str):
                     raise exceptions.ServerError(f"Keys of return dict need to be strings.")

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -214,7 +214,7 @@ class CallArguments(object):
                 f"Failed to validate generic type {arg_type} of {arg_name}, only List and Dict are supported"
             )
 
-    def _validate_union_return(self, arg_type: Type, value: Any) -> Any:
+    def _validate_union_return(self, arg_type: Type, value: Any) -> None:
         """ Validate a return with a union type
         """
         matching_type = None
@@ -239,7 +239,7 @@ class CallArguments(object):
         if typing_inspect.is_generic_type(matching_type):
             self._validate_generic_return(arg_type, matching_type)
 
-    def _validate_generic_return(self, arg_type: Type, value: Any) -> Any:
+    def _validate_generic_return(self, arg_type: Type, value: Any) -> None:
         """ Validate List or Dict types.
 
             :note: we return any here because the calling function also returns any.
@@ -271,7 +271,7 @@ class CallArguments(object):
                 if typing_inspect.is_union_type(el_type):
                     self._validate_union_return(el_type, v)
                 elif not isinstance(v, el_type):
-                    raise exceptions.ServerError(f"Element {v } of returned list is not of type {el_type}.")
+                    raise exceptions.ServerError(f"Element {v} of returned list is not of type {el_type}.")
 
         else:
             # This should not happen because of MethodProperties validation

--- a/src/inmanta/types.py
+++ b/src/inmanta/types.py
@@ -16,6 +16,9 @@
     Contact: code@inmanta.com
 """
 # This file defines named type definition for the Inmanta code base
+from datetime import datetime
+import uuid
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, Optional, Tuple, Union
 
 if TYPE_CHECKING:
@@ -23,13 +26,17 @@ if TYPE_CHECKING:
     from inmanta.data.model import BaseModel  # noqa: F401
     from inmanta.protocol.common import ReturnValue  # noqa: F401
 
+SimpleTypes = Union["BaseModel", Enum, uuid.UUID, str, float, int, bool, datetime]
 
-PrimitiveTypes = Union[float, int, str, bool]
 JsonType = Dict[str, Any]
 ReturnTupple = Tuple[int, Optional[JsonType]]
-Apireturn = Union[int, ReturnTupple, "ReturnValue", "BaseModel"]
+
+ArgumentTypes = Union[SimpleTypes, List[SimpleTypes], Dict[str, SimpleTypes]]
+
+ReturnTypes = Union[None, ArgumentTypes]
+MethodReturn = Union[ReturnTypes, "ReturnValue[ReturnTypes]"]
+MethodType = Callable[..., MethodReturn]
+
+Apireturn = Union[int, ReturnTupple, "ReturnValue[ReturnTypes]", ReturnTypes]
 Warnings = Optional[List[str]]
 HandlerType = Callable[..., Coroutine[Any, Any, Apireturn]]
-
-MethodReturn = Union[None, "ReturnValue", "BaseModel"]
-MethodType = Callable[..., MethodReturn]

--- a/src/inmanta/types.py
+++ b/src/inmanta/types.py
@@ -15,9 +15,9 @@
 
     Contact: code@inmanta.com
 """
-import uuid
-
 # This file defines named type definition for the Inmanta code base
+
+import uuid
 from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, Optional, Tuple, Union

--- a/src/inmanta/types.py
+++ b/src/inmanta/types.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from inmanta.protocol.common import ReturnValue  # noqa: F401
 
 
+PrimitiveTypes = Union[float, int, str, bool]
 JsonType = Dict[str, Any]
 ReturnTupple = Tuple[int, Optional[JsonType]]
 Apireturn = Union[int, ReturnTupple, "ReturnValue", "BaseModel"]

--- a/src/inmanta/types.py
+++ b/src/inmanta/types.py
@@ -15,9 +15,10 @@
 
     Contact: code@inmanta.com
 """
+import uuid
+
 # This file defines named type definition for the Inmanta code base
 from datetime import datetime
-import uuid
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, Optional, Tuple, Union
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -812,9 +812,7 @@ async def test_method_definition():
         "or a Dict with str keys and values of these types."
     ) in str(e)
 
-    @protocol.typedmethod(
-        path="/service_types/<service_type>", operation="DELETE", client_types=["api"]
-    )
+    @protocol.typedmethod(path="/service_types/<service_type>", operation="DELETE", client_types=["api"])
     def lcm_service_type_delete(tid: uuid.UUID, service_type: str) -> None:
         """ Delete an existing service type.
         """

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -785,7 +785,7 @@ async def test_method_definition():
             """
 
     assert (
-        "Type object of argument name must be a either BaseModel, datetime, Enum, UUID, str, float, int, bool, datetime or a "
+        "Type object of argument name must be a either BaseModel, Enum, UUID, str, float, int, bool, datetime or a "
         "List of these types or a Dict with str keys and values of these types."
     ) in str(e)
 
@@ -808,7 +808,7 @@ async def test_method_definition():
             """
 
     assert (
-        "Type object of argument name must be a either BaseModel, datetime, Enum, UUID, str, float, int, bool, datetime or a "
+        "Type object of argument name must be a either BaseModel, Enum, UUID, str, float, int, bool, datetime or a "
         "List of these types or a Dict with str keys and values of these types."
     ) in str(e)
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -23,6 +23,7 @@ import threading
 import time
 import uuid
 from enum import Enum
+from typing import Dict, Iterator, List
 
 import pytest
 import tornado
@@ -32,7 +33,7 @@ from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 from inmanta import config, protocol
 from inmanta.data.model import BaseModel
 from inmanta.protocol import exceptions, json_encode
-from inmanta.protocol.common import InvalidPathException, ReturnValue
+from inmanta.protocol.common import InvalidMethodDefinition, InvalidPathException, ReturnValue
 from inmanta.protocol.rest import CallArguments
 from inmanta.server import config as opt
 from inmanta.server.protocol import Server, ServerSlice
@@ -304,7 +305,7 @@ async def test_invalid_client_type():
     """
         Test invalid client ype
     """
-    with pytest.raises(Exception) as e:
+    with pytest.raises(InvalidMethodDefinition) as e:
 
         @protocol.method(path="/test", operation="PUT", client_types=["invalid"])
         def test_method(name):
@@ -589,8 +590,7 @@ async def test_invalid_paths():
 
 @pytest.mark.asyncio
 async def test_nested_paths(unused_tcp_port, postgres_db, database_name):
-    """
-        Test the use and validation of methods that use common.ReturnValue
+    """ Test overlapping path definition
     """
     configure(unused_tcp_port, database_name, postgres_db.port)
 
@@ -631,3 +631,180 @@ async def test_nested_paths(unused_tcp_port, postgres_db, database_name):
 
     await server.stop()
     await rs.stop()
+
+
+@pytest.mark.asyncio
+async def test_list_basemodel_argument(unused_tcp_port, postgres_db, database_name):
+    """ Test list of basemodel arguments and primitive types
+    """
+    configure(unused_tcp_port, database_name, postgres_db.port)
+
+    class Project(BaseModel):
+        name: str
+
+    class ProjectServer(ServerSlice):
+        @protocol.typedmethod(path="/test", operation="POST", client_types=["api"])
+        def test_method(data: List[Project], data2: List[int]) -> Project:  # NOQA
+            pass
+
+        @protocol.handle(test_method)
+        async def test_method(self, data: List[Project], data2: List[int]) -> Project:
+            assert len(data) == 1
+            assert data[0].name == "test"
+            assert len(data2) == 3
+
+            return Project(name="test_method")
+
+    rs = Server()
+    server = ProjectServer(name="projectserver")
+    rs.add_slice(server)
+    await rs.start()
+
+    client = protocol.Client("client")
+    result = await client.test_method(data=[{"name": "test"}], data2=[1, 2, 3])
+    assert result.code == 200
+    assert "test_method" == result.result["data"]["name"]
+
+    await server.stop()
+    await rs.stop()
+
+
+@pytest.mark.asyncio
+async def test_dict_basemodel_argument(unused_tcp_port, postgres_db, database_name):
+    """ Test dict of basemodel arguments and primitive types
+    """
+    configure(unused_tcp_port, database_name, postgres_db.port)
+
+    class Project(BaseModel):
+        name: str
+
+    class ProjectServer(ServerSlice):
+        @protocol.typedmethod(path="/test", operation="POST", client_types=["api"])
+        def test_method(data: Dict[str, Project], data2: Dict[str, int]) -> Project:  # NOQA
+            pass
+
+        @protocol.handle(test_method)
+        async def test_method(self, data: Dict[str, Project], data2: Dict[str, int]) -> Project:
+            assert len(data) == 1
+            assert data["projectA"].name == "test"
+            assert len(data2) == 3
+
+            return Project(name="test_method")
+
+    rs = Server()
+    server = ProjectServer(name="projectserver")
+    rs.add_slice(server)
+    await rs.start()
+
+    client = protocol.Client("client")
+    result = await client.test_method(data={"projectA": {"name": "test"}}, data2={"1": 1, "2": 2, "3": 3})
+    assert result.code == 200
+    assert "test_method" == result.result["data"]["name"]
+
+    await server.stop()
+    await rs.stop()
+
+
+@pytest.mark.asyncio
+async def test_dict_and_list_return(unused_tcp_port, postgres_db, database_name):
+    """ Test list of basemodel arguments
+    """
+    configure(unused_tcp_port, database_name, postgres_db.port)
+
+    class Project(BaseModel):
+        name: str
+
+    class ProjectServer(ServerSlice):
+        @protocol.typedmethod(path="/test", operation="POST", client_types=["api"])
+        def test_method(data: Project) -> List[Project]:  # NOQA
+            pass
+
+        @protocol.handle(test_method)
+        async def test_method(self, data: Project) -> List[Project]:  # NOQA
+            return [Project(name="test_method")]
+
+        @protocol.typedmethod(path="/test2", operation="POST", client_types=["api"])
+        def test_method2(data: Project) -> List[str]:  # NOQA
+            pass
+
+        @protocol.handle(test_method2)
+        async def test_method2(self, data: Project) -> List[str]:  # NOQA
+            return ["test_method"]
+
+    rs = Server()
+    server = ProjectServer(name="projectserver")
+    rs.add_slice(server)
+    await rs.start()
+
+    client = protocol.Client("client")
+    result = await client.test_method(data={"name": "test"})
+    assert result.code == 200
+    assert len(result.result["data"]) == 1
+    assert "test_method" == result.result["data"][0]["name"]
+
+    result = await client.test_method2(data={"name": "test"})
+    assert result.code == 200
+    assert len(result.result["data"]) == 1
+    assert "test_method" == result.result["data"][0]
+
+    await server.stop()
+    await rs.stop()
+
+
+@pytest.mark.asyncio
+async def test_method_definition():
+    """
+        Test typed methods with wrong annotations
+    """
+    with pytest.raises(InvalidMethodDefinition) as e:
+
+        @protocol.typedmethod(path="/test", operation="PUT", client_types=["api"])
+        def test_method1(name) -> None:
+            """
+                Create a new project
+            """
+
+    assert "has no type annotation." in str(e)
+
+    with pytest.raises(InvalidMethodDefinition) as e:
+
+        @protocol.typedmethod(path="/test", operation="PUT", client_types=["api"])
+        def test_method2(name: Iterator[str]) -> None:
+            """
+                Create a new project
+            """
+
+    assert "Type typing.Iterator[str] of argument name can only be generic List or Dict" in str(e)
+
+    with pytest.raises(InvalidMethodDefinition) as e:
+
+        @protocol.typedmethod(path="/test", operation="PUT", client_types=["api"])
+        def test_method3(name: List[object]) -> None:
+            """
+                Create a new project
+            """
+
+    assert "Type typing.List[object] of argument name must be a List of BaseModel, Enum, str, float, int, bool" in str(e)
+
+    with pytest.raises(InvalidMethodDefinition) as e:
+
+        @protocol.typedmethod(path="/test", operation="PUT", client_types=["api"])
+        def test_method4(name: Dict[int, str]) -> None:
+            """
+                Create a new project
+            """
+
+    assert "Type typing.Dict[int, str] of argument name must be a Dict with str keys and not int" in str(e)
+
+    with pytest.raises(InvalidMethodDefinition) as e:
+
+        @protocol.typedmethod(path="/test", operation="PUT", client_types=["api"])
+        def test_method5(name: Dict[str, object]) -> None:
+            """
+                Create a new project
+            """
+
+    assert (
+        "Type typing.Dict[str, object] of argument name must be a "
+        "Dict with value type one of BaseModel, Enum, str, float, int, bool"
+    ) in str(e)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -785,7 +785,7 @@ async def test_method_definition():
             """
 
     assert (
-        "Type object of argument name must be a either BaseModel, Enum, UUID, str, float, int, bool or a "
+        "Type object of argument name must be a either BaseModel, datetime, Enum, UUID, str, float, int, bool, datetime or a "
         "List of these types or a Dict with str keys and values of these types."
     ) in str(e)
 
@@ -808,8 +808,8 @@ async def test_method_definition():
             """
 
     assert (
-        "Type object of argument name must be a either BaseModel, Enum, UUID, str, float, int, bool or a List of these types "
-        "or a Dict with str keys and values of these types."
+        "Type object of argument name must be a either BaseModel, datetime, Enum, UUID, str, float, int, bool, datetime or a "
+        "List of these types or a Dict with str keys and values of these types."
     ) in str(e)
 
     @protocol.typedmethod(path="/service_types/<service_type>", operation="DELETE", client_types=["api"])

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -812,6 +812,13 @@ async def test_method_definition():
         "or a Dict with str keys and values of these types."
     ) in str(e)
 
+    @protocol.typedmethod(
+        path="/service_types/<service_type>", operation="DELETE", client_types=["api"]
+    )
+    def lcm_service_type_delete(tid: uuid.UUID, service_type: str) -> None:
+        """ Delete an existing service type.
+        """
+
 
 @pytest.mark.asyncio
 async def test_union_types(unused_tcp_port, postgres_db, database_name):


### PR DESCRIPTION
Arguments and returns types can be
- Primitive types 
- A union of valid types
- Enum
- datetime
- List of primitive types or BaseModel
- Dict of str to primitive types or BaseModel

The same applies for return types. Additionally the return type can also
be a generic ReturnValue with BaseModel, List or Dict as type.