### PR TITLE
Fix file hash when having errors in sha1sum output

### DIFF
--- a/src/inmanta/agent/io/local.py
+++ b/src/inmanta/agent/io/local.py
@@ -122,10 +122,15 @@ class BashIO(IOBase):
         result = subprocess.Popen(self._run_as_args("sha1sum", path), stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd)
         data = result.communicate()
 
-        if result.returncode > 0 or len(data[1]) > 0:
-            raise IOError(data)
+        if result.returncode > 0:
+            raise IOError("Failed to hash file")
 
-        return data[0].decode("utf-8").strip().split(" ")[0]
+        hash = data[0].decode("utf-8").strip().split(" ")[0]
+
+        if len(hash) != 20:
+            raise IOError("Invalid hash output")
+
+        return hash
 
     def read(self, path):
         # type: (str) -> str

--- a/src/inmanta/agent/io/local.py
+++ b/src/inmanta/agent/io/local.py
@@ -123,7 +123,7 @@ class BashIO(IOBase):
         data = result.communicate()
 
         if result.returncode > 0 or len(data[1]) > 0:
-            raise IOError()
+            raise IOError(data)
 
         return data[0].decode("utf-8").strip().split(" ")[0]
 

--- a/src/inmanta/agent/io/local.py
+++ b/src/inmanta/agent/io/local.py
@@ -127,7 +127,7 @@ class BashIO(IOBase):
 
         hash = data[0].decode("utf-8").strip().split(" ")[0]
 
-        if len(hash) != 20:
+        if len(hash) != 40:
             raise IOError("Invalid hash output")
 
         return hash


### PR DESCRIPTION
In docker containers certain sudo operations are not allowed. This produces an error on stderr but the result is still valid:

stdout: b'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3  /tmp/tmp82pla41d/hashfile\n', 
stderr: b'sudo: setrlimit(RLIMIT_CORE): Operation not permitted\n'

This PR validates the output in stdout instead of assuming if something is in stderr the result is wrong.