### PR TITLE
Fail if db schema downgrade is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Breaking changes
 - Non-boolean arguments to boolean operators are no longer allowed, this was previously possible due to bug (#1808)
+- Server will no longer start if the database schema is for a newer version (#1878)
 
 ## Deprecated
  - Leaving a nullable attribute unassigned now produces a deprecation warning. Explicitly assign null instead. (#1775)
@@ -20,7 +21,6 @@
  - Added support for compiler warnings (#1779, #1905, #1906)
  - Added support for DISABLED flag for database migration scripts (#1913)
  - Added v5 database migration script (#1914)
- - Check to fail if DB Schema downgrade would be necessary (#1878)
 
 # v 2020.1 (2020-02-19) Changes in this release:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
  - Various compiler error reporting improvements (#1810, #1920)
  - Fixed cache leak in agent when deployments are canceled (#1883)
  - Improved robustness of modules update (#1885)
- - Removed environmental variables from agent report (#1891)tests/db/test_db_schema.py
+ - Removed environmental variables from agent report (#1891)
  - Use asyncio subprocess instead of tornado subprocess (#1792)
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
  - Various compiler error reporting improvements (#1810, #1920)
  - Fixed cache leak in agent when deployments are canceled (#1883)
  - Improved robustness of modules update (#1885)
- - Removed environmental variables from agent report (#1891)
+ - Removed environmental variables from agent report (#1891)tests/db/test_db_schema.py
  - Use asyncio subprocess instead of tornado subprocess (#1792)
 
 ## Added
@@ -20,6 +20,7 @@
  - Added support for compiler warnings (#1779, #1905, #1906)
  - Added support for DISABLED flag for database migration scripts (#1913)
  - Added v5 database migration script (#1914)
+ - Check to fail if DB Schema downgrade would be necessary (#1878)
 
 # v 2020.1 (2020-02-19) Changes in this release:
 

--- a/tests/db/test_db_schema.py
+++ b/tests/db/test_db_schema.py
@@ -32,7 +32,7 @@ import inmanta.db.versions
 from data.db import versions
 from inmanta import data
 from inmanta.data import CORE_SCHEMA_NAME, schema
-from inmanta.data.schema import TableNotFound, Version
+from inmanta.data.schema import InvalidSchemaVersion, TableNotFound, Version, create_schemamanager
 from utils import log_contains
 
 
@@ -357,3 +357,21 @@ async def test_dbschema_get_dct_filter_disabled():
         assert isinstance(version.function, types.FunctionType)
         assert version.function.__name__ == "update"
         assert inspect.getfullargspec(version.function)[0] == ["connection"]
+
+
+@pytest.mark.asyncio
+async def test_dbschema_update_db_downgrade(postgresql_client):
+    schema_name = "test_dbschema_update_db_downgrade"
+    SCHEMA_VERSION_TABLE = "schemamanager"
+    await postgresql_client.execute(create_schemamanager)
+
+    db_schema = schema.DBSchema(schema_name, inmanta.db.versions, postgresql_client)
+    update_function_map = await db_schema._get_update_functions()
+    original_version = len(update_function_map) + 1
+    await postgresql_client.execute(
+        f"INSERT INTO {SCHEMA_VERSION_TABLE} (name, current_version) VALUES ($1, $2)", schema_name, original_version
+    )
+    with pytest.raises(InvalidSchemaVersion):
+        await db_schema.ensure_db_schema()
+    current_db_version = await db_schema.get_current_version()
+    assert original_version == current_db_version


### PR DESCRIPTION
# Description

Downgrading the database schema version is not supported, this change introduces a check to fail if that would be required.

closes #1878 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Code is clear and sufficiently documented
- [x] Correct, in line with design