### PR TITLE
deprecated old relation syntax: fixes #2000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Deprecated
  - Leaving a nullable attribute unassigned now produces a deprecation warning. Explicitly assign null instead. (#1775)
  - Default constructors (typedef MyType as SomeEntityType(some_field = "some_value")). Use inheritance instead. (#402)
+ - Old relation syntax (A aa [0:] -- [0:] B bb) (#2000)
 
 ## Fixed
  - Various compiler error reporting improvements (#1810, #1920)

--- a/src/inmanta/parser/__init__.py
+++ b/src/inmanta/parser/__init__.py
@@ -16,8 +16,6 @@
     Contact: code@inmanta.com
 """
 
-from typing import Optional
-
 from inmanta.ast import CompilerException, Range
 from inmanta.warnings import InmantaWarning
 
@@ -38,6 +36,15 @@ class ParserException(CompilerException):
 class ParserWarning(InmantaWarning, ParserException):
     """Warning occurring during the parsing of the code"""
 
-    def __init__(self, location: Range, value: object, msg: Optional[str] = None) -> None:
+    def __init__(self, location: Range, value: object, msg: str) -> None:
         InmantaWarning.__init__(self)
         ParserException.__init__(self, location, value, msg)
+        # Override parent message since it's not an error
+        self.msg = msg
+
+
+class SyntaxDeprecationWarning(ParserWarning):
+    """Deprecation warning occurring during the parsing of the code"""
+
+    def __init__(self, location: Range, value: object, msg: str) -> None:
+        ParserWarning.__init__(self, location, value, msg)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -20,6 +20,7 @@ import re
 from typing import List
 
 import pytest
+import warnings
 
 from inmanta.ast import LocatableString, Namespace
 from inmanta.ast.blocks import BasicBlock
@@ -47,7 +48,7 @@ from inmanta.ast.statements.define import (
 from inmanta.ast.statements.generator import Constructor, If
 from inmanta.ast.variables import AttributeReference, Reference
 from inmanta.execute.util import NoneValue
-from inmanta.parser import ParserException
+from inmanta.parser import ParserException, SyntaxDeprecationWarning
 from inmanta.parser.plyInmantaParser import parse
 
 
@@ -1769,3 +1770,24 @@ __x__ = {expression}
             raise Exception("this test does not support %s" % type(expression))
 
     expression_asserter(assign_stmt.rhs, expected_tree)
+
+
+def test_relation_deprecated_syntax():
+    with warnings.catch_warnings(record=True) as w:
+        parse_code(
+            """
+entity A:
+end
+
+entity B:
+end
+
+A aa [1] -- [0:] B bb
+            """,
+        )
+        assert len(w) == 1
+        assert issubclass(w[0].category, SyntaxDeprecationWarning)
+        assert str(w[0].message) == (
+            "The relation definition syntax `A aa [1:1] -- [0:] B bb` is deprecated."
+            " Please use `A.bb [0:] -- B.aa [1:1]` instead. (test:8)"
+        )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -17,10 +17,10 @@
 """
 
 import re
+import warnings
 from typing import List
 
 import pytest
-import warnings
 
 from inmanta.ast import LocatableString, Namespace
 from inmanta.ast.blocks import BasicBlock


### PR DESCRIPTION
# Description

Deprecated the old relation definition syntax.

closes #2000

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
