### PR TITLE
fixed dataflow compilation failure for entity extension: fixes #1974

### DIFF
--- a/src/inmanta/ast/attribute.py
+++ b/src/inmanta/ast/attribute.py
@@ -18,7 +18,6 @@
 
 from typing import List, Optional, Tuple
 
-import inmanta.execute.dataflow as dataflow
 from inmanta.ast import Locatable, RuntimeException, TypingException
 from inmanta.ast.type import NullableType, TypedList
 from inmanta.execute.runtime import (
@@ -120,9 +119,6 @@ class Attribute(Locatable):
         else:
             out = ResultVariable()
 
-        node_ref: Optional[dataflow.InstanceNodeReference] = instance.instance_node
-        if node_ref is not None:
-            out.set_dataflow_node(dataflow.InstanceAttributeNodeReference(node_ref.top_node(), self.name))
         out.set_type(mytype)
         return out
 
@@ -170,9 +166,6 @@ class RelationAttribute(Attribute):
             out = OptionVariable(self, instance, queue)  # type: ResultVariable
         else:
             out = ListVariable(self, instance, queue)  # type: ResultVariable
-        node_ref: Optional[dataflow.InstanceNodeReference] = instance.instance_node
-        if node_ref is not None:
-            out.set_dataflow_node(dataflow.InstanceAttributeNodeReference(node_ref.top_node(), self.name))
         out.set_type(self.get_type())
         return out
 

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -914,7 +914,7 @@ class Instance(ExecutionContext):
         self.dataflow_graph: Optional[DataflowGraph] = None
         self.instance_node: Optional[dataflow.InstanceNodeReference] = node
         self.self_var_node: Optional[dataflow.AssignableNodeReference] = None
-        if resolver.dataflow_graph is not None:
+        if self.instance_node is not None:
             self.dataflow_graph = DataflowGraph(self, resolver.dataflow_graph)
             self.self_var_node = dataflow.AssignableNode("__self__").reference()
             self.self_var_node.assign(

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -903,6 +903,12 @@ class Instance(ExecutionContext):
         self.resolver = resolver.get_root_resolver()
         self.type = mytype
 
+        self.slots: Dict[str, ResultVariable] = {
+            n: mytype.get_attribute(n).get_new_result_variable(self, queue) for n in mytype.get_all_attribute_names()
+        }
+        self.slots["self"] = ResultVariable()
+        self.slots["self"].set_value(self, None)
+
         # TODO: this is somewhat ugly. Is there a cleaner way to enforce this constraint
         assert (resolver.dataflow_graph is None) == (node is None)
         self.dataflow_graph: Optional[DataflowGraph] = None
@@ -914,12 +920,9 @@ class Instance(ExecutionContext):
             self.self_var_node.assign(
                 cast(dataflow.InstanceNodeReference, self.instance_node), self, cast(DataflowGraph, self.dataflow_graph),
             )
+            for name, var in self.slots.items():
+                var.set_dataflow_node(dataflow.InstanceAttributeNodeReference(self.instance_node.top_node(), name))
 
-        self.slots: Dict[str, ResultVariable] = {
-            n: mytype.get_attribute(n).get_new_result_variable(self, queue) for n in mytype.get_all_attribute_names()
-        }
-        self.slots["self"] = ResultVariable()
-        self.slots["self"].set_value(self, None)
         self.sid = id(self)
         self.implementations: "Set[Implementation]" = set()
 

--- a/tests/compiler/dataflow/test_model_entities.py
+++ b/tests/compiler/dataflow/test_model_entities.py
@@ -1,0 +1,38 @@
+"""
+    Copyright 2020 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+from compiler.dataflow.conftest import DataflowTestHelper
+
+
+def test_1974_dataflow_model_entity_extend(dataflow_test_helper: DataflowTestHelper) -> None:
+    dataflow_test_helper.compile(
+        """
+entity A:
+    int n
+end
+
+entity B extends A:
+    int n = 1
+end
+
+implement A using std::none
+implement B using std::none
+
+B()
+        """,
+    )


### PR DESCRIPTION
# Description

Compiling with `--experimental-data-trace` failed when the model included a child entity that redeclared an existing attribute, for example for specifying a default value. This pull request fixes that.

closes #1974

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] ~~Changelog entry~~
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Code is clear and sufficiently documented
- [x] Correct, in line with design
