### PR TITLE
Add timestamp to resource action log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
  - Added support for compiler warnings (#1779, #1905, #1906)
  - Added support for DISABLED flag for database migration scripts (#1913)
  - Added v5 database migration script (#1914)
+ - Resource Action Log now includes timestamps (#1496)
 
 # v 2020.1 (2020-02-19) Changes in this release:
 

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -128,7 +128,7 @@ class ResourceService(protocol.ServerSlice):
 
         file_handler = logging.handlers.WatchedFileHandler(filename=resource_action_log, mode="a+")
         # Most logs will come from agents. We need to use their level and timestamp and their formatted message
-        file_handler.setFormatter(logging.Formatter(fmt="%(message)s"))
+        file_handler.setFormatter(logging.Formatter(fmt="%(asctime)s %(levelname)-8s %(name)-10s %(message)s"))
         file_handler.setLevel(logging.DEBUG)
 
         resource_action_logger = logging.getLogger(const.NAME_RESOURCE_ACTION_LOGGER).getChild(str(environment))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -23,6 +23,7 @@ import uuid
 from datetime import datetime
 
 import pytest
+from dateutil import parser
 
 from inmanta import config, const, data, loader, resources
 from inmanta.agent import handler
@@ -643,6 +644,11 @@ async def test_resource_action_log(server, client, environment):
     resource_action_log = server.get_slice(SLICE_RESOURCE).get_resource_action_log_file(environment)
     assert os.path.isfile(resource_action_log)
     assert os.stat(resource_action_log).st_size != 0
+    with open(resource_action_log, "r") as f:
+        contents = f.read()
+        parts = contents.split(" ")
+        # Date and time
+        parser.parse(f"{parts[0]} {parts[1]}")
 
 
 @pytest.mark.asyncio(timeout=30)


### PR DESCRIPTION
# Description

Adds timestamps to the log lines of the resource action log, by specifying a log formatter.

closes #1496 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
