### PR TITLE
fixed parser warning ns_list unreachable

### DIFF
--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -855,17 +855,6 @@ def p_operand_list_term_2(p: YaccProduction) -> None:
     p[0] = []
 
 
-def p_ns_list_collect(p: YaccProduction) -> None:
-    """ns_list : ns_ref ',' ns_list"""
-    p[3].insert(0, p[1])
-    p[0] = p[3]
-
-
-def p_ns_list_term(p: YaccProduction) -> None:
-    "ns_list : ns_ref"
-    p[0] = [p[1]]
-
-
 def p_var_ref(p: YaccProduction) -> None:
     "var_ref : attr_ref"
     p[0] = p[1]


### PR DESCRIPTION
# Description

Fixes `WARNING: Symbol 'ns_list' is unreachable` since `ns_list` has been replaced by `implement_ns_list`.

~~closes *Add ticket reference here*~~

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] ~~Changelog entry~~
- [x] ~~Type annotations are present~~
- [x] ~~Code is clear and sufficiently documented~~
- [x] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] ~~Correct, in line with design~~
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
