### PR TITLE
Lexer string regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixed
  - Compiler bugfix, ensure done nodes are correctly removed from zerowaiters
  - Fixed memory leak in database layer
+ - Fixed lexing of strings ending in an escaped backslash (#1601)
 
 v 2019.4 (2019-10-30) Changes in this release:
 - Various bugfixes (#1367,#1398,#736, #1454)
@@ -38,7 +39,7 @@ IMPORTANT CHANGES:
 - The Inmanta server now listens on 127.0.0.1:8888 by default, while
   this was 0.0.0.0:8888 in previous versions. This behavior is
   configurable with the `bind-address` config option.
- 
+
 DEPRECATIONS:
 - The `server_rest_transport.port` config option is deprecated in favor
   of the `server.bind-port` option.

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -189,7 +189,7 @@ def t_STRING(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
 
 
 def t_REGEX(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r"/([^/]|\\/)*?[^\\]/"
+    r"/([^/\\]|\\.)+/"
     value = Reference("self")  # anonymous value
     expr = Regex(value, t.value[1:-1])
     t.value = expr

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -173,7 +173,7 @@ def t_STRING_EMPTY(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
 
 
 def t_STRING(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r"(\".*?[^\\]\")|(\'.*?[^\\]\')"
+    r"(\"((\\\\)+|.*?[^\\](\\\\)*)\")|(\'((\\\\)+|.*?[^\\](\\\\)*)\')"
     t.value = bytes(t.value[1:-1], "utf-8").decode("unicode_escape")
     lexer = t.lexer
 

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -173,7 +173,7 @@ def t_STRING_EMPTY(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
 
 
 def t_STRING(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r"(\"((\\\\)+|.*?[^\\](\\\\)*)\")|(\'((\\\\)+|.*?[^\\](\\\\)*)\')"
+    r"(\"([^\\\"]|\\.)+\")|(\'([^\\\']|\\.)+\')"
     t.value = bytes(t.value[1:-1], "utf-8").decode("unicode_escape")
     lexer = t.lexer
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -458,7 +458,7 @@ a = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}
 def test_regex_backslash():
     statements = parse_code(
         r"""
-a = /\\\\/
+a = /\\/
 """
     )
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -468,7 +468,7 @@ a = /\\\\/
     assert stmt.children[1].value == re.compile(r"\\")
 
 
-def test_regex_backslash():
+def test_regex_escape():
     statements = parse_code(
         r"""
 a = /\/1/

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -782,6 +782,32 @@ a='jos'
     assert stmt.value.value == "jos"
 
 
+def test_string_backslash():
+    statements = parse_code(
+        """
+a="\\\\"
+"""
+    )
+    assert len(statements) == 1
+    stmt = statements[0]
+    assert isinstance(stmt, Assign)
+    assert isinstance(stmt.value, Literal)
+    assert stmt.value.value == "\\"
+
+
+def test_string_backslash_2():
+    statements = parse_code(
+        """
+a='\\\\'
+"""
+    )
+    assert len(statements) == 1
+    stmt = statements[0]
+    assert isinstance(stmt, Assign)
+    assert isinstance(stmt.value, Literal)
+    assert stmt.value.value == "\\"
+
+
 def test_empty():
     statements = parse_code(
         """

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -455,7 +455,20 @@ a = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}
     assert stmt.children[1].value == re.compile(r"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}")
 
 
-def test_regex_escape():
+def test_regex_backslash():
+    statements = parse_code(
+        r"""
+a = /\\\\/
+"""
+    )
+
+    assert len(statements) == 1
+    stmt = statements[0].value
+    assert isinstance(stmt, Regex)
+    assert stmt.children[1].value == re.compile(r"\\")
+
+
+def test_regex_backslash():
     statements = parse_code(
         r"""
 a = /\/1/


### PR DESCRIPTION
Arnaud noticed that a string ending with an escaped backslash (`'\\'`) was not allowed. This commit fixes the issue.
An possible alternative to the regex in this commit, closer to the original would be this: `r"(\"((\\\\)+|.*?[^\\](\\\\)*)\")|(\'((\\\\)+|.*?[^\\](\\\\)*)\')"` but it seems less readable.