### PR TITLE
fix for regression in implements statement

### DIFF
--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -354,7 +354,8 @@ class DefineImplement(DefinitionStatement):
 
             entity_type = entity_type.get_entity()
 
-            entity_type.implements_inherits = self.inherit
+            # If one implements statement has parent declared, set to true
+            entity_type.implements_inherits |= self.inherit
 
             implement = Implement()
             implement.comment = self.comment

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -99,9 +99,10 @@ implementation test for Test:
 end
 
 
-
-implement Test using test
 implement TestC using parents
+implement TestC using std::none, parents
+implement TestC using std::none
+implement Test using test
 
 a = TestC()
 """


### PR DESCRIPTION
# Description

Fixes the bug that breaks lsm and compilerscaling tests 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~~Attached issue to pull request~~
- [ ] ~~Changelog entry~~
- [ ] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
