### PR TITLE
Add tags to openapi definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
  - Added support for declaring implement using parents together with normal implement declaration list (#1971)
  - Resource Action Log now includes timestamps (#1496)
  - Added --no-tag option to module tool (#1939)
+ - Added tags to openapi definition (#1751)
 
 # v 2020.1 (2020-02-19) Changes in this release:
 

--- a/src/inmanta/protocol/openapi/converter.py
+++ b/src/inmanta/protocol/openapi/converter.py
@@ -405,6 +405,7 @@ class OperationHandler:
             parameters=(parameters if len(parameters) else None),
             summary=url_method.short_method_description,
             description=url_method.long_method_description,
+            tags=[url_method.endpoint.__class__.__name__],
             **extra_params,
         )
 

--- a/src/inmanta/protocol/openapi/converter.py
+++ b/src/inmanta/protocol/openapi/converter.py
@@ -400,14 +400,25 @@ class OperationHandler:
         else:
             extra_params = {}
 
+        tags = self._get_tags_of_operation(url_method)
+
         return Operation(
             responses=responses,
             parameters=(parameters if len(parameters) else None),
             summary=url_method.short_method_description,
             description=url_method.long_method_description,
-            tags=[url_method.endpoint.__class__.__name__],
+            tags=tags,
             **extra_params,
         )
+
+    def _get_tags_of_operation(self, url_method: UrlMethod) -> Optional[List[str]]:
+        if url_method.endpoint is not None:
+            if hasattr(url_method.endpoint, "_name"):
+                return [url_method.endpoint._name]
+            else:
+                return [url_method.endpoint.__class__.__name__]
+        else:
+            return None
 
     def _build_responses(self, url_method_properties: MethodProperties) -> Dict[str, Response]:
         result: Dict[str, Response] = {}

--- a/src/inmanta/protocol/openapi/model.py
+++ b/src/inmanta/protocol/openapi/model.py
@@ -147,6 +147,7 @@ class Operation(BaseModel):
     requestBody: Optional[Union[RequestBody, Reference]] = None
     responses: Dict[str, Response]
     deprecated: Optional[bool] = None
+    tags: Optional[List[str]] = None
 
 
 class PathItem(BaseModel):

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -626,4 +626,4 @@ async def test_tags(server):
     for path in openapi_parsed["paths"].values():
         for operation in path.values():
             assert len(operation["tags"]) > 0
-    assert "ProjectService" in openapi_parsed["paths"]["/api/v1/project"]["get"]["tags"]
+    assert "core.project" in openapi_parsed["paths"]["/api/v1/project"]["get"]["tags"]

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -615,3 +615,15 @@ async def test_openapi_endpoint(client):
 async def test_swagger_endpoint(client):
     result = await client.get_api_docs()
     assert result.code == 200
+
+
+@pytest.mark.asyncio
+async def test_tags(server):
+    global_url_map = server._transport.get_global_url_map(server.get_slices().values())
+    openapi = OpenApiConverter(global_url_map)
+    openapi_json = openapi.generate_openapi_json()
+    openapi_parsed = json.loads(openapi_json)
+    for path in openapi_parsed["paths"].values():
+        for operation in path.values():
+            assert len(operation["tags"]) > 0
+    assert "ProjectService" in openapi_parsed["paths"]["/api/v1/project"]["get"]["tags"]


### PR DESCRIPTION
# Description

Adds tags based on the slice

closes #1751 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
