### PR TITLE
fixed string interpolation documentation

### DIFF
--- a/docs/language.rst
+++ b/docs/language.rst
@@ -500,7 +500,7 @@ Interpolating strings
 .. code-block:: inmanta
 
     hostname = "serv1.example.org"
-    motd = """Welcome to {{hostname}}\n"""
+    motd = "Welcome to {{hostname}}\n"
 
 
 Templates


### PR DESCRIPTION
The documentation shows string interpolation using triple quotes (`"""{{string}} interpolation"""`) while the compiler only seems to interpolate in single-quoted strings (`"{{string}} interpolation"`). Example model:
```
entity File:
	string path
end

implement File using std::none

for file in files:
	std::print("""/backup{{file.path}}""")
end

files =
	[ File(path = "/file")
	, File(path = "/otherfile")
	]
```