### PR TITLE
Enable debug logging for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ mypy:
 
 .PHONY: test
 test:
-	pytest -vvv tests
+	pytest -vvv --log-level DEBUG tests
 
 .PHONY: testcov
 testcov:

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps=
     pytest-timeout
     psutil
 install_command=pip install -c requirements.txt {opts} {packages}
-commands=py.test --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv tests/
+commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv tests/
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT
 
 [testenv:pep8]


### PR DESCRIPTION
This should print debug logs when a test fails instead of only warning