### PR TITLE
fixed constructor defaults and kwargs issue: fixes #2003

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
  - Added warning for incorrect database migration script names (#1912)
  - Agent manager remains consistent when the database connection is lost (#1893)
  - Ensure correct version is used in api docs (#1994)
+ - Fixed double assignment error resulting from combining constructor kwargs with default values (#2003)
 
 ## Added
  - Experimental data trace and root cause application (#1820, #1831, #1821)

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -400,13 +400,15 @@ class Constructor(ExpressionStatement):
                 self, "attributes %s are part of an index and should be set in the constructor." % ",".join(missing_attrs)
             )
 
-        # schedule all direct attributes for direct execution
+        # Schedule all direct attributes for direct execution. The kwarg keys and the direct_attributes keys are disjoint
+        # because a RuntimeException is raised above when they are not.
         direct_attributes: Dict[str, object] = {
             k: v.execute(requires, resolver, queue) for (k, v) in self._direct_attributes.items()
         }
         direct_attributes.update(kwarg_attrs)
 
-        # override defaults with kwargs
+        # Override defaults with kwargs. The kwarg keys and the indirect_attributes keys are disjoint because a RuntimeException
+        # is raised above when they are not.
         indirect_attributes: Dict[str, ExpressionStatement] = {
             k: v for k, v in self._indirect_attributes.items() if k not in kwarg_attrs
         }

--- a/tests/compiler/test_dict.py
+++ b/tests/compiler/test_dict.py
@@ -242,6 +242,30 @@ x = Test(**dct["config"], str = "Hello World!")
     assert instance.get_attribute("str").get_value() == "Hello World!"
 
 
+@pytest.mark.parametrize("override", [True, False])
+def test_2003_constructor_kwargs_default(snippetcompiler, override: bool):
+    snippetcompiler.setup_for_snippet(
+        """
+entity Test:
+    number v = 0
+end
+
+implement Test using std::none
+
+values = {%s}
+t = Test(
+    **values
+)
+        """
+        % ("'v': 10" if override else ""),
+    )
+    (_, root) = compiler.do_compile()
+    scope = root.get_child("__config__").scope
+
+    instance: Instance = scope.lookup("t").get_value()
+    assert instance.get_attribute("v").get_value() == (10 if override else 0)
+
+
 def test_constructor_kwargs_index_match(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """

--- a/tests/compiler/test_dict.py
+++ b/tests/compiler/test_dict.py
@@ -266,6 +266,20 @@ t = Test(
     assert instance.get_attribute("v").get_value() == (10 if override else 0)
 
 
+def test_constructor_kwargs_double_set(snippetcompiler):
+    snippetcompiler.setup_for_error(
+        """
+entity A:
+    int a
+end
+
+v = {"a": 4}
+A(a = 3, **v)
+        """,
+        "The attribute a is set twice in the constructor call of A. (reported in Construct(A) ({dir}/main.cf:7))",
+    )
+
+
 def test_constructor_kwargs_index_match(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """


### PR DESCRIPTION
# Description

Fixed double assignment error resulting from combining constructor kwargs with default values

closes #2003

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Code is clear and sufficiently documented
- [x] Correct, in line with design
