### PR TITLE
added mypy pydantic support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,3 +44,4 @@ plugins = pydantic.mypy
 [pydantic-mypy]
 init_forbid_extra=True
 init_typed=True
+warn_untyped_fields=True

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,3 +37,10 @@ default_section=FIRSTPARTY
 known_first_party=inmanta,inmanta_ext,inmanta_plugins
 known_third_party=pytest,psutil,pydantic,pkg_resources
 skip=tests/data
+
+[mypy]
+plugins = pydantic.mypy
+
+[pydantic-mypy]
+init_forbid_extra=True
+init_typed=True


### PR DESCRIPTION
This adds quite strict checking to pydantic

docs: https://pydantic-docs.helpmanual.io/mypy_plugin/#plugin-settings

it finds the following problems
```
+ src/inmanta/data/__init__.py:714: error: Argument "default" to "EnvironmentSetting" has incompatible type "Union[StrictNonIntBool, int, str, Dict[str, Union[str, int, StrictNonIntBool]], None]"; expected "Union[StrictNonIntBool, int, str, Dict[str, Union[str, int, StrictNonIntBool]]]"
+ src/inmanta/data/__init__.py:715: error: Argument "doc" to "EnvironmentSetting" has incompatible type "Optional[str]"; expected "str"
+ src/inmanta/agent/agent.py:266: error: Argument "status" to "Event" has incompatible type "Optional[ResourceState]"; expected "ResourceState"
+ src/inmanta/agent/agent.py:266: error: Argument "change" to "Event" has incompatible type "Optional[Change]"; expected "Change"
```