### PR TITLE
Forward env vars server to compilerservice. 

### DIFF
--- a/src/inmanta/server/compilerservice.py
+++ b/src/inmanta/server/compilerservice.py
@@ -357,7 +357,8 @@ class CompilerService(ServerSlice):
             return None, ["Skipping compile because server compile not enabled for this environment."]
 
         env_vars_compile: Dict[str, str] = os.environ.copy()
-        env_vars_compile.update(extra_env_vars)
+        if extra_env_vars:
+            env_vars_compile.update(extra_env_vars)
 
         requested = datetime.datetime.now()
         compile = data.Compile(

--- a/src/inmanta/server/compilerservice.py
+++ b/src/inmanta/server/compilerservice.py
@@ -344,7 +344,7 @@ class CompilerService(ServerSlice):
         do_export: bool,
         remote_id: uuid.UUID,
         metadata: JsonType = {},
-        env_vars: Dict[str, str] = {},
+        extra_env_vars: Dict[str, str] = {},
     ) -> Tuple[Optional[uuid.UUID], Warnings]:
         """
             Recompile an environment in a different thread and taking wait time into account.
@@ -356,6 +356,9 @@ class CompilerService(ServerSlice):
             LOGGER.info("Skipping compile because server compile not enabled for this environment.")
             return None, ["Skipping compile because server compile not enabled for this environment."]
 
+        env_vars_compile: Dict[str, str] = os.environ.copy()
+        env_vars_compile.update(extra_env_vars)
+
         requested = datetime.datetime.now()
         compile = data.Compile(
             environment=env.id,
@@ -364,7 +367,7 @@ class CompilerService(ServerSlice):
             do_export=do_export,
             force_update=force_update,
             metadata=metadata,
-            environment_variables=env_vars,
+            environment_variables=env_vars_compile,
         )
         await compile.insert()
         await self._queue(compile)

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -1987,7 +1987,12 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
             Recompile an environment in a different thread and taking wait time into account.
         """
         _, warnings = await self.compiler.request_recompile(
-            env=env, force_update=update_repo, do_export=True, remote_id=uuid.uuid4(), metadata=metadata
+            env=env,
+            force_update=update_repo,
+            do_export=True,
+            remote_id=uuid.uuid4(),
+            metadata=metadata,
+            env_vars=os.environ.copy()
         )
         return warnings
 

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -1991,8 +1991,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
             force_update=update_repo,
             do_export=True,
             remote_id=uuid.uuid4(),
-            metadata=metadata,
-            env_vars=os.environ.copy()
+            metadata=metadata
         )
         return warnings
 

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -1987,11 +1987,7 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
             Recompile an environment in a different thread and taking wait time into account.
         """
         _, warnings = await self.compiler.request_recompile(
-            env=env,
-            force_update=update_repo,
-            do_export=True,
-            remote_id=uuid.uuid4(),
-            metadata=metadata
+            env=env, force_update=update_repo, do_export=True, remote_id=uuid.uuid4(), metadata=metadata
         )
         return warnings
 

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -437,7 +437,7 @@ async def test_e2e_recompile_failure(compilerservice: CompilerService):
 
 
 @pytest.mark.asyncio(timeout=90)
-async def test_server_recompile(server_multi, client_multi, environment_multi):
+async def test_server_recompile(server_multi, client_multi, environment_multi, monkeypatch):
     """
         Test a recompile on the server and verify recompile triggers
     """
@@ -460,7 +460,7 @@ async def test_server_recompile(server_multi, client_multi, environment_multi):
     # Set environment variable to be passed to the compiler
     key_env_var = "TEST_MESSAGE"
     value_env_var = "a_message"
-    os.environ[key_env_var] = value_env_var
+    monkeypatch.setenv(key_env_var, value_env_var)
 
     # add main.cf
     with open(os.path.join(project_dir, "main.cf"), "w") as fd:


### PR DESCRIPTION
Make sure that environment variable set on the Inmanta server are forwarded to the subprocess that executes the compilation.