### PR TITLE
Handle undefined tags in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,10 +32,14 @@ extensions = [
     'sphinxcontrib.inmanta.environmentsettings',
 ]
 
-# noinspection PyUnresolvedReferences
-# "tags" are injected while the file is being read
-if tags.has("include_redoc"):
-    extensions.append('sphinxcontrib.redoc')
+
+try:
+    # noinspection PyUnresolvedReferences
+    # "tags" are injected while the file is being read
+    if tags.has("include_redoc"):
+        extensions.append('sphinxcontrib.redoc')
+except NameError as e:
+    print("Openapi definition with Redoc won't be included", e)
 
 redoc_uri = 'https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js'
 redoc = [


### PR DESCRIPTION
The inmanta-docs job checks the conf.py for the release version, that way the tags are not defined like when sphinx processes it.