### PR TITLE
fixed nullable attribute deprecation warning in entity with diamond inheritance: fixes #1950

### DIFF
--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -904,7 +904,9 @@ class Instance(ExecutionContext):
         self.type = mytype
 
         self.slots: Dict[str, ResultVariable] = {
-            n: mytype.get_attribute(n).get_new_result_variable(self, queue) for n in mytype.get_all_attribute_names()
+            n: mytype.get_attribute(n).get_new_result_variable(self, queue)
+            # prune duplicates first because get_new_result_variable() has side effects
+            for n in set(mytype.get_all_attribute_names())
         }
         self.slots["self"] = ResultVariable()
         self.slots["self"].set_value(self, None)

--- a/tests/compiler/test_warnings.py
+++ b/tests/compiler/test_warnings.py
@@ -174,7 +174,7 @@ A(n = null)
 
 
 @pytest.mark.parametrize("assign", [True, False])
-def test_deprecation_warning_nullable_diamond_inheritance(snippetcompiler, assign: bool):
+def test_1950_deprecation_warning_nullable_diamond_inheritance(snippetcompiler, assign: bool):
     snippetcompiler.setup_for_snippet(
         """
 entity A:

--- a/tests/compiler/test_warnings.py
+++ b/tests/compiler/test_warnings.py
@@ -173,6 +173,38 @@ A(n = null)
         assert str(w[0].message) == message
 
 
+@pytest.mark.parametrize("assign", [True, False])
+def test_deprecation_warning_nullable_diamond_inheritance(snippetcompiler, assign: bool):
+    snippetcompiler.setup_for_snippet(
+        """
+entity A:
+    number? n%s
+end
+
+entity B extends A:
+end
+
+entity C extends A, B:
+end
+
+
+implement A using std::none
+implement B using std::none
+implement C using std::none
+
+C()
+        """
+        % (" = null" if assign else ""),
+    )
+    message: str = "No value for attribute __config__::C.n. Assign null instead of leaving unassigned. ({dir}/main.cf:17)"
+    with warnings.catch_warnings(record=True) as w:
+        compiler.do_compile()
+        assert len(w) == 0 if assign else 1
+        if not assign:
+            assert issubclass(w[0].category, CompilerDeprecationWarning)
+            assert str(w[0].message) == message.format(dir=snippetcompiler.project_dir)
+
+
 def test_deprecation_warning_default_constructors(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """


### PR DESCRIPTION
# Description

Fixes wrongfully raised deprecation warning when using nullable attributes in presence of diamond inheritance.
As a side effect prevents creation of multiple `ResultVariable` instances when an attribute occurs multiple times in the inheritance hierarchy.

closes #1950

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] ~~Changelog entry~~
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
