### PR TITLE
fixed recusive unwrapping of dict return values from plugins: fixes #2004

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
  - Agent manager remains consistent when the database connection is lost (#1893)
  - Ensure correct version is used in api docs (#1994)
  - Fixed double assignment error resulting from combining constructor kwargs with default values (#2003)
+ - Fixed recursively unwrapping of dict return values from plugins (#2004)
 
 ## Added
  - Experimental data trace and root cause application (#1820, #1831, #1821)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
  - Agent manager remains consistent when the database connection is lost (#1893)
  - Ensure correct version is used in api docs (#1994)
  - Fixed double assignment error resulting from combining constructor kwargs with default values (#2003)
- - Fixed recursively unwrapping of dict return values from plugins (#2004)
+ - Fixed recursive unwrapping of dict return values from plugins (#2004)
 
 ## Added
  - Experimental data trace and root cause application (#1820, #1831, #1821)

--- a/src/inmanta/execute/proxy.py
+++ b/src/inmanta/execute/proxy.py
@@ -18,7 +18,7 @@
 
 from collections import Mapping
 from copy import copy
-from typing import Any, Optional, Union
+from typing import Any, Optional, Tuple, Union
 
 from inmanta.ast import RuntimeException
 from inmanta.execute.util import NoneValue, Unknown
@@ -85,9 +85,16 @@ class DynamicProxy(object):
             return [cls.unwrap(x) for x in item]
 
         if isinstance(item, dict):
-            if not all(isinstance(key, str) for key in item.keys()):
-                raise RuntimeException(None, "dict keys should be strings.")
-            return {key: cls.unwrap(value) for key, value in item.items()}
+
+            def recurse_dict_item(key_value: Tuple[object, object]) -> Tuple[object, object]:
+                (key, value) = key_value
+                if not isinstance(key, str):
+                    raise RuntimeException(
+                        None, "dict keys should be strings, got %s of type %s with dict value %s" % (key, type(key), value)
+                    )
+                return (key, cls.unwrap(value))
+
+            return dict(map(recurse_dict_item, item.items()))
 
         return item
 

--- a/src/inmanta/execute/proxy.py
+++ b/src/inmanta/execute/proxy.py
@@ -75,11 +75,19 @@ class DynamicProxy(object):
 
     @classmethod
     def unwrap(cls, item):
+        if item is None:
+            return NoneValue()
+
         if isinstance(item, DynamicProxy):
             return item._get_instance()
 
         if isinstance(item, list):
             return [cls.unwrap(x) for x in item]
+
+        if isinstance(item, dict):
+            if not all(isinstance(key, str) for key in item.keys()):
+                raise RuntimeException(None, "dict keys should be strings.")
+            return {key: cls.unwrap(value) for key, value in item.items()}
 
         return item
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -19,7 +19,9 @@
 import pytest
 
 import inmanta.compiler as compiler
+from inmanta.ast import RuntimeException
 from inmanta.execute.proxy import DynamicProxy
+from inmanta.execute.util import NoneValue
 
 
 def proxy_object(snippetcompiler, snippet, var):
@@ -75,3 +77,16 @@ a = Test1(x={"a":"A"})
 
     with pytest.raises(Exception):
         dic["b"] = "a"
+
+
+def test_unwrap_none():
+    assert DynamicProxy.unwrap(None) == NoneValue()
+
+
+def test_unwrap_list_dict_recurse():
+    assert DynamicProxy.unwrap([{"null": None, "nulls": [None]}]) == [{"null": NoneValue(), "nulls": [NoneValue()]}]
+
+
+def test_unwrap_dict_key_validation():
+    with pytest.raises(RuntimeException):
+        DynamicProxy.unwrap({1: 2})


### PR DESCRIPTION
# Description

Fixes the recursive unwrapping of dicts using `DynamicProxy.unwrap()`.

closes #2004

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Code is clear and sufficiently documented
- [x] Correct, in line with design
