### PR TITLE
Verify that inmanta-cli uses HTTP/1.1

### DIFF
--- a/src/inmanta/protocol/rest/server.py
+++ b/src/inmanta/protocol/rest/server.py
@@ -116,6 +116,7 @@ class RESTHandler(tornado.web.RequestHandler):
             self._transport.start_request()
             try:
                 message = self._transport._decode(self.request.body)
+                LOGGER.debug(f"HTTP version of request: {self.request.version}")
                 if message is None:
                     message = {}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,12 +15,14 @@
 
     Contact: code@inmanta.com
 """
+import logging
 import os
 
 import pytest
 
 from inmanta import data
 from inmanta.util import get_compiler_version
+from utils import log_contains
 
 
 @pytest.mark.asyncio
@@ -259,3 +261,11 @@ async def test_create_environment(tmpdir, server, client, cli):
 
     assert file_content_0 != file_content_2
     assert ctime_0 != ctime_2
+
+
+@pytest.mark.asyncio
+async def test_inmanta_cli_http_version(server, client, cli, caplog):
+    with caplog.at_level(logging.DEBUG):
+        result = await cli.run("project", "create", "-n", "test_project")
+        assert result.exit_code == 0
+        log_contains(caplog, "inmanta.protocol.rest.server", logging.DEBUG, "HTTP version of request: HTTP/1.1")


### PR DESCRIPTION
The Tornado AsyncHttpClient uses HTTP/1.1, added a test case to verify that
Closes #1740 