### PR TITLE
Apply missing get_version call to api docs

### DIFF
--- a/src/inmanta/protocol/openapi/converter.py
+++ b/src/inmanta/protocol/openapi/converter.py
@@ -81,7 +81,7 @@ class OpenApiConverter:
         return metadata["version"]
 
     def generate_openapi_definition(self) -> OpenAPI:
-        version = get_compiler_version()
+        version = self._get_inmanta_version()
         info = Info(title="Inmanta Service Orchestrator", version=version if version else "")
         servers = self._collect_server_information()
         paths = {}

--- a/src/inmanta/protocol/openapi/converter.py
+++ b/src/inmanta/protocol/openapi/converter.py
@@ -49,7 +49,6 @@ from inmanta.protocol.openapi.model import (
 )
 from inmanta.server import config
 from inmanta.server.extensions import FeatureManager
-from inmanta.util import get_compiler_version
 
 
 def openapi_json_encoder(o) -> Union[Dict, str, List]:


### PR DESCRIPTION
# Description

The function to get the correct version wasn't called in the previous PR.

closes #1994 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [ ] ~Changelog entry~
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
