### PR TITLE
dataflow: moved NodeStub creation from ExpressionStatement to unsupported children: fixes #1869

### DIFF
--- a/src/inmanta/ast/constraint/expression.py
+++ b/src/inmanta/ast/constraint/expression.py
@@ -20,10 +20,12 @@ import re
 from abc import ABCMeta, abstractmethod
 from typing import Dict, Optional
 
+import inmanta.execute.dataflow as dataflow
 from inmanta.ast import LocatableString, RuntimeException, TypingException
 from inmanta.ast.statements import Literal, ReferenceStatement
 from inmanta.ast.type import Bool, create_function
 from inmanta.ast.variables import IsDefinedReferenceHelper, Reference
+from inmanta.execute.dataflow import DataflowGraph
 from inmanta.execute.runtime import ExecutionUnit, HangUnit, QueueScheduler, RawUnit, Resolver, ResultVariable
 
 
@@ -89,6 +91,9 @@ class IsDefined(ReferenceStatement):
     def execute(self, requires: Dict[object, object], resolver: Resolver, queue: QueueScheduler) -> object:
         # helper returned: return result
         return requires[self]
+
+    def get_dataflow_node(self, graph: DataflowGraph) -> dataflow.NodeReference:
+        return dataflow.NodeStub("IsDefined.get_node() placeholder for %s" % self).reference()
 
     def pretty_print(self) -> str:
         if self.attr is not None:
@@ -164,6 +169,9 @@ class Operator(ReferenceStatement, metaclass=OpMetaClass):
             Returns a function that represents this expression
         """
         return create_function(self)
+
+    def get_dataflow_node(self, graph: DataflowGraph) -> dataflow.NodeReference:
+        return dataflow.NodeStub("Operator.get_node() placeholder for %s" % self).reference()
 
     def pretty_print(self):
         return repr(self)

--- a/src/inmanta/ast/statements/__init__.py
+++ b/src/inmanta/ast/statements/__init__.py
@@ -139,9 +139,7 @@ class ExpressionStatement(DynamicStatement):
         """
             Return the node in the data flow graph this ExpressionStatement will evaluate to.
         """
-        # TODO: NodeStub is used while the dataflow graph is not fully compatible with the language.
-        #   This should raise a NotImplementedError instead.
-        return dataflow.NodeStub("expressionStatement.get_node(Resolver) placeholder for %s" % type(self)).reference()
+        raise NotImplementedError()
 
 
 class Resumer(ExpressionStatement):

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -128,6 +128,9 @@ class CreateList(ReferenceStatement):
     def as_constant(self) -> typing.List[object]:
         return [item.as_constant() for item in self.items]
 
+    def get_dataflow_node(self, graph: DataflowGraph) -> dataflow.NodeReference:
+        return dataflow.NodeStub("CreateList.get_node() placeholder for %s" % self).reference()
+
     def pretty_print(self) -> str:
         return "[%s]" % ",".join(item.pretty_print() for item in self.items)
 
@@ -168,6 +171,9 @@ class CreateDict(ReferenceStatement):
 
     def as_constant(self) -> typing.Dict[str, object]:
         return {k: v.as_constant() for k, v in self.items}
+
+    def get_dataflow_node(self, graph: DataflowGraph) -> dataflow.NodeReference:
+        return dataflow.NodeStub("CreateDict.get_node() placeholder for %s" % self).reference()
 
     def __repr__(self) -> str:
         return "Dict()"
@@ -320,6 +326,9 @@ class MapLookup(ReferenceStatement):
 
         return mapv[keyv]
 
+    def get_dataflow_node(self, graph: DataflowGraph) -> dataflow.NodeReference:
+        return dataflow.NodeStub("MapLookup.get_node() placeholder for %s" % self).reference()
+
     def __repr__(self) -> str:
         return "%s[%s]" % (repr(self.themap), repr(self.key))
 
@@ -369,6 +378,9 @@ class IndexLookup(ReferenceStatement, Resumer):
 
     def execute(self, requires: typing.Dict[object, object], resolver: Resolver, queue: QueueScheduler) -> object:
         return requires[self]
+
+    def get_dataflow_node(self, graph: DataflowGraph) -> dataflow.NodeReference:
+        return dataflow.NodeStub("IndexLookup.get_node() placeholder for %s" % self).reference()
 
     def __repr__(self) -> str:
         """
@@ -469,6 +481,9 @@ class StringFormat(ReferenceStatement):
             result_string = result_string.replace(str_id, str(value))
 
         return result_string
+
+    def get_dataflow_node(self, graph: DataflowGraph) -> dataflow.NodeReference:
+        return dataflow.NodeStub("StringFormat.get_node() placeholder for %s" % self).reference()
 
     def __repr__(self) -> str:
         return "Format(%s)" % self._format_string

--- a/src/inmanta/ast/statements/call.py
+++ b/src/inmanta/ast/statements/call.py
@@ -21,10 +21,12 @@ from itertools import chain
 from typing import Dict, List, Optional, Tuple
 
 import inmanta.ast.type as InmantaType
+import inmanta.execute.dataflow as dataflow
 from inmanta import plugins
 from inmanta.ast import ExternalException, LocatableString, Location, Namespace, RuntimeException, WrappingRuntimeException
 from inmanta.ast.statements import ExpressionStatement, ReferenceStatement
 from inmanta.ast.statements.generator import WrappedKwargs
+from inmanta.execute.dataflow import DataflowGraph
 from inmanta.execute.proxy import UnknownException, UnsetException
 from inmanta.execute.runtime import QueueScheduler, Resolver, ResultVariable, Waiter
 from inmanta.execute.util import NoneValue, Unknown
@@ -109,6 +111,9 @@ class FunctionCall(ReferenceStatement):
                     raise RuntimeException(self, "Keyword argument %s repeated in function call" % k)
                 kwargs[k] = v
         self.function.call_in_context(arguments, kwargs, resolver, queue, result)
+
+    def get_dataflow_node(self, graph: DataflowGraph) -> dataflow.NodeReference:
+        return dataflow.NodeStub("FunctionCall.get_node() placeholder for %s" % self).reference()
 
     def __repr__(self):
         return "%s(%s)" % (

--- a/tests/compiler/dataflow/test_model_assignment.py
+++ b/tests/compiler/dataflow/test_model_assignment.py
@@ -30,7 +30,6 @@ from inmanta.execute.dataflow import (
     Assignment,
     AttributeNode,
     DataflowGraph,
-    DirectNodeReference,
     ValueNode,
     ValueNodeReference,
     VariableNodeReference,
@@ -45,7 +44,7 @@ x = 42
     )
     graph: DataflowGraph = dataflow_test_helper.get_graph()
     x: AssignableNodeReference = graph.get_named_node("x")
-    assert isinstance(x, DirectNodeReference)
+    assert isinstance(x, VariableNodeReference)
     assert len(x.node.value_assignments) == 1
     assignment: Assignment[ValueNodeReference] = x.node.value_assignments[0]
     assert isinstance(assignment.responsible, Assign)
@@ -65,7 +64,7 @@ x = 0
     )
     graph: DataflowGraph = dataflow_test_helper.get_graph()
     x: AssignableNodeReference = graph.get_named_node("x")
-    assert isinstance(x, DirectNodeReference)
+    assert isinstance(x, VariableNodeReference)
     assignments: List[Assignment] = x.node.value_assignments
     assert len(assignments) == 2
     zero_index: int = [assignment.rhs for assignment in assignments].index(ValueNode(0).reference())
@@ -87,7 +86,7 @@ y = 42
     )
     graph: DataflowGraph = dataflow_test_helper.get_graph()
     x: AssignableNodeReference = graph.get_named_node("x")
-    assert isinstance(x, DirectNodeReference)
+    assert isinstance(x, VariableNodeReference)
     assert len(x.node.assignable_assignments) == 1
     assignment: Assignment[AssignableNodeReference] = x.node.assignable_assignments[0]
     assert isinstance(assignment.responsible, Assign)

--- a/tests/compiler/dataflow/test_model_stubs.py
+++ b/tests/compiler/dataflow/test_model_stubs.py
@@ -1,0 +1,104 @@
+"""
+    Copyright 2020 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+from compiler.dataflow.conftest import DataflowTestHelper
+from typing import Dict, List
+
+import pytest
+
+import inmanta.ast.type as inmanta_type
+from inmanta.execute.dataflow import (
+    AssignableNodeReference,
+    Assignment,
+    DataflowGraph,
+    NodeReference,
+    NodeStub,
+    ValueNodeReference,
+    VariableNodeReference,
+)
+
+
+@pytest.mark.parametrize(
+    "value_string,other_stmts",
+    [
+        ("[1,2,3]", []),
+        ("{'a': 1}", []),
+        ("std::replace('Hello World?', '?', '!')", []),
+        ("true or true", []),
+        ("true and true", []),
+        ("not true", []),
+        ("y is defined", ["y = 0"]),
+        ("y['a']", ["y = {'a': 1}"]),
+        (
+            "A[n = 0]",
+            [
+                """
+                entity A:
+                    number n
+                end
+
+                index A(n)
+
+                implement A using std::none
+            """,
+                "A(n = 0)",
+            ],
+        ),
+        ("'{{y}}'", "y = 0"),
+        ("true == true", []),
+        ("1 < 0", []),
+        ("1 > 0", []),
+        ("1 <= 0", []),
+        ("1 >= 0", []),
+        ("1 != 0", []),
+        ("1 in [1]", []),
+    ],
+)
+def test_dataflow_nodestub(dataflow_test_helper: DataflowTestHelper, value_string: str, other_stmts: List[str]) -> None:
+    dataflow_test_helper.compile(
+        """
+x = %s
+%s
+        """
+        % (value_string, "\n".join(other_stmts)),
+    )
+    graph: DataflowGraph = dataflow_test_helper.get_graph()
+    x: AssignableNodeReference = graph.get_named_node("x")
+    assert isinstance(x, VariableNodeReference)
+    assignments: List[Assignment] = list(x.node.assignments())
+    assert len(assignments) == 1
+    assert isinstance(assignments[0].rhs, ValueNodeReference)
+    assert isinstance(assignments[0].rhs.node, NodeStub)
+
+
+def test_dataflow_nodestub_regex(dataflow_test_helper: DataflowTestHelper) -> None:
+    dataflow_test_helper.compile(
+        """
+typedef my_type as string matching /test/
+        """,
+    )
+    graph: DataflowGraph = dataflow_test_helper.get_graph()
+    types: Dict[str, inmanta_type.Type] = dataflow_test_helper.get_types()
+    type_string: str = "__config__::my_type"
+    assert type_string in types
+    my_type: inmanta_type.Type = types[type_string]
+    assert isinstance(my_type, inmanta_type.ConstraintType)
+    assert my_type.expression is not None
+    regex_node_ref: NodeReference = my_type.expression.get_dataflow_node(graph)
+    assert isinstance(regex_node_ref, ValueNodeReference)
+    assert isinstance(regex_node_ref.node, NodeStub)


### PR DESCRIPTION
# Description

Moved NodeStub creation from ExpressionStatement to unsupported children. `ExpressionStatement.get_dataflow_node()` now raises `NotImplementedError`, as it should.

closes #1869

# Self Check:

- [x] Attached issue to pull request
- [x] ~~Changelog entry~~
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Code is clear and sufficiently documented
- [x] Correct, in line with design