### PR TITLE
Define the types a bit less strict

### DIFF
--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -97,8 +97,8 @@ class AttributeStateChange(BaseModel):
         Changes in the attribute
     """
 
-    current: Optional[SimpleTypes] = None
-    desired: Optional[SimpleTypes] = None
+    current: Optional[Union[SimpleTypes, List[SimpleTypes], Dict[str, SimpleTypes]]] = None
+    desired: Optional[Union[SimpleTypes, List[SimpleTypes], Dict[str, SimpleTypes]]] = None
 
 
 class Event(BaseModel):


### PR DESCRIPTION
Openstack handler reports an attribute as list of strings. This is also valid. This change only defines it one level deep. The definition could also be recursive. @wouterdb @sanderr could you make a suggestion here?