### PR TITLE
Fix broken link in documentation

### DIFF
--- a/docs/administrators/auth.rst
+++ b/docs/administrators/auth.rst
@@ -281,7 +281,7 @@ able to access this url).
 
 Both the correct url for the issuer and the jwks_uri is also defined in the openid-configuration endpoint of keycloack. For
 the examples above this url is http://localhost:8080/auth/realms/master/.well-known/openid-configuration
-(http://www.keycloak.org/docs/3.3/securing_apps/topics/oidc/oidc-generic.html)
+(https://www.keycloak.org/docs/latest/securing_apps/index.html#endpoints-2)
 
 .. warning:: When the certificate of keycloak is not trusted by the system on which inmanta is installed, set ``validate_cert``
     to false in the ``auth_jwt_keycloak`` block for keycloak.


### PR DESCRIPTION
Point to the new location that explains the openid-configuratiron endpoint on keycloak