### PR TITLE
Add option to enable extensions

### DIFF
--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -92,8 +92,7 @@ async def wait_for_proc_bounded(procs: List[process.Subprocess], timeout: float 
 
 
 class AgentManager(ServerSlice, SessionListener):
-    """
-    This class contains all server functionality related to the management of agents
+    """ This class contains all server functionality related to the management of agents
     """
 
     def __init__(self, closesessionsonstart: bool = True, fact_back_off: int = None) -> None:
@@ -501,12 +500,8 @@ class AgentManager(ServerSlice, SessionListener):
         with open(config_path, "w+") as fd:
             fd.write(config)
 
-        if not self._server._agent_no_log:
-            out: Optional[str] = os.path.join(self._server_storage["logs"], "agent-%s.out" % env.id)
-            err: Optional[str] = os.path.join(self._server_storage["logs"], "agent-%s.err" % env.id)
-        else:
-            out = None
-            err = None
+        out: str = os.path.join(self._server_storage["logs"], "agent-%s.out" % env.id)
+        err: str = os.path.join(self._server_storage["logs"], "agent-%s.err" % env.id)
 
         agent_log = os.path.join(self._server_storage["logs"], "agent-%s.log" % env.id)
         proc = self._fork_inmanta(

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -18,7 +18,7 @@
 
 import logging
 
-from inmanta.config import Option, is_bool, is_int, is_map, is_str_opt, is_time, log_dir, state_dir
+from inmanta.config import Option, is_bool, is_int, is_map, is_str_opt, is_time, log_dir, state_dir, is_list
 
 LOGGER = logging.getLogger(__name__)
 
@@ -172,6 +172,25 @@ server_resource_action_log_prefix = Option(
     "resource-actions-",
     "File prefix in log-dir, containing the resource-action logs. The after the prefix the environment uuid and .log is added",
     is_str_opt,
+)
+
+server_enabled_extensions = Option(
+    "server",
+    "enabled_extensions",
+    None,
+    "A list of extensions the server must load. If this option is empty, the server will load all extensions available. "
+    "If an extension listed in this list is not available, the server will refuse to start.",
+    is_list,
+)
+
+server_disabled_extensions = Option(
+    "server",
+    "disabled_extensions",
+    None,
+    "A list of extensions the server must not load. If this option is empty, the server will load all extensions available. "
+    "The server will not start any extensions in this list. Extensions in this list take precedence of extension in the "
+    "enabled list. core is not allowed in the list of disabled extensions.",
+    is_list,
 )
 
 

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -178,18 +178,8 @@ server_enabled_extensions = Option(
     "server",
     "enabled_extensions",
     "",
-    "A list of extensions the server must load. If the list is empty, the server will load all extensions available. "
+    "A list of extensions the server must load. "
     "If an extension listed in this list is not available, the server will refuse to start.",
-    is_list,
-)
-
-server_disabled_extensions = Option(
-    "server",
-    "disabled_extensions",
-    "",
-    "A list of extensions the server must not load. "
-    "The server will not start any extensions in this list. Extensions in this list take precedence of extension in the "
-    "enabled list. core is not allowed in the list of disabled extensions.",
     is_list,
 )
 

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -177,8 +177,8 @@ server_resource_action_log_prefix = Option(
 server_enabled_extensions = Option(
     "server",
     "enabled_extensions",
-    None,
-    "A list of extensions the server must load. If this option is empty, the server will load all extensions available. "
+    "",
+    "A list of extensions the server must load. If the list is empty, the server will load all extensions available. "
     "If an extension listed in this list is not available, the server will refuse to start.",
     is_list,
 )
@@ -186,8 +186,8 @@ server_enabled_extensions = Option(
 server_disabled_extensions = Option(
     "server",
     "disabled_extensions",
-    None,
-    "A list of extensions the server must not load. If this option is empty, the server will load all extensions available. "
+    "",
+    "A list of extensions the server must not load. "
     "The server will not start any extensions in this list. Extensions in this list take precedence of extension in the "
     "enabled list. core is not allowed in the list of disabled extensions.",
     is_list,

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -178,7 +178,7 @@ server_enabled_extensions = Option(
     "server",
     "enabled_extensions",
     "",
-    "A list of extensions the server must load. "
+    "A list of extensions the server must load. Core is always loaded."
     "If an extension listed in this list is not available, the server will refuse to start.",
     is_list,
 )

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -150,11 +150,9 @@ class Server(protocol.ServerSlice):
     compiler: "CompilerService"
     _server: protocol.Server
 
-    def __init__(self, agent_no_log: bool = False) -> None:
+    def __init__(self) -> None:
         super().__init__(name=SLICE_SERVER)
         LOGGER.info("Starting server endpoint")
-
-        self._agent_no_log: bool = agent_no_log
 
         self.setup_dashboard()
         self.dryrun_lock = locks.Lock()

--- a/src/inmanta_ext/core/extension.py
+++ b/src/inmanta_ext/core/extension.py
@@ -17,8 +17,11 @@
 """
 
 from inmanta.server.extensions import ApplicationContext
+from inmanta.server import server, agentmanager, compilerservice
 
 
 def setup(application: ApplicationContext) -> None:
-    # dummy to allow packaging
-    pass
+    application.register_slice(server.Server())
+    application.register_slice(agentmanager.AgentManager())
+    application.register_slice(server.DatabaseSlice())
+    application.register_slice(compilerservice.CompilerService())


### PR DESCRIPTION
This commit adds a config setting to enable extensions. They are no longer loaded by default. This commit also cleans up core vs other slices.

Fixes #1170 