### PR TITLE
Don't wait for already terminated processes

### DIFF
--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -84,8 +84,9 @@ set_parameters
 
 async def wait_for_proc_bounded(procs: Iterable[process.Subprocess], timeout: float = const.SHUTDOWN_GRACE_HARD) -> None:
     try:
+        unfinished_processes = [proc for proc in procs if proc.returncode is None]
         await asyncio.wait_for(
-            asyncio.gather(*[asyncio.shield(proc.wait_for_exit(raise_error=False)) for proc in procs]), timeout
+            asyncio.gather(*[asyncio.shield(proc.wait_for_exit(raise_error=False)) for proc in unfinished_processes]), timeout
         )
     except asyncio.TimeoutError:
         LOGGER.warning("Agent processes did not close in time (%s)", procs)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -43,6 +43,8 @@ LOGGER = logging.getLogger(__name__)
 async def test_autostart(server, client, environment, caplog):
     """
         Test auto start of agent
+        An agent is started and then killed to simulate unexpected failure
+        When the second agent is started for the same environment, the first is terminated in a controlled manner
     """
     env = await data.Environment.get_by_id(uuid.UUID(environment))
     await env.set(data.AUTOSTART_AGENT_MAP, {"iaas_agent": "", "iaas_agentx": ""})
@@ -85,6 +87,7 @@ async def test_autostart(server, client, environment, caplog):
     assert len(agentmanager._agent_procs) == 0
 
     log_doesnt_contain(caplog, "inmanta.config", logging.WARNING, "rest_transport not defined")
+    log_doesnt_contain(caplog, "inmanta.server.agentmanager", logging.WARNING, "Agent processes did not close in time")
 
 
 @pytest.mark.asyncio(timeout=60)


### PR DESCRIPTION
Related to #1098 
It seems that the wait_for_exit waits for the timeout when the process has already ended.
This affects the runtime of tests/test_server.py::test_autostart and tests/test_server.py::test_autostart_batched for example (locally it reduced the total runtime by ~30 sec)