### PR TITLE
Increased iteration limit and override with env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ Changes in this release:
 - Marked pypi package as typed
 - Create pytest-inmanta-extensions package for extensions testing
 - Added support for /etc/inmanta.d style configuration files (#183)
+- Increased the iteration limit to 10000. This value is controlled with INMANTA_MAX_ITERATIONS
+  environment variable.
 
 DEPRECATIONS:
-* The files /etc/inmanta/agent.cfg and /etc/inmanta/server.cfg are not used anymore. More information about the available 
-configuration files can be found in the documentation pages under `Administrator Documentation -> Configuration files`.  
+* The files /etc/inmanta/agent.cfg and /etc/inmanta/server.cfg are not used anymore. More information about the available
+configuration files can be found in the documentation pages under `Administrator Documentation -> Configuration files`.
 
 v 2019.2 (2019-04-30)
 Changes in this release:

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -36,7 +36,7 @@ I get a click related error/exception when I run inmanta-cli.
         export LANG=en_US.utf8
 
 
-The model does not compile and exists with "could not complete model".
+The model does not compile and exits with "could not complete model".
     There is an upperbound on the number of iterations used in the model transformation algorithm. For large models this might
     not be enough. This limit is controlled with the environment variable INMANTA_MAX_ITERATIONS The default value is set to
     10000 iterations.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -34,3 +34,9 @@ I get a click related error/exception when I run inmanta-cli.
 
         export LC_ALL=en_US.utf8
         export LANG=en_US.utf8
+
+
+The model does not compile and exists with "could not complete model".
+    There is an upperbound on the number of iterations used in the model transformation algorithm. For large models this might
+    not be enough. This limit is controlled with the environment variable INMANTA_MAX_ITERATIONS The default value is set to
+    10000 iterations.

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -18,6 +18,7 @@
 
 import itertools
 import logging
+import os
 import time
 from typing import Dict, List, Set, Tuple
 
@@ -35,7 +36,7 @@ from inmanta.execute.tracking import ModuleTracker
 DEBUG = True
 LOGGER = logging.getLogger(__name__)
 
-MAX_ITERATIONS = 2000
+MAX_ITERATIONS = 10000
 
 
 class Scheduler(object):
@@ -234,7 +235,8 @@ class Scheduler(object):
         # start an evaluation loop
         i = 0
         count = 0
-        while i < MAX_ITERATIONS:
+        max_iterations = os.getenv("INMANTA_MAX_ITERATIONS", MAX_ITERATIONS)
+        while i < max_iterations:
             now = time.time()
 
             # check if we can stop the execution
@@ -317,7 +319,7 @@ class Scheduler(object):
             now - prev,
         )
 
-        if i == MAX_ITERATIONS:
+        if i == max_iterations:
             print("could not complete model")
             return False
         # now = time.time()

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -235,7 +235,7 @@ class Scheduler(object):
         # start an evaluation loop
         i = 0
         count = 0
-        max_iterations = os.getenv("INMANTA_MAX_ITERATIONS", MAX_ITERATIONS)
+        max_iterations = int(os.getenv("INMANTA_MAX_ITERATIONS", MAX_ITERATIONS))
         while i < max_iterations:
             now = time.time()
 

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -23,7 +23,7 @@ import time
 from typing import Dict, List, Set, Tuple
 
 from inmanta import plugins
-from inmanta.ast import CycleExcpetion, Location, MultiException, RuntimeException
+from inmanta.ast import CompilerException, CycleExcpetion, Location, MultiException, RuntimeException
 from inmanta.ast.entity import Entity
 from inmanta.ast.statements import DefinitionStatement, TypeDefinitionStatement
 from inmanta.ast.statements.define import DefineEntity, DefineImplement, DefineIndex, DefineRelation, DefineTypeDefault
@@ -320,8 +320,8 @@ class Scheduler(object):
         )
 
         if i == max_iterations:
-            print("could not complete model")
-            return False
+            raise CompilerException(f"Could not complete model, max_iterations {max_iterations} reached.")
+
         # now = time.time()
         # print(now - prev)
         # end evaluation loop

--- a/tests/compiler/test_iterations.py
+++ b/tests/compiler/test_iterations.py
@@ -1,0 +1,55 @@
+"""
+    Copyright 2019 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+import pytest
+
+import inmanta.compiler as compiler
+from inmanta.ast import CompilerException
+
+
+def test_max_iterations(snippetcompiler, monkeypatch):
+    monkeypatch.setenv("INMANTA_MAX_ITERATIONS", "1")
+
+    with pytest.raises(CompilerException) as e:
+        snippetcompiler.setup_for_snippet(
+            """
+    import std
+    
+    entity Hg:
+    end
+    
+    Hg.hosts [0:] -- std::Host
+    
+    implement Hg using std::none
+    
+    hg = Hg()
+    
+    for i in [1,2,3]:
+     hg.hosts = std::Host(name="Test{{i}}", os=std::unix)
+    end
+    
+    
+    for i in hg.hosts:
+        std::ConfigFile(host=i, path="/fx", content="")
+    end
+    """
+        )
+
+        (types, _) = compiler.do_compile()
+
+    assert "Could not complete model, max_iterations 1 reached." in str(e)

--- a/tests/compiler/test_iterations.py
+++ b/tests/compiler/test_iterations.py
@@ -29,21 +29,21 @@ def test_max_iterations(snippetcompiler, monkeypatch):
         snippetcompiler.setup_for_snippet(
             """
     import std
-    
+
     entity Hg:
     end
-    
+
     Hg.hosts [0:] -- std::Host
-    
+
     implement Hg using std::none
-    
+
     hg = Hg()
-    
+
     for i in [1,2,3]:
      hg.hosts = std::Host(name="Test{{i}}", os=std::unix)
     end
-    
-    
+
+
     for i in hg.hosts:
         std::ConfigFile(host=i, path="/fx", content="")
     end


### PR DESCRIPTION
Increased iteration limit from 2k to 10k and make it overrideable with an environment variable. Fow now this is used for scale testing of the compiler and tracking its evolution over time.