### PR TITLE
Add no-tag option to moduletool commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
  - Added support for compiler warnings (#1779, #1905, #1906)
  - Added support for DISABLED flag for database migration scripts (#1913)
  - Added v5 database migration script (#1914)
+ - Added --no-tag option to module tool (#1939)
 
 # v 2020.1 (2020-02-19) Changes in this release:
 

--- a/docs/model_developers/modules.rst
+++ b/docs/model_developers/modules.rst
@@ -110,13 +110,21 @@ When done, first use git to add files::
 
     git add *
 
-To commit, use the module tool. It will autmatically set the right tags on the module::
+To commit, use the module tool. This will create a new dev release.::
 
     inmanta module commit -m "First commit"
 
-This will create a new dev release. To make an actual release::
+For the dev releases, no tags are created by default. If a tag is required for a dev release, use the --tag option.::
+
+    inmanta module commit -m "First commit" --tag
+
+To make an actual release. It will automatically set the right tags on the module::
 
     inmanta module commit -r -m "First Release"
+
+If a release shouldn't be tagged, the --no-tag option should be specified::
+
+    inmanta module commit -r -m "First Release" --no-tag
 
 To set a specific version::
 

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -276,6 +276,7 @@ class ModuleTool(ModuleLikeTool):
         commit.add_argument("--patch", dest="patch", help="make a major release", action="store_true")
         commit.add_argument("-v", "--version", help="Version to use on tag")
         commit.add_argument("-a", "--all", dest="commit_all", help="Use commit -a", action="store_true")
+        commit.add_argument("-n", "--no-tag", help="Don't create a tag for the commit", action="store_true")
 
         create = subparser.add_parser("create", help="Create a new module")
         create.add_argument("name", help="The name of the module")
@@ -513,7 +514,18 @@ version: 0.0.1dev0"""
         LOGGER.info("Successfully loaded module %s with version %s" % (module.name, module.version))
         return module
 
-    def commit(self, message, module=None, version=None, dev=False, major=False, minor=False, patch=False, commit_all=False):
+    def commit(
+        self,
+        message,
+        module=None,
+        version=None,
+        dev=False,
+        major=False,
+        minor=False,
+        patch=False,
+        commit_all=False,
+        no_tag=False,
+    ):
         """
             Commit all current changes.
         """
@@ -531,7 +543,8 @@ version: 0.0.1dev0"""
         # commit
         gitprovider.commit(module._path, message, commit_all, [module.get_config_file_name()])
         # tag
-        gitprovider.tag(module._path, str(outversion))
+        if not no_tag:
+            gitprovider.tag(module._path, str(outversion))
 
     def freeze(self, outfile, recursive, operator, module=None):
         """

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -276,7 +276,16 @@ class ModuleTool(ModuleLikeTool):
         commit.add_argument("--patch", dest="patch", help="make a major release", action="store_true")
         commit.add_argument("-v", "--version", help="Version to use on tag")
         commit.add_argument("-a", "--all", dest="commit_all", help="Use commit -a", action="store_true")
-        commit.add_argument("-n", "--no-tag", help="Don't create a tag for the commit", action="store_true")
+        commit.add_argument(
+            "-t",
+            "--tag",
+            dest="tag",
+            help="Create a tag for the commit."
+            "Tags are not created for dev releases by default, if you want to tag it, specify this flag explicitly",
+            action="store_true",
+        )
+        commit.add_argument("-n", "--no-tag", dest="tag", help="Don't create a tag for the commit", action="store_false")
+        commit.set_defaults(tag=False)
 
         create = subparser.add_parser("create", help="Create a new module")
         create.add_argument("name", help="The name of the module")
@@ -515,16 +524,7 @@ version: 0.0.1dev0"""
         return module
 
     def commit(
-        self,
-        message,
-        module=None,
-        version=None,
-        dev=False,
-        major=False,
-        minor=False,
-        patch=False,
-        commit_all=False,
-        no_tag=False,
+        self, message, module=None, version=None, dev=False, major=False, minor=False, patch=False, commit_all=False, tag=False,
     ):
         """
             Commit all current changes.
@@ -543,7 +543,7 @@ version: 0.0.1dev0"""
         # commit
         gitprovider.commit(module._path, message, commit_all, [module.get_config_file_name()])
         # tag
-        if not no_tag:
+        if not dev or tag:
             gitprovider.tag(module._path, str(outversion))
 
     def freeze(self, outfile, recursive, operator, module=None):

--- a/tests/moduletool/common.py
+++ b/tests/moduletool/common.py
@@ -84,7 +84,7 @@ repo: %s"""
     return path
 
 
-def add_file(modpath, file, content, msg, version=None, no_tag=False):
+def add_file(modpath, file, content, msg, version=None, dev=False, tag=True):
     with open(os.path.join(modpath, file), "w", encoding="utf-8") as projectfile:
         projectfile.write(content)
 
@@ -94,7 +94,7 @@ def add_file(modpath, file, content, msg, version=None, no_tag=False):
         ocd = os.curdir
         os.curdir = modpath
         subprocess.check_output(["git", "add", "*"], cwd=modpath, stderr=subprocess.STDOUT)
-        ModuleTool().commit(msg, version=version, dev=False, commit_all=True, no_tag=no_tag)
+        ModuleTool().commit(msg, version=version, dev=dev, commit_all=True, tag=tag)
         os.curdir = ocd
 
 

--- a/tests/moduletool/common.py
+++ b/tests/moduletool/common.py
@@ -84,7 +84,7 @@ repo: %s"""
     return path
 
 
-def add_file(modpath, file, content, msg, version=None):
+def add_file(modpath, file, content, msg, version=None, no_tag=False):
     with open(os.path.join(modpath, file), "w", encoding="utf-8") as projectfile:
         projectfile.write(content)
 
@@ -94,7 +94,7 @@ def add_file(modpath, file, content, msg, version=None):
         ocd = os.curdir
         os.curdir = modpath
         subprocess.check_output(["git", "add", "*"], cwd=modpath, stderr=subprocess.STDOUT)
-        ModuleTool().commit(msg, version=version, dev=False, commit_all=True)
+        ModuleTool().commit(msg, version=version, dev=False, commit_all=True, no_tag=no_tag)
         os.curdir = ocd
 
 

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -17,6 +17,7 @@
 """
 import os
 import re
+import shutil
 import subprocess
 
 import pytest
@@ -172,8 +173,17 @@ def test_module_corruption(modules_dir, modules_repo):
     assert not os.path.exists(os.path.join(m10dir, "badsignal"))
 
 
-def test_commit_no_tags(modules_dir, modules_repo):
+@pytest.fixture(scope="function")
+def module_without_tags(modules_repo):
     mod_no_tag = make_module_simple(modules_repo, "mod-no-tag")
-    add_file(mod_no_tag, "dummyfile", "Content", "Commit without tags", version="5.0", no_tag=True)
-    output = subprocess.check_output(["git", "tag", "-l"], cwd=mod_no_tag, stderr=subprocess.STDOUT)
-    assert "5.0" not in str(output)
+    yield mod_no_tag
+    shutil.rmtree(mod_no_tag)
+
+
+@pytest.mark.parametrize(
+    "dev, tag, version_tag_in_output", [(True, True, True), (True, False, False), (False, True, True), (False, False, True)],
+)
+def test_commit_no_tags(modules_dir, module_without_tags, dev, tag, version_tag_in_output):
+    add_file(module_without_tags, "dummyfile", "Content", "Commit without tags", version="5.0", dev=dev, tag=tag)
+    output = subprocess.check_output(["git", "tag", "-l"], cwd=module_without_tags, stderr=subprocess.STDOUT)
+    assert ("5.0" in str(output)) is version_tag_in_output

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -17,6 +17,7 @@
 """
 import os
 import re
+import subprocess
 
 import pytest
 import yaml
@@ -169,3 +170,10 @@ def test_module_corruption(modules_dir, modules_repo):
     assert os.path.exists(os.path.join(m10dir, "secondsignal"))
     # should not be lastest version
     assert not os.path.exists(os.path.join(m10dir, "badsignal"))
+
+
+def test_commit_no_tags(modules_dir, modules_repo):
+    mod_no_tag = make_module_simple(modules_repo, "mod-no-tag")
+    add_file(mod_no_tag, "dummyfile", "Content", "Commit without tags", version="5.0", no_tag=True)
+    output = subprocess.check_output(["git", "tag", "-l"], cwd=mod_no_tag, stderr=subprocess.STDOUT)
+    assert "5.0" not in str(output)


### PR DESCRIPTION
# Description


closes #1939 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
