### PR TITLE
Fixes in export and compiler behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changes in this release:
 - Added the --export-plugin option to the export command (#1277)
 - Only one of set_created, set_updated or set_purged may be called now from a handler
 - Remove facts when the resource is no longer present in any version (#1027)
+- Successful exports without resources or unknowns will now be exported
 
 DEPRECATIONS:
 * The files /etc/inmanta/agent.cfg and /etc/inmanta/server.cfg are not used anymore. More information about the available

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -292,6 +292,7 @@ class Exporter(object):
             metadata[const.META_DATA_COMPILE_STATE] = const.Compilestate.success.name
         else:
             metadata[const.META_DATA_COMPILE_STATE] = const.Compilestate.failed.name
+            LOGGER.warning("Compilation of model failed.")
 
         # validate the dependency graph
         self._validate_graph()
@@ -311,7 +312,7 @@ class Exporter(object):
                 with open(self.options.json + ".types", "wb+") as fd:
                     fd.write(protocol.json_encode(model).encode("utf-8"))
         elif (
-            metadata[const.META_DATA_COMPILE_STATE] == const.Compilestate.success
+            metadata[const.META_DATA_COMPILE_STATE] == const.Compilestate.success.name
             or len(self._resources) > 0
             or len(unknown_parameters) > 0
         ) and not no_commit:

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -310,7 +310,11 @@ class Exporter(object):
                 model = ModelExporter(types).export_all()
                 with open(self.options.json + ".types", "wb+") as fd:
                     fd.write(protocol.json_encode(model).encode("utf-8"))
-        elif len(self._resources) > 0 or len(unknown_parameters) > 0 and not no_commit:
+        elif (
+            metadata[const.META_DATA_COMPILE_STATE] == const.Compilestate.success
+            or len(self._resources) > 0
+            or len(unknown_parameters) > 0
+        ) and not no_commit:
             model = None
             if types is not None and model_export:
                 model = ModelExporter(types).export_all()

--- a/src/inmanta/server/compilerservice.py
+++ b/src/inmanta/server/compilerservice.py
@@ -192,8 +192,8 @@ class CompileRun(object):
             repo_url: str = env.repo_url
             repo_branch: str = env.repo_branch
             if not repo_url:
-                if not os.path.exists(os.path.join(project_dir, ".git")):
-                    await self._warning("Project not found and repository not set %s" % project_dir)
+                if not os.path.exists(os.path.join(project_dir, "project.yml")):
+                    await self._warning(f"Failed to compile: no project found in {project_dir} and no repository set set")
                 await self._end_stage(0)
             else:
                 await self._end_stage(0)
@@ -259,7 +259,7 @@ class CompileRun(object):
             )
             success = result.returncode == 0
             if not success:
-                LOGGER.debug("Compile %d failed", self.request.id)
+                LOGGER.debug("Compile %s failed", self.request.id)
 
             match = re.search(r"Committed resources with version (\d+)", self.tail_stdout)
             if match:

--- a/src/inmanta/server/compilerservice.py
+++ b/src/inmanta/server/compilerservice.py
@@ -226,6 +226,7 @@ class CompileRun(object):
             cmd = inmanta_path + [
                 "-vvv",
                 "export",
+                "-X",
                 "-e",
                 str(environment_id),
                 "--server_address",
@@ -261,6 +262,7 @@ class CompileRun(object):
             if not success:
                 LOGGER.debug("Compile %s failed", self.request.id)
 
+            print("---", self.tail_stdout, result.errstream)
             match = re.search(r"Committed resources with version (\d+)", self.tail_stdout)
             if match:
                 self.version = int(match.group(1))

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -419,7 +419,7 @@ async def test_e2e_recompile_failure(compilerservice: CompilerService):
         # stages
         init = reports["Init"]
         assert not init["errstream"]
-        assert "Project not found and repository not set" in init["outstream"]
+        assert "project found in" in init["outstream"] and "and no repository set set" in init["outstream"]
 
         # compile
         comp = reports["Recompiling configuration model"]

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -173,13 +173,17 @@ def test_unknown_in_attribute_requires(snippetcompiler, caplog):
 
 
 @pytest.mark.asyncio
-async def test_empty_server_export(snippetcompiler, server, client):
+async def test_empty_server_export(snippetcompiler, server, client, environment):
     snippetcompiler.setup_for_snippet(
         """
             h = std::Host(name="test", os=std::linux)
         """
     )
     await snippetcompiler.do_export_and_deploy()
+
+    response = await client.list_versions(tid=environment)
+    assert response.code == 200
+    assert len(response.result["versions"]) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- A valid project for the compiler service is now one with a project.yml and not a .git
- When a compile is successful but there are no resources, a version is still created.