### PR TITLE
Make pep8 angry when copyright headers are missing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ jinja2==2.10.1
 pep8-naming==0.8.2
 flake8==3.7.8
 flake8-black==0.1.0
+flake8-copyright
 psutil==5.6.3
 pyformance==0.4
 pymongo==3.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,10 @@ tag_svn_revision = 0
 ignore = H405,H404,H302,H306,H301,H101,H801,E402,W503,E252,E203
 max-line-length = 128
 exclude = **/.env,.venv,.git,.tox,dist,doc,**egg,src/inmanta/parser/parsetab.py,tests/data/**
+copyright-check=True
+# C errors are not selected by default, so add them to your selection
+select = E,F,W,C
+copyright-author=Inmanta
 
 [isort]
 multi_line_output=3

--- a/src/inmanta/profile_mem.py
+++ b/src/inmanta/profile_mem.py
@@ -1,3 +1,20 @@
+"""
+    Copyright 2019 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 import gc
 import sys
 

--- a/src/inmanta/reporter.py
+++ b/src/inmanta/reporter.py
@@ -1,3 +1,20 @@
+"""
+    Copyright 2019 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 # Adapted from pyformance
 
 import asyncio

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -18,7 +18,7 @@
 
 import logging
 
-from inmanta.config import Option, is_bool, is_int, is_map, is_str_opt, is_time, log_dir, state_dir
+from inmanta.config import Option, is_bool, is_int, is_map, is_str_opt, is_time, log_dir, state_dir, is_list
 
 LOGGER = logging.getLogger(__name__)
 
@@ -172,6 +172,25 @@ server_resource_action_log_prefix = Option(
     "resource-actions-",
     "File prefix in log-dir, containing the resource-action logs. The after the prefix the environment uuid and .log is added",
     is_str_opt,
+)
+
+server_enabled_extensions = Option(
+    "server",
+    "enabled_extensions",
+    None,
+    "A list of extensions the server must load. If this option is empty, the server will load all extensions available. "
+    "If an extension listed in this list is not available, the server will refuse to start.",
+    is_list,
+)
+
+server_disabled_extensions = Option(
+    "server",
+    "disabled_extensions",
+    None,
+    "A list of extensions the server must not load. If this option is empty, the server will load all extensions available. "
+    "The server will not start any extensions in this list. Extensions in this list take precedence of extension in the "
+    "enabled list. core is not allowed in the list of disabled extensions.",
+    is_list,
 )
 
 

--- a/tests/agent_server/test_facts.py
+++ b/tests/agent_server/test_facts.py
@@ -1,3 +1,20 @@
+"""
+    Copyright 2019 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 import asyncio
 import logging
 import time

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -1,3 +1,20 @@
+"""
+    Copyright 2019 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 import os
 
 

--- a/tests/compiler/test_slots.py
+++ b/tests/compiler/test_slots.py
@@ -1,3 +1,20 @@
+"""
+    Copyright 2019 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 from inmanta.ast import Location, Range
 from inmanta.ast.attribute import RelationAttribute
 from inmanta.ast.entity import Entity, Namespace

--- a/tests/inmanta_ext/testplugin/__init__.py
+++ b/tests/inmanta_ext/testplugin/__init__.py
@@ -1,0 +1,17 @@
+"""
+    Copyright 2019 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""

--- a/tests/inmanta_ext/testplugin/extension.py
+++ b/tests/inmanta_ext/testplugin/extension.py
@@ -1,3 +1,20 @@
+"""
+    Copyright 2019 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 from typing import List
 
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_SERVER

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -1,3 +1,20 @@
+"""
+    Copyright 2019 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 import asyncio
 import logging
 import os

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,20 @@
+"""
+    Copyright 2019 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 import os
 
 import inmanta.agent.config as cfg

--- a/tests/test_extension_loading.py
+++ b/tests/test_extension_loading.py
@@ -1,3 +1,20 @@
+"""
+    Copyright 2019 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 import importlib
 import logging
 import os

--- a/tests/test_influxdbreporting.py
+++ b/tests/test_influxdbreporting.py
@@ -1,3 +1,20 @@
+"""
+    Copyright 2019 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 import asyncio
 import re
 

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -1,3 +1,20 @@
+"""
+    Copyright 2019 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 from os import path
 
 from setuptools import find_packages, setup

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ deps=
     pep8-naming
     flake8-black
     flake8-isort
+    flake8-copyright
 commands = flake8 src tests tests_common
 basepython = python3
 


### PR DESCRIPTION
This change checks that each *.py file contains a "Copyright YYYY AUTHOR" line, with AUHTOR in this case Inmanta