### PR TITLE
Only include redoc in html doc builds

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -54,7 +54,7 @@ clean:
 	-rm -rf $(PNGs)
 
 html: openapi
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html -t include_redoc $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,8 +29,13 @@ import sys, os, pkg_resources
 extensions = [
     'sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig', 'sphinx.ext.viewcode',
     'sphinxarg.ext', 'sphinxcontrib.inmanta.config', 'sphinxcontrib.inmanta.dsl', 'sphinx_tabs.tabs',
-    'sphinxcontrib.inmanta.environmentsettings', 'sphinxcontrib.redoc',
+    'sphinxcontrib.inmanta.environmentsettings',
 ]
+
+# noinspection PyUnresolvedReferences
+# "tags" are injected while the file is being read
+if tags.has("include_redoc"):
+    extensions.append('sphinxcontrib.redoc')
 
 redoc_uri = 'https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js'
 redoc = [


### PR DESCRIPTION
sphinx-contrib/redoc only supports html as a build target
