### PR TITLE
dataflow duplicate lookup: fixes #1879

### DIFF
--- a/src/inmanta/execute/dataflow/__init__.py
+++ b/src/inmanta/execute/dataflow/__init__.py
@@ -161,26 +161,31 @@ class DataflowGraph:
         Graph representation of the data flow and declarative control flow of an Inmanta model.
     """
 
-    __slots__ = ("resolver", "parent", "named_nodes", "_entities", "_own_instances")
+    __slots__ = ("resolver", "parent", "_own_variables", "_own_instances")
 
     def __init__(self, resolver: "Resolver", parent: Optional["DataflowGraph"] = None) -> None:
         self.resolver: "Resolver" = resolver
         self.parent: Optional[DataflowGraph] = parent if parent is not None else None
-        self.named_nodes: Dict[str, AssignableNode] = {}
+        # keeps track of variables that have not been declared in the resolver's scope
+        self._own_variables: Dict[str, AssignableNode] = {}
         # keeps track of instance nodes and their responsible
         self._own_instances: Dict["Constructor", InstanceNode] = {}
 
+    # TODO: should this be removed? It's useful in testing.
     def get_named_node(self, name: str) -> "AssignableNodeReference":
         """
             Returns a reference to a named node, by name.
         """
-        # TODO: temporary name lookup implementation. Will be replaced by #1879
         parts: List[str] = name.split(".")
-        root: str = parts[0]
-        if root not in self.named_nodes:
-            self.named_nodes[root] = AssignableNode(root)
-        root_ref: AssignableNodeReference = VariableNodeReference(self.named_nodes[root])
-        return reduce(lambda acc, part: AttributeNodeReference(acc, part), parts[1:], root_ref)
+        return reduce(lambda acc, part: AttributeNodeReference(acc, part), parts[1:], self.resolver.get_dataflow_node(parts[0]))
+
+    def get_own_variable(self, name: str) -> "AssignableNodeReference":
+        """
+            Returns a reference to one of this graph's own variable nodes.
+        """
+        if name not in self._own_variables:
+            self._own_variables[name] = AssignableNode(name)
+        return self._own_variables[name].reference()
 
     def own_instance_node_for_responsible(
         self, entity: "Entity", responsible: "Constructor", get_new: Callable[[], "InstanceNode"]

--- a/src/inmanta/execute/dataflow/__init__.py
+++ b/src/inmanta/execute/dataflow/__init__.py
@@ -171,14 +171,6 @@ class DataflowGraph:
         # keeps track of instance nodes and their responsible
         self._own_instances: Dict["Constructor", InstanceNode] = {}
 
-    # TODO: should this be removed? It's useful in testing.
-    def get_named_node(self, name: str) -> "AssignableNodeReference":
-        """
-            Returns a reference to a named node, by name.
-        """
-        parts: List[str] = name.split(".")
-        return reduce(lambda acc, part: AttributeNodeReference(acc, part), parts[1:], self.resolver.get_dataflow_node(parts[0]))
-
     def get_own_variable(self, name: str) -> "AssignableNodeReference":
         """
             Returns a reference to one of this graph's own variable nodes.

--- a/src/inmanta/execute/dataflow/__init__.py
+++ b/src/inmanta/execute/dataflow/__init__.py
@@ -166,7 +166,9 @@ class DataflowGraph:
     def __init__(self, resolver: "Resolver", parent: Optional["DataflowGraph"] = None) -> None:
         self.resolver: "Resolver" = resolver
         self.parent: Optional[DataflowGraph] = parent if parent is not None else None
-        # keeps track of variables that have not been declared in the resolver's scope
+        # keeps track of variables that have not been declared in the resolver's scope. This should only be populated
+        # if the model refers to a variable in the rhs that has no declaration in the left hand side.
+        # For example `n = y.n` in a scope that does not contain a `y = ...` statement.
         self._own_variables: Dict[str, AssignableNode] = {}
         # keeps track of instance nodes and their responsible
         self._own_instances: Dict["Constructor", InstanceNode] = {}

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -794,6 +794,8 @@ class Resolver(object):
             assert isinstance(result_variable, ResultVariable)
             return result_variable.get_dataflow_node()
         except NotFoundException:
+            # This block is only executed if the model contains a reference to an undefined variable.
+            # Since we don't know in which scope it should be defined, we assume top scope.
             root_graph: Optional[DataflowGraph] = self.get_root_resolver().dataflow_graph
             assert root_graph is not None
             return root_graph.get_own_variable(name)

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -789,11 +789,14 @@ class Resolver(object):
         return NamespaceResolver(self, namespace)
 
     def get_dataflow_node(self, name: str) -> "dataflow.AssignableNodeReference":
-        graph: Optional[DataflowGraph] = self.dataflow_graph
-        if self.get_root_resolver() == self:
-            graph = self.namespace.get_scope().dataflow_graph
-        assert graph is not None
-        return graph.get_named_node(name)
+        try:
+            result_variable: Typeorvalue = self.lookup(name)
+            assert isinstance(result_variable, ResultVariable)
+            return result_variable.get_dataflow_node()
+        except NotFoundException:
+            root_graph: Optional[DataflowGraph] = self.get_root_resolver().dataflow_graph
+            assert root_graph is not None
+            return root_graph.get_own_variable(name)
 
 
 class NamespaceResolver(Resolver):
@@ -818,9 +821,6 @@ class NamespaceResolver(Resolver):
     def get_root_resolver(self) -> "Resolver":
         return self.parent.get_root_resolver()
 
-    def get_dataflow_node(self, name: str) -> "dataflow.AssignableNodeReference":
-        return self.parent.get_dataflow_node(name)
-
 
 class ExecutionContext(Resolver):
 
@@ -834,7 +834,7 @@ class ExecutionContext(Resolver):
         if resolver.dataflow_graph is not None:
             self.dataflow_graph = DataflowGraph(self, resolver.dataflow_graph)
             for name, var in self.slots.items():
-                node_ref: dataflow.AssignableNodeReference = self.dataflow_graph.get_named_node(name)
+                node_ref: dataflow.AssignableNodeReference = dataflow.AssignableNode(name).reference()
                 var.set_dataflow_node(node_ref)
 
     def lookup(self, name: str, root: Namespace = None) -> Typeorvalue:
@@ -859,13 +859,6 @@ class ExecutionContext(Resolver):
     def for_namespace(self, namespace: Namespace) -> Resolver:
         return NamespaceResolver(self, namespace)
 
-    def get_dataflow_node(self, name: str) -> "dataflow.AssignableNodeReference":
-        try:
-            self.direct_lookup(name.split(".")[0])
-            return Resolver.get_dataflow_node(self, name)
-        except NotFoundException:
-            return self.resolver.get_dataflow_node(name)
-
 
 # also extends locatable
 class Instance(ExecutionContext):
@@ -888,7 +881,6 @@ class Instance(ExecutionContext):
         "trackers",
         "locations",
         "instance_node",
-        "self_var_node",
     )
 
     def __init__(
@@ -902,26 +894,25 @@ class Instance(ExecutionContext):
         # ExecutionContext, Resolver -> this class only uses it as an "interface", so no constructor call!
         self.resolver = resolver.get_root_resolver()
         self.type = mytype
-
         self.slots: Dict[str, ResultVariable] = {
             n: mytype.get_attribute(n).get_new_result_variable(self, queue) for n in mytype.get_all_attribute_names()
         }
-        self.slots["self"] = ResultVariable()
-        self.slots["self"].set_value(self, None)
 
         # TODO: this is somewhat ugly. Is there a cleaner way to enforce this constraint
         assert (resolver.dataflow_graph is None) == (node is None)
         self.dataflow_graph: Optional[DataflowGraph] = None
         self.instance_node: Optional[dataflow.InstanceNodeReference] = node
-        self.self_var_node: Optional[dataflow.AssignableNodeReference] = None
         if self.instance_node is not None:
             self.dataflow_graph = DataflowGraph(self, resolver.dataflow_graph)
-            self.self_var_node = dataflow.AssignableNode("__self__").reference()
-            self.self_var_node.assign(
-                cast(dataflow.InstanceNodeReference, self.instance_node), self, cast(DataflowGraph, self.dataflow_graph),
-            )
             for name, var in self.slots.items():
                 var.set_dataflow_node(dataflow.InstanceAttributeNodeReference(self.instance_node.top_node(), name))
+
+        self.slots["self"] = ResultVariable()
+        self.slots["self"].set_value(self, None)
+        if self.instance_node is not None:
+            self_var_node: dataflow.AssignableNodeReference = dataflow.AssignableNode("__self__").reference()
+            self_var_node.assign(self.instance_node, self, cast(DataflowGraph, self.dataflow_graph))
+            self.slots["self"].set_dataflow_node(self_var_node)
 
         self.sid = id(self)
         self.implementations: "Set[Implementation]" = set()
@@ -1022,13 +1013,3 @@ class Instance(ExecutionContext):
 
     def get_locations(self) -> List[Location]:
         return self.locations
-
-    def get_dataflow_node(self, name: str) -> "dataflow.AssignableNodeReference":
-        assert self.self_var_node is not None
-        if name == "self":
-            return self.self_var_node
-        try:
-            self.direct_lookup(name.split(".")[0])
-            return dataflow.AttributeNodeReference(self.self_var_node, name)
-        except NotFoundException:
-            return self.resolver.get_dataflow_node(name)

--- a/tests/compiler/dataflow/conftest.py
+++ b/tests/compiler/dataflow/conftest.py
@@ -16,9 +16,9 @@
     Contact: code@inmanta.com
 """
 
-from itertools import chain
-from typing import Callable, Dict, Iterator, List, Optional, Set, Tuple, Type, List
 from functools import reduce
+from itertools import chain
+from typing import Callable, Dict, Iterator, List, Optional, Set, Tuple, Type
 
 import pytest
 
@@ -40,7 +40,7 @@ from inmanta.execute.dataflow import (
     ValueNode,
     VariableNodeReference,
 )
-from inmanta.execute.runtime import Resolver, ExecutionContext
+from inmanta.execute.runtime import ExecutionContext, Resolver
 
 
 def create_instance(

--- a/tests/compiler/dataflow/test_assignment.py
+++ b/tests/compiler/dataflow/test_assignment.py
@@ -17,7 +17,7 @@
 """
 
 
-from compiler.dataflow.conftest import create_instance
+from compiler.dataflow.conftest import create_instance, get_dataflow_node
 from typing import Optional, Set
 
 import pytest
@@ -38,8 +38,8 @@ from inmanta.execute.dataflow import (
 
 
 def test_dataflow_assignment_node_simple(graph: DataflowGraph) -> None:
-    x: AssignableNodeReference = graph.get_named_node("x")
-    y: AssignableNodeReference = graph.get_named_node("y")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
+    y: AssignableNodeReference = get_dataflow_node(graph, "y")
 
     x.assign(y, Statement(), graph)
 
@@ -49,16 +49,16 @@ def test_dataflow_assignment_node_simple(graph: DataflowGraph) -> None:
 
 @pytest.mark.parametrize("instantiate", [True, False])
 def test_dataflow_assignment_node_attribute(graph: DataflowGraph, instantiate: bool) -> None:
-    x: AssignableNodeReference = graph.get_named_node("x")
-    y: AssignableNodeReference = graph.get_named_node("y")
-    z: AssignableNodeReference = graph.get_named_node("z")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
+    y: AssignableNodeReference = get_dataflow_node(graph, "y")
+    z: AssignableNodeReference = get_dataflow_node(graph, "z")
 
     x.assign(y, Statement(), graph)
     y.assign(z, Statement(), graph)
     if instantiate:
         y.assign(create_instance().reference(), Statement(), graph)
 
-    x_n: AssignableNodeReference = graph.get_named_node("x.n")
+    x_n: AssignableNodeReference = get_dataflow_node(graph, "x.n")
 
     assignment_node: AssignableNode = x_n.assignment_node()
     instance: InstanceNode
@@ -77,9 +77,9 @@ def test_dataflow_assignment_node_attribute(graph: DataflowGraph, instantiate: b
 
 
 def test_dataflow_assignment_node_nested_tentative(graph: DataflowGraph) -> None:
-    x: AssignableNodeReference = graph.get_named_node("x")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
 
-    x_a_n: AssignableNodeReference = graph.get_named_node("x.a.n")
+    x_a_n: AssignableNodeReference = get_dataflow_node(graph, "x.a.n")
     assignment_node: AssignableNode = x_a_n.assignment_node()
 
     assert isinstance(x, VariableNodeReference)
@@ -95,7 +95,7 @@ def test_dataflow_assignment_node_nested_tentative(graph: DataflowGraph) -> None
 
 
 def test_dataflow_primitive_assignment(graph: DataflowGraph) -> None:
-    x: AssignableNodeReference = graph.get_named_node("x")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
     statement: Statement = Statement()
     x.assign(ValueNode(42).reference(), statement, graph)
     assert isinstance(x, DirectNodeReference)
@@ -109,8 +109,8 @@ def test_dataflow_primitive_assignment(graph: DataflowGraph) -> None:
 
 @pytest.mark.parametrize("instantiate", [True, False])
 def test_attribute_assignment(graph: DataflowGraph, instantiate: bool) -> None:
-    x: AssignableNodeReference = graph.get_named_node("x")
-    x_n: AssignableNodeReference = graph.get_named_node("x.n")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
+    x_n: AssignableNodeReference = get_dataflow_node(graph, "x.n")
 
     if instantiate:
         x.assign(create_instance().reference(), Statement(), graph)
@@ -133,14 +133,14 @@ def test_attribute_assignment(graph: DataflowGraph, instantiate: bool) -> None:
 
 
 def test_dataflow_tentative_attribute_propagation(graph: DataflowGraph) -> None:
-    x: AssignableNodeReference = graph.get_named_node("x")
-    y: AssignableNodeReference = graph.get_named_node("y")
-    z: AssignableNodeReference = graph.get_named_node("z")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
+    y: AssignableNodeReference = get_dataflow_node(graph, "y")
+    z: AssignableNodeReference = get_dataflow_node(graph, "z")
 
     x.assign(y, Statement(), graph)
     y.assign(z, Statement(), graph)
 
-    x_a_n: AssignableNodeReference = graph.get_named_node("x.a.n")
+    x_a_n: AssignableNodeReference = get_dataflow_node(graph, "x.a.n")
     x_a_n.assign(ValueNode(42).reference(), Statement(), graph)
 
     def assert_tentative_a_n(var: AssignableNode, values: Optional[Set[int]] = None) -> None:
@@ -160,8 +160,8 @@ def test_dataflow_tentative_attribute_propagation(graph: DataflowGraph) -> None:
     assert isinstance(z, VariableNodeReference)
     assert_tentative_a_n(z.node)
 
-    u: AssignableNodeReference = graph.get_named_node("u")
-    v: AssignableNodeReference = graph.get_named_node("v")
+    u: AssignableNodeReference = get_dataflow_node(graph, "u")
+    v: AssignableNodeReference = get_dataflow_node(graph, "v")
 
     u.assign(v, Statement(), graph)
     z.assign(u, Statement(), graph)
@@ -176,15 +176,15 @@ def test_dataflow_tentative_attribute_propagation(graph: DataflowGraph) -> None:
 
 
 def test_dataflow_tentative_attribute_propagation_on_equivalence(graph: DataflowGraph) -> None:
-    x: AssignableNodeReference = graph.get_named_node("x")
-    y: AssignableNodeReference = graph.get_named_node("y")
-    z: AssignableNodeReference = graph.get_named_node("z")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
+    y: AssignableNodeReference = get_dataflow_node(graph, "y")
+    z: AssignableNodeReference = get_dataflow_node(graph, "z")
 
     x.assign(y, Statement(), graph)
     y.assign(z, Statement(), graph)
     z.assign(x, Statement(), graph)
 
-    x_n: AssignableNodeReference = graph.get_named_node("x.n")
+    x_n: AssignableNodeReference = get_dataflow_node(graph, "x.n")
     x_n.assign(ValueNode(42).reference(), Statement(), graph)
 
     assert isinstance(y, VariableNodeReference)
@@ -201,14 +201,14 @@ def test_dataflow_tentative_attribute_propagation_on_equivalence(graph: Dataflow
 
 
 def test_dataflow_tentative_attribute_propagation_to_uninitialized_attribute(graph: DataflowGraph) -> None:
-    x_u: AssignableNodeReference = graph.get_named_node("x.u")
-    u: AssignableNodeReference = graph.get_named_node("u")
-    u_n: AssignableNodeReference = graph.get_named_node("u.n")
+    x_u: AssignableNodeReference = get_dataflow_node(graph, "x.u")
+    u: AssignableNodeReference = get_dataflow_node(graph, "u")
+    u_n: AssignableNodeReference = get_dataflow_node(graph, "u.n")
 
     u_n.assign(ValueNode(42).reference(), Statement(), graph)
     u.assign(x_u, Statement(), graph)
 
-    x: AssignableNodeReference = graph.get_named_node("x")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
     assert isinstance(x, VariableNodeReference)
     instance: Optional[InstanceNode] = x.node.equivalence.tentative_instance
     assert instance is not None
@@ -223,10 +223,10 @@ def test_dataflow_tentative_attribute_propagation_to_uninitialized_attribute(gra
 
 
 def test_dataflow_tentative_attribute_propagation_over_uninitialized_attribute(graph: DataflowGraph) -> None:
-    x_y: AssignableNodeReference = graph.get_named_node("x.y")
-    u_n: AssignableNodeReference = graph.get_named_node("u.n")
-    y: AssignableNodeReference = graph.get_named_node("y")
-    u: AssignableNodeReference = graph.get_named_node("u")
+    x_y: AssignableNodeReference = get_dataflow_node(graph, "x.y")
+    u_n: AssignableNodeReference = get_dataflow_node(graph, "u.n")
+    y: AssignableNodeReference = get_dataflow_node(graph, "y")
+    u: AssignableNodeReference = get_dataflow_node(graph, "u")
 
     u_n.assign(ValueNode(42).reference(), Statement(), graph)
     x_y.assign(y, Statement(), graph)

--- a/tests/compiler/dataflow/test_basic.py
+++ b/tests/compiler/dataflow/test_basic.py
@@ -51,7 +51,7 @@ def entity_instance(entity: str) -> InstanceNode:
         (AttributeNodeReference(AttributeNodeReference(AssignableNode("x").reference(), "y"), "z"), "x.y.z"),
         (entity_instance("MyEntity"), "__config__::MyEntity instance"),
         (entity_instance("MyEntity").reference(), "__config__::MyEntity instance"),
-        (AttributeNode(entity_instance("MyEntity").reference(), "n"), "attribute n on __config__::MyEntity instance"),
+        (AttributeNode(entity_instance("MyEntity"), "n"), "attribute n on __config__::MyEntity instance"),
     ],
 )
 def test_dataflow_repr(instance: Union[Node, NodeReference], expected_repr: str) -> None:

--- a/tests/compiler/dataflow/test_dataflow_entities.py
+++ b/tests/compiler/dataflow/test_dataflow_entities.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 
-from compiler.dataflow.conftest import create_instance
+from compiler.dataflow.conftest import create_instance, get_dataflow_node
 
 import pytest
 
@@ -56,15 +56,15 @@ def test_dataflow_index_nodes(graph: DataflowGraph) -> None:
     i1.register_attribute("n").assign(ValueNode(0).reference(), Statement(), graph)
     i1.register_attribute("n").assign(ValueNode(0).reference(), Statement(), graph)
 
-    x: AssignableNodeReference = graph.get_named_node("x")
-    y: AssignableNodeReference = graph.get_named_node("y")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
+    y: AssignableNodeReference = get_dataflow_node(graph, "y")
 
     x.assign(i1.reference(), Statement(), graph)
     y.assign(i2.reference(), Statement(), graph)
 
     graph.add_index_match([i.reference() for i in [i1, i2]])
 
-    x_n: AssignableNodeReference = graph.get_named_node("x.n")
-    y_n: AssignableNodeReference = graph.get_named_node("y.n")
+    x_n: AssignableNodeReference = get_dataflow_node(graph, "x.n")
+    y_n: AssignableNodeReference = get_dataflow_node(graph, "y.n")
 
     assert set(x_n.nodes()) == set(y_n.nodes())

--- a/tests/compiler/dataflow/test_leaves.py
+++ b/tests/compiler/dataflow/test_leaves.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 
-from compiler.dataflow.conftest import create_instance
+from compiler.dataflow.conftest import create_instance, get_dataflow_node
 from typing import List, Set
 
 import pytest
@@ -34,7 +34,7 @@ from inmanta.execute.dataflow import (
 
 
 def test_dataflow_reference_nodes(graph: DataflowGraph) -> None:
-    x: AssignableNodeReference = graph.get_named_node("x")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
     x_nodes: List[AssignableNode] = list(x.nodes())
     assert len(x_nodes) == 1
     assert isinstance(x, DirectNodeReference)
@@ -42,34 +42,34 @@ def test_dataflow_reference_nodes(graph: DataflowGraph) -> None:
 
 
 def test_dataflow_attribute_reference_nodes(graph: DataflowGraph) -> None:
-    x: AssignableNodeReference = graph.get_named_node("x")
-    y: AssignableNodeReference = graph.get_named_node("y")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
+    y: AssignableNodeReference = get_dataflow_node(graph, "y")
     x.assign(y, Statement(), graph)
     y.assign(create_instance().reference(), Statement(), graph)
 
     assert isinstance(y, VariableNodeReference)
     assert len(y.node.instance_assignments) == 1
 
-    y_n: AssignableNodeReference = graph.get_named_node("y.n")
+    y_n: AssignableNodeReference = get_dataflow_node(graph, "y.n")
     y_n.assign(ValueNode(42).reference(), Statement(), graph)
 
-    x_n: AssignableNodeReference = graph.get_named_node("x.n")
+    x_n: AssignableNodeReference = get_dataflow_node(graph, "x.n")
     x_n_nodes: List[AssignableNode] = list(x_n.nodes())
     assert len(x_n_nodes) == 1
     assert x_n_nodes[0] == y.node.instance_assignments[0].rhs.node().get_attribute("n")
 
 
 def test_dataflow_simple_leaf(graph) -> None:
-    x: AssignableNodeReference = graph.get_named_node("x")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
     leaves: List[AssignableNode] = list(x.leaf_nodes())
     assert isinstance(x, DirectNodeReference)
     assert leaves == [x.node]
 
 
 def test_dataflow_variable_chain_leaf(graph: DataflowGraph) -> None:
-    x: AssignableNodeReference = graph.get_named_node("x")
-    y: AssignableNodeReference = graph.get_named_node("y")
-    z: AssignableNodeReference = graph.get_named_node("z")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
+    y: AssignableNodeReference = get_dataflow_node(graph, "y")
+    z: AssignableNodeReference = get_dataflow_node(graph, "z")
 
     x.assign(y, Statement(), graph)
     y.assign(z, Statement(), graph)
@@ -81,9 +81,9 @@ def test_dataflow_variable_chain_leaf(graph: DataflowGraph) -> None:
 
 @pytest.mark.parametrize("value_node", [ValueNode(42), create_instance()])
 def test_dataflow_variable_tree_leaves(graph: DataflowGraph, value_node: Node) -> None:
-    x: AssignableNodeReference = graph.get_named_node("x")
-    y: AssignableNodeReference = graph.get_named_node("y")
-    z: AssignableNodeReference = graph.get_named_node("z")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
+    y: AssignableNodeReference = get_dataflow_node(graph, "y")
+    z: AssignableNodeReference = get_dataflow_node(graph, "z")
 
     x.assign(y, Statement(), graph)
     y.assign(z, Statement(), graph)
@@ -96,9 +96,9 @@ def test_dataflow_variable_tree_leaves(graph: DataflowGraph, value_node: Node) -
 
 
 def test_dataflow_variable_loop_leaves(graph: DataflowGraph) -> None:
-    x: AssignableNodeReference = graph.get_named_node("x")
-    y: AssignableNodeReference = graph.get_named_node("y")
-    z: AssignableNodeReference = graph.get_named_node("z")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
+    y: AssignableNodeReference = get_dataflow_node(graph, "y")
+    z: AssignableNodeReference = get_dataflow_node(graph, "z")
 
     x.assign(y, Statement(), graph)
     y.assign(z, Statement(), graph)
@@ -112,15 +112,15 @@ def test_dataflow_variable_loop_leaves(graph: DataflowGraph) -> None:
 
 
 def test_dataflow_variable_loop_with_external_assignment_leaves(graph: DataflowGraph) -> None:
-    x: AssignableNodeReference = graph.get_named_node("x")
-    y: AssignableNodeReference = graph.get_named_node("y")
-    z: AssignableNodeReference = graph.get_named_node("z")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
+    y: AssignableNodeReference = get_dataflow_node(graph, "y")
+    z: AssignableNodeReference = get_dataflow_node(graph, "z")
 
     x.assign(y, Statement(), graph)
     y.assign(z, Statement(), graph)
     z.assign(x, Statement(), graph)
 
-    u: AssignableNodeReference = graph.get_named_node("u")
+    u: AssignableNodeReference = get_dataflow_node(graph, "u")
     y.assign(u, Statement(), graph)
 
     leaves: Set[AssignableNode] = set(x.leaf_nodes())
@@ -129,9 +129,9 @@ def test_dataflow_variable_loop_with_external_assignment_leaves(graph: DataflowG
 
 
 def test_dataflow_variable_loop_with_value_assignment_leaves(graph: DataflowGraph) -> None:
-    x: AssignableNodeReference = graph.get_named_node("x")
-    y: AssignableNodeReference = graph.get_named_node("y")
-    z: AssignableNodeReference = graph.get_named_node("z")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
+    y: AssignableNodeReference = get_dataflow_node(graph, "y")
+    z: AssignableNodeReference = get_dataflow_node(graph, "z")
 
     x.assign(y, Statement(), graph)
     y.assign(z, Statement(), graph)

--- a/tests/compiler/dataflow/test_model_assignment.py
+++ b/tests/compiler/dataflow/test_model_assignment.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 
-from compiler.dataflow.conftest import DataflowTestHelper
+from compiler.dataflow.conftest import DataflowTestHelper, get_dataflow_node
 from typing import Dict, List, Optional
 
 import pytest
@@ -47,7 +47,7 @@ x = 42
         """,
     )
     graph: DataflowGraph = dataflow_test_helper.get_graph()
-    x: AssignableNodeReference = graph.get_named_node("x")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
     assert isinstance(x, VariableNodeReference)
     assert len(x.node.value_assignments) == 1
     assignment: Assignment[ValueNodeReference] = x.node.value_assignments[0]
@@ -67,7 +67,7 @@ x = 0
         DoubleSetException,
     )
     graph: DataflowGraph = dataflow_test_helper.get_graph()
-    x: AssignableNodeReference = graph.get_named_node("x")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
     assert isinstance(x, VariableNodeReference)
     assignments: List[Assignment] = x.node.value_assignments
     assert len(assignments) == 2
@@ -89,7 +89,7 @@ y = 42
         """,
     )
     graph: DataflowGraph = dataflow_test_helper.get_graph()
-    x: AssignableNodeReference = graph.get_named_node("x")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
     assert isinstance(x, VariableNodeReference)
     assert len(x.node.assignable_assignments) == 1
     assignment: Assignment[AssignableNodeReference] = x.node.assignable_assignments[0]
@@ -113,7 +113,7 @@ x.n = 42
         """
     )
     graph: DataflowGraph = dataflow_test_helper.get_graph()
-    x: AssignableNodeReference = graph.get_named_node("x")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
     assert isinstance(x, VariableNodeReference)
     assert len(x.node.instance_assignments) == 1
     n: Optional[AttributeNode] = x.node.instance_assignments[0].rhs.node().get_attribute("n")

--- a/tests/compiler/dataflow/test_model_assignment.py
+++ b/tests/compiler/dataflow/test_model_assignment.py
@@ -260,7 +260,7 @@ def test_dataflow_model_no_leaf_error(dataflow_test_helper: DataflowTestHelper) 
         """
 n = x.n
         """,
-        RuntimeException,
+        NotFoundException,
     )
 
 

--- a/tests/compiler/dataflow/test_model_dynamic_scope.py
+++ b/tests/compiler/dataflow/test_model_dynamic_scope.py
@@ -65,7 +65,7 @@ b -> x . b
         """,
     )
     dataflow_test_helper.verify_leaves({"b.n": {"x.n"}})
-    leaves: List[AssignableNode] = list(dataflow_test_helper.get_graph().resolver.get_dataflow_node("b.n").leaf_nodes())
+    leaves: List[AssignableNode] = list(dataflow_test_helper.get_graph().get_named_node("b.n").leaf_nodes())
     assert len(leaves) == 1
     assert len(leaves[0].value_assignments) == 1
     assert leaves[0].value_assignments[0].rhs.node.value == 42

--- a/tests/compiler/dataflow/test_model_dynamic_scope.py
+++ b/tests/compiler/dataflow/test_model_dynamic_scope.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 
-from compiler.dataflow.conftest import DataflowTestHelper
+from compiler.dataflow.conftest import DataflowTestHelper, get_dataflow_node
 from typing import List
 
 import pytest
@@ -65,7 +65,7 @@ b -> x . b
         """,
     )
     dataflow_test_helper.verify_leaves({"b.n": {"x.n"}})
-    leaves: List[AssignableNode] = list(dataflow_test_helper.get_graph().get_named_node("b.n").leaf_nodes())
+    leaves: List[AssignableNode] = list(get_dataflow_node(dataflow_test_helper.get_graph(), "b.n").leaf_nodes())
     assert len(leaves) == 1
     assert len(leaves[0].value_assignments) == 1
     assert leaves[0].value_assignments[0].rhs.node.value == 42

--- a/tests/compiler/dataflow/test_model_root_cause.py
+++ b/tests/compiler/dataflow/test_model_root_cause.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 
-from compiler.dataflow.conftest import DataflowTestHelper
+from compiler.dataflow.conftest import DataflowTestHelper, get_dataflow_node
 from typing import List, Set
 
 import pytest
@@ -27,7 +27,7 @@ from inmanta.execute.dataflow.root_cause import UnsetRootCauseAnalyzer
 
 
 def get_attribute_node(graph: DataflowGraph, attr: str) -> AttributeNode:
-    node_ref: AssignableNodeReference = graph.get_named_node(attr)
+    node_ref: AssignableNodeReference = get_dataflow_node(graph, attr)
     node: AssignableNode = next(node_ref.nodes())
     assert isinstance(node, AttributeNode)
     return node

--- a/tests/compiler/dataflow/test_model_stubs.py
+++ b/tests/compiler/dataflow/test_model_stubs.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 
-from compiler.dataflow.conftest import DataflowTestHelper
+from compiler.dataflow.conftest import DataflowTestHelper, get_dataflow_node
 from typing import Dict, List
 
 import pytest
@@ -78,7 +78,7 @@ x = %s
         % (value_string, "\n".join(other_stmts)),
     )
     graph: DataflowGraph = dataflow_test_helper.get_graph()
-    x: AssignableNodeReference = graph.get_named_node("x")
+    x: AssignableNodeReference = get_dataflow_node(graph, "x")
     assert isinstance(x, VariableNodeReference)
     assignments: List[Assignment] = list(x.node.assignments())
     assert len(assignments) == 1


### PR DESCRIPTION
# Description

Fixes the duplicate lookup between `ResultVariables` and `AssignableNodeReferences`

closes #1879

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] ~~Changelog entry~~
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
