### PR TITLE
added missing dependency to requirements.txt: lxml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ flake8-isort==2.7.0
 black==19.3b0
 typing_inspect==0.4.0
 importlib_metadata==0.23
+mypy==0.730
 setuptools==41.2.0
 pip==19.2.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,6 +51,7 @@ pip==19.2.3
 # Transitive dependencies
 MarkupSafe==1.1.1
 mypy-extensions==0.4.1
+lxml==4.4.1
 pycparser==2.19
 zipp==0.6.0
 apipkg==1.5


### PR DESCRIPTION
When starting from a clean environment, running `make install` and then `make mypy` results in an error, reporting that lxml is not installed. Running `pip install lxml` manually resolves this. Should lxml be added to the requirements.txt file?