### PR TITLE
Issue/1839 fetch agent map from server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
  - Added base exception for plugins and corresponding documentation (#1205)
  - Added tags to openapi definition (#1751)
  - Added support to pause an agent (#1128, #1982)
+ - Autostarted agents can load a new value for the autostart_agent_map setting without agent restart (#1839)
 
 # v 2020.1 (2020-02-19) Changes in this release:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Breaking changes
 - Non-boolean arguments to boolean operators are no longer allowed, this was previously possible due to bug (#1808)
 - Server will no longer start if the database schema is for a newer version (#1878)
+- The environment setting autostart_agent_map should always contain an entry for the agent "internal" (#1839)
 
 ## Deprecated
  - Leaving a nullable attribute unassigned now produces a deprecation warning. Explicitly assign null instead. (#1775)

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -1032,7 +1032,7 @@ class Agent(SessionEndpoint):
 
     async def _init_agent_map(self):
         if cfg.use_autostart_agent_map.get():
-            LOGGER.info("Using the agent-map configured on the server")
+            LOGGER.info("Using the autostart_agent_map configured on the server")
             env_id = self.get_environment()
             assert env_id is not None
             result = await self._client.environment_setting_get(env_id, data.AUTOSTART_AGENT_MAP)

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -1094,6 +1094,9 @@ class Agent(SessionEndpoint):
         LOGGER.info("Adding endpoint %s", name)
         await super(Agent, self).add_end_point_name(name)
 
+        # Make mypy happy
+        assert self.agent_map is not None
+
         hostname = "local:"
         if name in self.agent_map:
             hostname = self.agent_map[name]
@@ -1236,9 +1239,7 @@ class Agent(SessionEndpoint):
 
         LOGGER.info("Agent %s got a trigger to update in environment %s", agent, env)
         self.add_background_task(
-            instance.get_latest_version_for_agent(
-                reason="call to trigger_update", incremental_deploy=incremental_deploy
-            )
+            instance.get_latest_version_for_agent(reason="call to trigger_update", incremental_deploy=incremental_deploy)
         )
         return 200
 

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -1035,8 +1035,6 @@ class Agent(SessionEndpoint):
             assert env_id is not None
             result = await self._client.environment_setting_get(env_id, data.AUTOSTART_AGENT_MAP)
             if result.code != 200:
-                print(result.__dict__)
-                # TODO: enhance
                 raise Exception("Failed to retrieve the autostart_agent_map from the server.")
             self.agent_map = result.result["data"]["settings"][data.AUTOSTART_AGENT_MAP]
         elif self.agent_map is None:

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -419,7 +419,7 @@ class ResourceScheduler(object):
     def __init__(
         self, agent: "AgentInstance", env_id: uuid.UUID, name: str, cache: AgentCache, ratelimiter: asyncio.Semaphore
     ) -> None:
-        self.generation: Dict[str, ResourceAction] = {}
+        self.generation: Dict[ResourceIdStr, ResourceAction] = {}
         self.cad: Dict[str, RemoteResourceAction] = {}
         self._env_id = env_id
         self.agent = agent
@@ -498,7 +498,7 @@ class ResourceScheduler(object):
         self.logger.info("Running %s for reason: %s" % (gid, reason))
 
         # re-generate generation
-        self.generation: Dict[ResourceIdStr, ResourceAction] = {
+        self.generation = {
             r.id.resource_str(): ResourceAction(self, r, gid, reason) for r in resources
         }
 

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -498,9 +498,7 @@ class ResourceScheduler(object):
         self.logger.info("Running %s for reason: %s" % (gid, reason))
 
         # re-generate generation
-        self.generation = {
-            r.id.resource_str(): ResourceAction(self, r, gid, reason) for r in resources
-        }
+        self.generation = {r.id.resource_str(): ResourceAction(self, r, gid, reason) for r in resources}
 
         # mark undeployable
         for key, res in self.generation.items():

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -21,9 +21,9 @@ import datetime
 import logging
 import os
 import random
+import sys
 import time
 import uuid
-import sys
 from concurrent.futures.thread import ThreadPoolExecutor
 from logging import Logger
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, cast

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -1026,7 +1026,11 @@ class Agent(SessionEndpoint):
             self._env.use_virtual_env()
             self._loader = CodeLoader(self._storage["code"])
 
-        self.agent_map: Optional[Dict[str, str]] = agent_map
+        self.agent_map: Dict[str, str]
+        if agent_map is None:
+            self.agent_map = {}
+        else:
+            self.agent_map = agent_map
 
     async def _init_agent_map(self):
         if cfg.use_autostart_agent_map.get():

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -23,6 +23,7 @@ import os
 import random
 import time
 import uuid
+import sys
 from concurrent.futures.thread import ThreadPoolExecutor
 from logging import Logger
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, cast
@@ -1039,7 +1040,10 @@ class Agent(SessionEndpoint):
             assert env_id is not None
             result = await self._client.environment_setting_get(env_id, data.AUTOSTART_AGENT_MAP)
             if result.code != 200:
-                raise Exception("Failed to retrieve the autostart_agent_map from the server.")
+                error_msg = result.result["message"]
+                LOGGER.error(f"Failed to retrieve the autostart_agent_map setting from the server. %s", error_msg)
+                await self.stop()
+                sys.exit(1)
             self.agent_map = result.result["data"]["settings"][data.AUTOSTART_AGENT_MAP]
         elif self.agent_map is None:
             self.agent_map = cfg.agent_map.get()

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -21,7 +21,6 @@ import datetime
 import logging
 import os
 import random
-import sys
 import time
 import uuid
 from concurrent.futures.thread import ThreadPoolExecutor

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -1101,8 +1101,10 @@ class Agent(SessionEndpoint):
     @protocol.handle(methods_v2.update_agent_map)
     async def update_agent_map(self, agent_map: Dict[str, str]) -> None:
         if not cfg.use_autostart_agent_map.get():
-            LOGGER.warning("Agent received an update_agent_map() trigger, but agent is not running with "
-                           "the use_autostart_agent_map option.")
+            LOGGER.warning(
+                "Agent received an update_agent_map() trigger, but agent is not running with "
+                "the use_autostart_agent_map option."
+            )
             return
         async with self._instances_lock:
             LOGGER.debug("Received update_agent_map() trigger with agent_map %s", agent_map)

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -44,7 +44,7 @@ use_autostart_agent_map = Option(
     False,
     """If this option is set to true, the agent-map of this agent will be set the the autostart_agent_map configured on the
     server. The agent_map will be kept up-to-date automatically.""",
-    is_bool
+    is_bool,
 )
 
 environment = Option("config", "environment", None, "The environment this agent or compile belongs to", is_uuid_opt)
@@ -55,7 +55,7 @@ agent_names = Option(
     "$node-name",
     """Names of the agents this instance should deploy configuration for. When the configuration option
 config.use_autostart_agent_map is set to true, this option will be ignored.""",
-    is_str
+    is_str,
 )
 
 agent_interval = Option(

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -30,17 +30,32 @@ agent_map = Option(
     None,
     """By default the agent assumes that all agent names map to the host on which the process is executed. With the
 agent map it can be mapped to other hosts. This value consists of a list of key/value pairs. The key is the name of the
-agent and the format of the value is described in :inmanta:entity:`std::AgentConfig`
+agent and the format of the value is described in :inmanta:entity:`std::AgentConfig`. When the configuration option
+config.use_autostart_agent_map is set to true, this option will be ignored.
 
 
 example: iaas_openstack=localhost,vm1=192.16.13.2""",
     is_map,
 )
 
+use_autostart_agent_map = Option(
+    "config",
+    "use_autostart_agent_map",
+    False,
+    """If this option is set to true, the agent-map of this agent will be set the the autostart_agent_map configured on the
+    server. The agent_map will be kept up-to-date automatically.""",
+    is_bool
+)
+
 environment = Option("config", "environment", None, "The environment this agent or compile belongs to", is_uuid_opt)
 
 agent_names = Option(
-    "config", "agent-names", "$node-name", "Names of the agents this instance should deploy configuration for", is_str
+    "config",
+    "agent-names",
+    "$node-name",
+    """Names of the agents this instance should deploy configuration for. When the configuration option
+config.use_autostart_agent_map is set to true, this option will be ignored.""",
+    is_str
 )
 
 agent_interval = Option(

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1085,7 +1085,7 @@ class AgentProcess(BaseDocument):
         return nodes
 
     @classmethod
-    async def get_by_sid(cls, sid: uuid.UUID) -> List["AgentProcess"]:
+    async def get_by_sid(cls, sid: uuid.UUID) -> Optional["AgentProcess"]:
         objects = await cls.get_list(limit=DBLIMIT, expired=None, sid=sid)
         if len(objects) == 0:
             return None

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1095,6 +1095,24 @@ class AgentProcess(BaseDocument):
         else:
             return objects[0]
 
+    @classmethod
+    async def seen(cls, env: uuid.UUID, nodename: str, sid: uuid.UUID, now: datetime.datetime):
+        """
+            Update the last_seen parameter of the process and mark as not expired.
+        """
+        proc = await cls.get_one(sid=sid)
+        if proc is None:
+            proc = cls(hostname=nodename, environment=env, first_seen=now, last_seen=now, sid=sid)
+            await proc.insert()
+        else:
+            await proc.update_fields(last_seen=now, expired=None)
+
+    @classmethod
+    async def expire_process(cls, sid: uuid.UUID, now: datetime.datetime) -> None:
+        aps = await cls.get_by_sid(sid=sid)
+        if aps is not None:
+            await aps.update_fields(expired=now)
+
     def to_dict(self) -> JsonType:
         result = super(AgentProcess, self).to_dict()
         # Ensure backward compatibility API
@@ -1131,7 +1149,7 @@ class AgentInstance(BaseDocument):
         return objects
 
     @classmethod
-    async def expire_endpoints_for_process(
+    async def _expire_endpoints_for_process(
         cls, tid: uuid.UUID, process: uuid.UUID, endpoints: List[str], now: datetime.datetime
     ) -> None:
         """
@@ -1146,6 +1164,30 @@ class AgentInstance(BaseDocument):
                  """
         values = [cls._get_value(now), cls._get_value(tid), cls._get_value(process)] + [cls._get_value(e) for e in endpoints]
         await cls._execute_query(query, *values)
+
+    @classmethod
+    async def log_instance_creation(cls, tid: uuid.UUID, process: uuid.UUID, endpoints: List[str], now: datetime) -> None:
+        """
+            Create new agent instances for a given session.
+        """
+        if not endpoints:
+            return
+        # Fix database corruption when database was down
+        await cls._expire_endpoints_for_process(tid, process, endpoints, now)
+        for nh in endpoints:
+            await cls(tid=tid, process=process, name=nh).insert()
+
+    @classmethod
+    async def log_instance_expiry(cls, sid: uuid.UUID, endpoints: List[str], now: datetime) -> None:
+        """
+            Expire specific instances for a given session id.
+        """
+        if not endpoints:
+            return
+        instances = await cls.get_list(process=sid)
+        for ai in instances:
+            if ai.name in endpoints:
+                await ai.update_fields(expired=now)
 
 
 class Agent(BaseDocument):
@@ -1241,6 +1283,33 @@ class Agent(BaseDocument):
             values = [cls._get_value(paused), cls._get_value(env), cls._get_value(endpoint)]
         result = await cls._fetch_query(query, *values)
         return sorted([r["name"] for r in result])
+
+    @classmethod
+    async def update_primary(
+        cls, env: uuid.UUID, endpoints_with_new_primary: Sequence[Tuple[str, Optional[uuid.UUID]]], now: datetime
+    ) -> None:
+        """
+            Update the primary agent instance for agents present in the database.
+
+            :param env: The environment of the agent
+            :param endpoints_with_new_primary: Contains a tuple (agent-name, sid) for each agent that has got a new
+                                               primary agent instance. The sid in the tuple is the session id of the new
+                                               primary. If the session id is None, the Agent doesn't have a primary anymore.
+            :param now: Timestamp of this failover
+        """
+        for (endpoint, sid) in endpoints_with_new_primary:
+            agent = await cls.get(env, endpoint)
+            if agent is None:
+                continue
+
+            if sid is None:
+                await agent.update_fields(last_failover=now, primary=None)
+            else:
+                instances = await AgentInstance.active_for(tid=env, endpoint=agent.name, process=sid)
+                if instances:
+                    await agent.update_fields(last_failover=now, primary=instances[0].id)
+                else:
+                    await agent.update_fields(last_failover=now, primary=None)
 
 
 class Report(BaseDocument):

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1139,7 +1139,7 @@ class AgentInstance(BaseDocument):
         """
         if not endpoints:
             return
-        names_subquery = ",".join([f"${i}" for i in range(4, 4+len(endpoints))])
+        names_subquery = ",".join([f"${i}" for i in range(4, 4 + len(endpoints))])
         query = f"""UPDATE {cls.table_name()}
                     SET expired=$1 WHERE tid=$2 AND process=$3 AND name IN ({names_subquery})
                  """

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1108,6 +1108,12 @@ class AgentProcess(BaseDocument):
             await proc.update_fields(last_seen=now, expired=None)
 
     @classmethod
+    async def update_last_seen(cls, sid: uuid.UUID, last_seen: datetime) -> None:
+        aps = await cls.get_by_sid(sid=sid)
+        if aps:
+            await aps.update_fields(last_seen=last_seen)
+
+    @classmethod
     async def expire_process(cls, sid: uuid.UUID, now: datetime.datetime) -> None:
         aps = await cls.get_by_sid(sid=sid)
         if aps is not None:

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1166,7 +1166,9 @@ class AgentInstance(BaseDocument):
         await cls._execute_query(query, *values)
 
     @classmethod
-    async def log_instance_creation(cls, tid: uuid.UUID, process: uuid.UUID, endpoints: List[str], now: datetime) -> None:
+    async def log_instance_creation(
+        cls, tid: uuid.UUID, process: uuid.UUID, endpoints: List[str], now: datetime.datetime
+    ) -> None:
         """
             Create new agent instances for a given session.
         """
@@ -1178,7 +1180,9 @@ class AgentInstance(BaseDocument):
             await cls(tid=tid, process=process, name=nh).insert()
 
     @classmethod
-    async def log_instance_expiry(cls, sid: uuid.UUID, endpoints: List[str], now: datetime) -> None:
+    async def log_instance_expiry(
+        cls, sid: uuid.UUID, endpoints: List[str], now: datetime.datetime
+    ) -> None:
         """
             Expire specific instances for a given session id.
         """
@@ -1286,7 +1290,7 @@ class Agent(BaseDocument):
 
     @classmethod
     async def update_primary(
-        cls, env: uuid.UUID, endpoints_with_new_primary: Sequence[Tuple[str, Optional[uuid.UUID]]], now: datetime
+        cls, env: uuid.UUID, endpoints_with_new_primary: Sequence[Tuple[str, Optional[uuid.UUID]]], now: datetime.datetime
     ) -> None:
         """
             Update the primary agent instance for agents present in the database.

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1108,7 +1108,7 @@ class AgentProcess(BaseDocument):
             await proc.update_fields(last_seen=now, expired=None)
 
     @classmethod
-    async def update_last_seen(cls, sid: uuid.UUID, last_seen: datetime) -> None:
+    async def update_last_seen(cls, sid: uuid.UUID, last_seen: datetime.datetime) -> None:
         aps = await cls.get_by_sid(sid=sid)
         if aps:
             await aps.update_fields(last_seen=last_seen)

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1135,13 +1135,14 @@ class AgentInstance(BaseDocument):
         cls, tid: uuid.UUID, process: uuid.UUID, endpoints: List[str], now: datetime.datetime
     ) -> None:
         """
-            Expire the given endpoints in an agent process.
+            Expire the agent instances for the given endpoints if they are not expired yet.
         """
         if not endpoints:
             return
         names_subquery = ",".join([f"${i}" for i in range(4, 4 + len(endpoints))])
         query = f"""UPDATE {cls.table_name()}
-                    SET expired=$1 WHERE tid=$2 AND process=$3 AND name IN ({names_subquery})
+                    SET expired=$1
+                    WHERE tid=$2 AND process=$3 AND name IN ({names_subquery}) AND expired IS NULL
                  """
         values = [cls._get_value(now), cls._get_value(tid), cls._get_value(process)] + [cls._get_value(e) for e in endpoints]
         await cls._execute_query(query, *values)

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -617,6 +617,9 @@ def convert_agent_map(value: Dict[str, str]) -> Dict[str, str]:
         if not isinstance(v, str):
             raise ValueError("The value of an agent map should be string")
 
+    if "internal" not in value:
+        raise ValueError("The internal agent must be present in the autostart_agent_map")
+
     return value
 
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1180,9 +1180,7 @@ class AgentInstance(BaseDocument):
             await cls(tid=tid, process=process, name=nh).insert()
 
     @classmethod
-    async def log_instance_expiry(
-        cls, sid: uuid.UUID, endpoints: List[str], now: datetime.datetime
-    ) -> None:
+    async def log_instance_expiry(cls, sid: uuid.UUID, endpoints: List[str], now: datetime.datetime) -> None:
         """
             Expire specific instances for a given session id.
         """

--- a/src/inmanta/protocol/endpoints.py
+++ b/src/inmanta/protocol/endpoints.py
@@ -182,7 +182,7 @@ class SessionEndpoint(Endpoint, CallTarget):
         else:
             self._env_id = environment_id
 
-    async def do_start(self):
+    async def start_connected(self):
         """
             This method is called after starting the client transport, but before sending the first heartbeat.
         """
@@ -195,7 +195,7 @@ class SessionEndpoint(Endpoint, CallTarget):
         assert self._env_id is not None
         LOGGER.log(3, "Starting agent for %s", str(self.sessionid))
         self._client = SessionClient(self.name, self.sessionid, timeout=self.server_timeout)
-        await self.do_start()
+        await self.start_connected()
         self.add_background_task(self.perform_heartbeat())
 
     async def stop(self) -> None:

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -271,10 +271,8 @@ def all_agents_action(tid: uuid.UUID, action: AgentAction) -> None:
                         * unpause: A unpaused agent will be able to execute deploy operations.
     """
 
-# TODO: client type???
-# TODO: Put this in agent_action API call???
-# TODO: timeout???
-@typedmethod(path="/agentmap", api=False, server_agent=True, timeout=5, operation="POST", client_types=[], api_version=2)
+
+@typedmethod(path="/agentmap", api=False, server_agent=True, operation="POST", client_types=[], api_version=2)
 def update_agent_map(agent_map: Dict[str, str]) -> None:
     """
         Notify an agent about the fact that the autostart_agent_map has been updated.

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 import uuid
-from typing import List, Optional, Union, Dict
+from typing import Dict, List, Optional, Union
 
 from inmanta.const import AgentAction
 from inmanta.data import model

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 import uuid
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 
 from inmanta.const import AgentAction
 from inmanta.data import model
@@ -269,4 +269,15 @@ def all_agents_action(tid: uuid.UUID, action: AgentAction) -> None:
         :param action: The type of action that should be executed on the agents
                         * pause: A paused agent cannot execute any deploy operations.
                         * unpause: A unpaused agent will be able to execute deploy operations.
+    """
+
+# TODO: client type???
+# TODO: Put this in agent_action API call???
+# TODO: timeout???
+@typedmethod(path="/agentmap", api=False, server_agent=True, timeout=5, operation="POST", client_types=[], api_version=2)
+def update_agent_map(agent_map: Dict[str, str]) -> None:
+    """
+        Notify an agent about the fact that the autostart_agent_map has been updated.
+
+        :param agent_map: The content of the new autostart_agent_map
     """

--- a/src/inmanta/server/__init__.py
+++ b/src/inmanta/server/__init__.py
@@ -20,6 +20,7 @@
 
 SLICE_SERVER = "core.server"
 SLICE_AGENT_MANAGER = "core.agentmanager"
+SLICE_AUTOSTARTED_AGENT_MANAGER = "core.autostarted_agent_manager"
 SLICE_SESSION_MANAGER = "core.session"
 SLICE_DATABASE = "core.database"
 SLICE_TRANSPORT = "core.transport"

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -453,12 +453,12 @@ class AgentManager(ServerSlice, SessionListener):
     async def expire_all_sessions_for_environment(self, env_id: uuid.UUID) -> None:
         sessions: List[protocol.Session] = await self._get_environment_sessions(env_id)
         for session in sessions:
-            session.expire(0)
+            await session.expire(0)
             session.abort()
 
     async def expire_all_sessions(self) -> None:
         for session in self.sessions.values():
-            session.expire(0)
+            await session.expire(0)
             session.abort()
 
     # Agent Management

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -23,7 +23,7 @@ import time
 import uuid
 from asyncio import subprocess
 from datetime import datetime
-from typing import Dict, Iterable, List, Optional, Tuple, Set
+from typing import Dict, Iterable, List, Optional, Tuple
 from uuid import UUID
 
 from inmanta import const, data
@@ -153,9 +153,13 @@ class AgentManager(ServerSlice, SessionListener):
     async def _seen_session(self, session: protocol.Session) -> None:
         endpoints_with_new_primary = []
         async with self.session_lock:
-            endpoints_in_agent_manager = set([endpoint
-                                          for (tid, endpoint) in self.tid_endpoint_to_session.keys()
-                                          if self.tid_endpoint_to_session[(tid, endpoint)].id == session.id])
+            endpoints_in_agent_manager = set(
+                [
+                    endpoint
+                    for (tid, endpoint) in self.tid_endpoint_to_session.keys()
+                    if self.tid_endpoint_to_session[(tid, endpoint)].id == session.id
+                ]
+            )
             endpoints_in_session = set(session.endpoint_names)
             endpoints_to_add = list(endpoints_in_session - endpoints_in_agent_manager)
             endpoints_to_remove = list(endpoints_in_agent_manager - endpoints_in_session)
@@ -373,10 +377,7 @@ class AgentManager(ServerSlice, SessionListener):
         if env is not None:
             await self._log_primary_to_db(env, endpoints_with_new_primary, now)
 
-    async def _log_instance_creation_to_db(self,
-                                           session: protocol.Session,
-                                           endpoints: List[str],
-                                           now: datetime) -> None:
+    async def _log_instance_creation_to_db(self, session: protocol.Session, endpoints: List[str], now: datetime) -> None:
         """
             Note: This method call is allowed to fail when the database connection is lost.
         """

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -15,15 +15,15 @@
 
     Contact: code@inmanta.com
 """
-from enum import Enum
 import asyncio
 import logging
 import os
 import sys
 import time
 import uuid
-from asyncio import subprocess, queues
+from asyncio import queues, subprocess
 from datetime import datetime
+from enum import Enum
 from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
 from uuid import UUID
 
@@ -133,7 +133,7 @@ class AgentManager(ServerSlice, SessionListener):
 
         # This queue ensures that notifications from the SessionManager are processed in the same order
         # in which they arrive in the SessionManager, without blocking the SessionManager.
-        self._session_listener_actions = queues.Queue()
+        self._session_listener_actions: queues.Queue = queues.Queue()
 
         self.closesessionsonstart: bool = closesessionsonstart
 
@@ -227,7 +227,8 @@ class AgentManager(ServerSlice, SessionListener):
                     "An exception occurred while handling session action %s on session id %s.",
                     session_action.action_type.name,
                     session_action.session.id,
-                    exc_info=True)
+                    exc_info=True,
+                )
             finally:
                 try:
                     self._session_listener_actions.task_done()
@@ -255,7 +256,7 @@ class AgentManager(ServerSlice, SessionListener):
             action_type=SessionActionType.REGISTER_SESSION,
             session=session,
             endpoint_names_snapshot=endpoint_names_snapshot,
-            timestamp=datetime.now()
+            timestamp=datetime.now(),
         )
         await self._session_listener_actions.put(session_action)
 
@@ -270,7 +271,7 @@ class AgentManager(ServerSlice, SessionListener):
             action_type=SessionActionType.EXPIRE_SESSION,
             session=session,
             endpoint_names_snapshot=endpoint_names_snapshot,
-            timestamp=datetime.now()
+            timestamp=datetime.now(),
         )
         await self._session_listener_actions.put(session_action)
 
@@ -290,7 +291,7 @@ class AgentManager(ServerSlice, SessionListener):
             action_type=SessionActionType.SEEN_SESSION,
             session=session,
             endpoint_names_snapshot=endpoint_names_snapshot,
-            timestamp=datetime.now()
+            timestamp=datetime.now(),
         )
         await self._session_listener_actions.put(session_action)
 

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -219,9 +219,8 @@ class AgentManager(ServerSlice, SessionListener):
             try:
                 session_action = await self._session_listener_actions.get()
                 await self._process_action(session_action)
-            except asyncio.CancelledError as e:
-                # Cancel this task
-                raise e
+            except asyncio.CancelledError:
+                return
             except Exception:
                 LOGGER.exception(
                     "An exception occurred while handling session action %s on session id %s.",

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -529,7 +529,7 @@ class AgentManager(ServerSlice, SessionListener):
 
             # TODO: perhaps show in dashboard?
             return await asyncio.create_subprocess_exec(
-                sys.executable, *full_args, cwd=cwd, env=os.environ.copy(), stdout=sys.stdout, stderr=sys.stderr
+                sys.executable, *full_args, cwd=cwd, env=os.environ.copy(), stdout=outhandle, stderr=errhandle
             )
         finally:
             if outhandle is not None:
@@ -834,8 +834,6 @@ ssl=True
         else:
             # Internal agent is paused or down
             for session in self.sessions.values():
-                print(session.__dict__)
-                print(session.nodename)
                 if "internal" in session.endpoint_names:
                     self.add_background_task(session.get_client().update_agent_map(new_agent_map))
                     return

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -313,7 +313,7 @@ class AgentManager(ServerSlice, SessionListener):
         session: protocol.Session,
         endpoints_to_add: List[str],
         endpoints_to_remove: List[str],
-        endpoints_with_new_primary: Sequence[Tuple[str, uuid.UUID]]
+        endpoints_with_new_primary: List[Tuple[str, Optional[uuid.UUID]]],
     ) -> None:
         """
             Note: This method call is allowed to fail when the database connection is lost.

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -32,8 +32,14 @@ from inmanta.const import AgentAction, AgentStatus
 from inmanta.protocol import encode_token, methods, methods_v2
 from inmanta.protocol.exceptions import NotFound, ShutdownInProgress
 from inmanta.resources import Id
-from inmanta.server import SLICE_AGENT_MANAGER, SLICE_DATABASE, SLICE_SERVER, SLICE_SESSION_MANAGER, SLICE_TRANSPORT, \
-    SLICE_AUTOSTARTED_AGENT_MANAGER
+from inmanta.server import (
+    SLICE_AGENT_MANAGER,
+    SLICE_AUTOSTARTED_AGENT_MANAGER,
+    SLICE_DATABASE,
+    SLICE_SERVER,
+    SLICE_SESSION_MANAGER,
+    SLICE_TRANSPORT,
+)
 from inmanta.server import config as opt
 from inmanta.server import protocol
 from inmanta.server.protocol import ReturnClient, ServerSlice, SessionListener, SessionManager
@@ -80,7 +86,7 @@ set_parameters
 """
 
 
-class AgentManager(ServerSlice):
+class AgentManager(ServerSlice, SessionListener):
     """ This class contains all server functionality related to the management of agents
     """
 
@@ -668,7 +674,6 @@ class AgentManager(ServerSlice):
 
 
 class AutostartedAgentManager(ServerSlice):
-
     def __init__(self):
         super(AutostartedAgentManager, self).__init__(SLICE_AUTOSTARTED_AGENT_MANAGER)
         self._agent_procs: Dict[UUID, subprocess.Process] = {}  # env uuid -> subprocess.Process
@@ -677,7 +682,7 @@ class AutostartedAgentManager(ServerSlice):
     async def get_status(self) -> Dict[str, ArgumentTypes]:
         return {"processes": len(self._agent_procs)}
 
-    async def prestart(self, server: Server) -> None:
+    async def prestart(self, server: protocol.Server) -> None:
         await ServerSlice.prestart(self, server)
         preserver = server.get_slice(SLICE_SERVER)
         assert isinstance(preserver, Server)

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -23,7 +23,7 @@ import time
 import uuid
 from asyncio import subprocess
 from datetime import datetime
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Set
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
 from uuid import UUID
 
 from inmanta import const, data

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -96,7 +96,7 @@ class AgentManager(ServerSlice, SessionListener):
         if fact_back_off is None:
             fact_back_off = opt.server_fact_resource_block.get()
 
-            # back-off timer for fact requests
+         # back-off timer for fact requests
         self._fact_resource_block: int = fact_back_off
         # per resource time of last fact request
         self._fact_resource_block_set: Dict[str, float] = {}

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -23,7 +23,7 @@ import time
 import uuid
 from asyncio import subprocess
 from datetime import datetime
-from typing import Dict, Iterable, List, Optional, Tuple, Sequence
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 from uuid import UUID
 
 from inmanta import const, data
@@ -222,8 +222,9 @@ class AgentManager(ServerSlice, SessionListener):
                 result.append((endpoint, session))
         return result
 
-    async def _failover_endpoints(self, session: protocol.Session, endpoints: List[str]
-                                  ) -> Sequence[Tuple[str, Optional[protocol.Session]]]:
+    async def _failover_endpoints(
+        self, session: protocol.Session, endpoints: List[str]
+    ) -> Sequence[Tuple[str, Optional[protocol.Session]]]:
         """
             If the given session is the primary for a given endpoint, failover to a new session.
 

--- a/src/inmanta/server/protocol.py
+++ b/src/inmanta/server/protocol.py
@@ -343,6 +343,7 @@ class Session(object):
         tid: uuid.UUID,
         endpoint_names: List[str],
         nodename: str,
+        disable_expire_check: bool = False
     ) -> None:
         self._sid = sid
         self._interval = hang_interval
@@ -357,7 +358,10 @@ class Session(object):
         self.nodename: str = nodename
 
         self._replies: Dict[uuid.UUID, asyncio.Future] = {}
-        self.check_expire()
+
+        # Disable expiry in certain tests
+        if not disable_expire_check:
+            self.check_expire()
         self._queue: queues.Queue[common.Request] = queues.Queue()
 
         self.client = ReturnClient(str(sid), self)

--- a/src/inmanta/server/protocol.py
+++ b/src/inmanta/server/protocol.py
@@ -473,7 +473,6 @@ class Session(object):
 
 
 class SessionListener(object):
-
     async def new_session(self, session: Session, endpoint_names_snapshot: List[str]) -> None:
         """
         Notify that a new session was created.

--- a/src/inmanta/server/protocol.py
+++ b/src/inmanta/server/protocol.py
@@ -343,7 +343,7 @@ class Session(object):
         tid: uuid.UUID,
         endpoint_names: List[str],
         nodename: str,
-        disable_expire_check: bool = False
+        disable_expire_check: bool = False,
     ) -> None:
         self._sid = sid
         self._interval = hang_interval

--- a/src/inmanta/server/services/dryrunservice.py
+++ b/src/inmanta/server/services/dryrunservice.py
@@ -25,8 +25,15 @@ from inmanta.data.model import ResourceVersionIdStr
 from inmanta.protocol import methods
 from inmanta.protocol.exceptions import NotFound
 from inmanta.resources import Id
-from inmanta.server import SLICE_AUTOSTARTED_AGENT_MANAGER, SLICE_DATABASE, SLICE_DRYRUN, SLICE_TRANSPORT, protocol, SLICE_AGENT_MANAGER
-from inmanta.server.agentmanager import AutostartedAgentManager, AgentManager
+from inmanta.server import (
+    SLICE_AGENT_MANAGER,
+    SLICE_AUTOSTARTED_AGENT_MANAGER,
+    SLICE_DATABASE,
+    SLICE_DRYRUN,
+    SLICE_TRANSPORT,
+    protocol,
+)
+from inmanta.server.agentmanager import AgentManager, AutostartedAgentManager
 from inmanta.types import Apireturn, JsonType
 
 LOGGER = logging.getLogger(__name__)

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -90,8 +90,12 @@ class EnvironmentService(protocol.ServerSlice):
             warnings = await self.server_slice._async_recompile(env, setting.update, metadata=metadata.dict())
 
         if setting.agent_restart:
-            LOGGER.info("Environment setting %s changed. Restarting agents.", key)
-            self.add_background_task(self.agentmanager.restart_agents(env))
+            if key == data.AUTOSTART_AGENT_MAP:
+                LOGGER.info("Environment setting %s changed. Notifying agents.", key)
+                self.add_background_task(self.agentmanager.notify_agent_about_agent_map_update(env))
+            else:
+                LOGGER.info("Environment setting %s changed. Restarting agents.", key)
+                self.add_background_task(self.agentmanager.restart_agents(env))
 
         return warnings
 

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -30,13 +30,13 @@ from inmanta.protocol import encode_token, methods, methods_v2
 from inmanta.protocol.common import ReturnValue, attach_warnings
 from inmanta.protocol.exceptions import BadRequest, NotFound, ServerError
 from inmanta.server import (
+    SLICE_AUTOSTARTED_AGENT_MANAGER,
     SLICE_DATABASE,
     SLICE_ENVIRONMENT,
     SLICE_ORCHESTRATION,
     SLICE_RESOURCE,
     SLICE_SERVER,
     SLICE_TRANSPORT,
-    SLICE_AUTOSTARTED_AGENT_MANAGER,
     protocol,
 )
 from inmanta.server.agentmanager import AutostartedAgentManager

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -177,8 +177,8 @@ class EnvironmentService(protocol.ServerSlice):
             return attach_warnings(200, None, warnings)
         except KeyError:
             raise NotFound()
-        except ValueError:
-            raise ServerError("Invalid value")
+        except ValueError as e:
+            raise ServerError(f"Invalid value. {e}")
 
     @protocol.handle(methods.get_setting, env="tid", key="id")
     async def get_setting(self, env: data.Environment, key: str) -> Apireturn:

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -31,7 +31,14 @@ from inmanta.protocol import methods, methods_v2
 from inmanta.protocol.common import attach_warnings
 from inmanta.protocol.exceptions import BadRequest, ServerError
 from inmanta.resources import Id
-from inmanta.server import SLICE_AGENT_MANAGER, SLICE_DATABASE, SLICE_ORCHESTRATION, SLICE_RESOURCE, SLICE_TRANSPORT, SLICE_AUTOSTARTED_AGENT_MANAGER
+from inmanta.server import (
+    SLICE_AGENT_MANAGER,
+    SLICE_AUTOSTARTED_AGENT_MANAGER,
+    SLICE_DATABASE,
+    SLICE_ORCHESTRATION,
+    SLICE_RESOURCE,
+    SLICE_TRANSPORT,
+)
 from inmanta.server import config as opt
 from inmanta.server import protocol
 from inmanta.server.agentmanager import AgentManager, AutostartedAgentManager

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -31,10 +31,10 @@ from inmanta.protocol import methods, methods_v2
 from inmanta.protocol.common import attach_warnings
 from inmanta.protocol.exceptions import BadRequest, ServerError
 from inmanta.resources import Id
-from inmanta.server import SLICE_AGENT_MANAGER, SLICE_DATABASE, SLICE_ORCHESTRATION, SLICE_RESOURCE, SLICE_TRANSPORT
+from inmanta.server import SLICE_AGENT_MANAGER, SLICE_DATABASE, SLICE_ORCHESTRATION, SLICE_RESOURCE, SLICE_TRANSPORT, SLICE_AUTOSTARTED_AGENT_MANAGER
 from inmanta.server import config as opt
 from inmanta.server import protocol
-from inmanta.server.agentmanager import AgentManager
+from inmanta.server.agentmanager import AgentManager, AutostartedAgentManager
 from inmanta.server.services.resourceservice import ResourceService
 from inmanta.types import Apireturn, JsonType, PrimitiveTypes
 
@@ -45,6 +45,7 @@ class OrchestrationService(protocol.ServerSlice):
     """Resource Manager service"""
 
     agentmanager_service: "AgentManager"
+    autostarted_agent_manager: AutostartedAgentManager
     resource_service: ResourceService
 
     def __init__(self) -> None:
@@ -59,6 +60,7 @@ class OrchestrationService(protocol.ServerSlice):
     async def prestart(self, server: protocol.Server) -> None:
         await super().prestart(server)
         self.agentmanager_service = cast("AgentManager", server.get_slice(SLICE_AGENT_MANAGER))
+        self.autostarted_agent_manager = cast(AutostartedAgentManager, server.get_slice(SLICE_AUTOSTARTED_AGENT_MANAGER))
         self.resource_service = cast(ResourceService, server.get_slice(SLICE_RESOURCE))
 
     async def start(self) -> None:
@@ -430,7 +432,7 @@ class OrchestrationService(protocol.ServerSlice):
         if push:
             # fetch all resource in this cm and create a list of distinct agents
             agents = await data.ConfigurationModel.get_agents(env.id, version_id)
-            await self.agentmanager_service._ensure_agents(env, agents)
+            await self.autostarted_agent_manager._ensure_agents(env, agents)
 
             for agent in agents:
                 client = self.agentmanager_service.get_agent_client(env.id, agent)
@@ -478,7 +480,7 @@ class OrchestrationService(protocol.ServerSlice):
         present = set()
         absent = set()
 
-        await self.agentmanager_service._ensure_agents(env, allagents)
+        await self.autostarted_agent_manager._ensure_agents(env, allagents)
 
         for agent in allagents:
             client = self.agentmanager_service.get_agent_client(env.id, agent)

--- a/src/inmanta/server/services/projectservice.py
+++ b/src/inmanta/server/services/projectservice.py
@@ -26,8 +26,8 @@ from inmanta import data
 from inmanta.data import model
 from inmanta.protocol import methods, methods_v2
 from inmanta.protocol.exceptions import NotFound, ServerError
-from inmanta.server import SLICE_AGENT_MANAGER, SLICE_DATABASE, SLICE_PROJECT, SLICE_RESOURCE, SLICE_TRANSPORT, protocol
-from inmanta.server.agentmanager import AgentManager
+from inmanta.server import SLICE_AUTOSTARTED_AGENT_MANAGER, SLICE_DATABASE, SLICE_PROJECT, SLICE_RESOURCE, SLICE_TRANSPORT, protocol
+from inmanta.server.agentmanager import AutostartedAgentManager
 from inmanta.server.services.resourceservice import ResourceService
 from inmanta.types import Apireturn, JsonType
 
@@ -37,21 +37,21 @@ LOGGER = logging.getLogger(__name__)
 class ProjectService(protocol.ServerSlice):
     """Slice with project and environment management"""
 
-    agentmanager: AgentManager
+    autostarted_agent_manager: AutostartedAgentManager
     resource_service: ResourceService
 
     def __init__(self) -> None:
         super(ProjectService, self).__init__(SLICE_PROJECT)
 
     def get_dependencies(self) -> List[str]:
-        return [SLICE_DATABASE, SLICE_RESOURCE, SLICE_AGENT_MANAGER]
+        return [SLICE_DATABASE, SLICE_RESOURCE, SLICE_AUTOSTARTED_AGENT_MANAGER]
 
     def get_depended_by(self) -> List[str]:
         return [SLICE_TRANSPORT]
 
     async def prestart(self, server: protocol.Server) -> None:
         await super().prestart(server)
-        self.agentmanager = cast(AgentManager, server.get_slice(SLICE_AGENT_MANAGER))
+        self.autostarted_agent_manager = cast(AutostartedAgentManager, server.get_slice(SLICE_AUTOSTARTED_AGENT_MANAGER))
         self.resource_service = cast(ResourceService, server.get_slice(SLICE_RESOURCE))
 
     # v1 handlers
@@ -103,7 +103,7 @@ class ProjectService(protocol.ServerSlice):
 
         environments = await data.Environment.get_list(project=project.id)
         for env in environments:
-            await asyncio.gather(self.agentmanager.stop_agents(env), env.delete_cascade())
+            await asyncio.gather(self.autostarted_agent_manager.stop_agents(env), env.delete_cascade())
             self.resource_service.close_resource_action_logger(env.id)
 
         await project.delete()

--- a/src/inmanta/server/services/projectservice.py
+++ b/src/inmanta/server/services/projectservice.py
@@ -26,7 +26,14 @@ from inmanta import data
 from inmanta.data import model
 from inmanta.protocol import methods, methods_v2
 from inmanta.protocol.exceptions import NotFound, ServerError
-from inmanta.server import SLICE_AUTOSTARTED_AGENT_MANAGER, SLICE_DATABASE, SLICE_PROJECT, SLICE_RESOURCE, SLICE_TRANSPORT, protocol
+from inmanta.server import (
+    SLICE_AUTOSTARTED_AGENT_MANAGER,
+    SLICE_DATABASE,
+    SLICE_PROJECT,
+    SLICE_RESOURCE,
+    SLICE_TRANSPORT,
+    protocol,
+)
 from inmanta.server.agentmanager import AutostartedAgentManager
 from inmanta.server.services.resourceservice import ResourceService
 from inmanta.types import Apireturn, JsonType

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -16,8 +16,8 @@
     Contact: code@inmanta.com
 """
 
-import datetime
 import asyncio
+import datetime
 import enum
 import functools
 import hashlib

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -17,6 +17,7 @@
 """
 
 import datetime
+import asyncio
 import enum
 import functools
 import hashlib
@@ -246,6 +247,8 @@ async def retry_limited(fun: Callable[[], bool], timeout: float, interval: float
     start = time.time()
     while time.time() - start < timeout and not fun():
         await sleep(interval)
+    if not fun():
+        raise asyncio.TimeoutError()
 
 
 class StoppedException(Exception):

--- a/src/inmanta_ext/core/extension.py
+++ b/src/inmanta_ext/core/extension.py
@@ -36,6 +36,7 @@ from inmanta.server.services import (
 def setup(application: ApplicationContext) -> None:
     application.register_slice(server.Server())
     application.register_slice(agentmanager.AgentManager())
+    application.register_slice(agentmanager.AutostartedAgentManager())
     application.register_slice(databaseservice.DatabaseService())
     application.register_slice(compilerservice.CompilerService())
     application.register_slice(projectservice.ProjectService())

--- a/tests/agent_server/conftest.py
+++ b/tests/agent_server/conftest.py
@@ -42,7 +42,7 @@ async def get_agent(server, environment, *endpoints, hostname="nodes1"):
         hostname=hostname, environment=environment, agent_map={agent: "localhost" for agent in endpoints}, code_loader=False
     )
     for agentname in endpoints:
-        agent.add_end_point_name(agentname)
+        await agent.add_end_point_name(agentname)
     await agent.start()
     await retry_limited(lambda: len(agentmanager.sessions) == prelen + 1, 10)
     return agent

--- a/tests/agent_server/test_dryrun.py
+++ b/tests/agent_server/test_dryrun.py
@@ -42,7 +42,7 @@ async def test_dryrun_and_deploy(server, client, resource_container, environment
     agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
 
     agent = Agent(hostname="node1", environment=environment, agent_map={"agent1": "localhost"}, code_loader=False)
-    agent.add_end_point_name("agent1")
+    await agent.add_end_point_name("agent1")
     await agent.start()
 
     await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)

--- a/tests/agent_server/test_send_events.py
+++ b/tests/agent_server/test_send_events.py
@@ -97,13 +97,13 @@ async def test_send_events_cross_agent(resource_container, environment, server, 
     resource_container.Provider.reset()
     agent = Agent(hostname="node1", environment=environment, agent_map={"agent1": "localhost"}, code_loader=False)
     async_finalizer.add(agent.stop)
-    agent.add_end_point_name("agent1")
+    await agent.add_end_point_name("agent1")
     await agent.start()
     await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 
     agent2 = Agent(hostname="node2", environment=environment, agent_map={"agent2": "localhost"}, code_loader=False)
     async_finalizer.add(agent2.stop)
-    agent2.add_end_point_name("agent2")
+    await agent2.add_end_point_name("agent2")
     await agent2.start()
     await retry_limited(lambda: len(agentmanager.sessions) == 2, 10)
 
@@ -172,13 +172,13 @@ async def test_send_events_cross_agent_deploying(
     resource_container.Provider.reset()
     agent = Agent(hostname="node1", environment=environment, agent_map={"agent1": "localhost"}, code_loader=False)
     async_finalizer.add(agent.stop)
-    agent.add_end_point_name("agent1")
+    await agent.add_end_point_name("agent1")
     await agent.start()
     await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 
     agent2 = Agent(hostname="node2", environment=environment, agent_map={"agent2": "localhost"}, code_loader=False)
     async_finalizer.add(agent2.stop)
-    agent2.add_end_point_name("agent2")
+    await agent2.add_end_point_name("agent2")
     await agent2.start()
     await retry_limited(lambda: len(agentmanager.sessions) == 2, 10)
 
@@ -249,7 +249,7 @@ async def test_send_events_cross_agent_restart(
 
     agent2 = Agent(hostname="node2", environment=environment, agent_map={"agent2": "localhost"}, code_loader=False)
     async_finalizer.add(agent2.stop)
-    agent2.add_end_point_name("agent2")
+    await agent2.add_end_point_name("agent2")
     await agent2.start()
     await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 
@@ -294,7 +294,7 @@ async def test_send_events_cross_agent_restart(
     # start agent 1 and wait for it to finish
     agent = Agent(hostname="node1", environment=environment, agent_map={"agent1": "localhost"}, code_loader=False)
     async_finalizer.add(agent.stop)
-    agent.add_end_point_name("agent1")
+    await agent.add_end_point_name("agent1")
     await agent.start()
     await retry_limited(lambda: len(agentmanager.sessions) == 2, 10)
 
@@ -326,13 +326,13 @@ async def test_send_events_cross_agent_fail(resource_container, environment, ser
     resource_container.Provider.reset()
     agent = Agent(hostname="node1", environment=environment, agent_map={"agent1": "localhost"}, code_loader=False)
     async_finalizer.add(agent.stop)
-    agent.add_end_point_name("agent1")
+    await agent.add_end_point_name("agent1")
     await agent.start()
     await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 
     agent2 = Agent(hostname="node2", environment=environment, agent_map={"agent2": "localhost"}, code_loader=False)
     async_finalizer.add(agent2.stop)
-    agent2.add_end_point_name("agent2")
+    await agent2.add_end_point_name("agent2")
     await agent2.start()
     await retry_limited(lambda: len(agentmanager.sessions) == 2, 10)
 

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -33,7 +33,7 @@ from inmanta.agent.agent import Agent
 from inmanta.ast import CompilerException
 from inmanta.config import Config
 from inmanta.const import AgentStatus
-from inmanta.server import SLICE_AGENT_MANAGER, SLICE_PARAM, SLICE_SESSION_MANAGER, SLICE_AUTOSTARTED_AGENT_MANAGER
+from inmanta.server import SLICE_AGENT_MANAGER, SLICE_AUTOSTARTED_AGENT_MANAGER, SLICE_PARAM, SLICE_SESSION_MANAGER
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.util import get_compiler_version
 from utils import (

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -33,7 +33,7 @@ from inmanta.agent.agent import Agent
 from inmanta.ast import CompilerException
 from inmanta.config import Config
 from inmanta.const import AgentStatus
-from inmanta.server import SLICE_AGENT_MANAGER, SLICE_PARAM, SLICE_SESSION_MANAGER
+from inmanta.server import SLICE_AGENT_MANAGER, SLICE_PARAM, SLICE_SESSION_MANAGER, SLICE_AUTOSTARTED_AGENT_MANAGER
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.util import get_compiler_version
 from utils import (
@@ -3204,6 +3204,7 @@ async def test_deploy_no_code(resource_container, client, clienthelper, environm
 @pytest.mark.asyncio
 async def test_issue_1662(resource_container, server, client, clienthelper, environment, monkeypatch, request):
     agent_manager = server.get_slice(SLICE_AGENT_MANAGER)
+    autostarted_agent_manager = server.get_slice(SLICE_AUTOSTARTED_AGENT_MANAGER)
 
     config.Config.set("config", "agent-deploy-interval", "0")
     config.Config.set("config", "agent-repair-interval", "0")
@@ -3224,7 +3225,7 @@ async def test_issue_1662(resource_container, server, client, clienthelper, envi
         # Run off main thread
         await asyncio.get_event_loop().run_in_executor(None, stop_agents_thread_pools)
 
-    monkeypatch.setattr(agent_manager, "restart_agents", restart_agents_patch)
+    monkeypatch.setattr(autostarted_agent_manager, "restart_agents", restart_agents_patch)
 
     version = await clienthelper.get_version()
     resource_id = f"test::AgentConfig[agent1,agentname=agent2],v={version}"

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -26,13 +26,13 @@ import psutil
 import pytest
 from psutil import NoSuchProcess, Process
 
-from inmanta.const import AgentStatus
 from agent_server.conftest import ResourceContainer, _deploy_resources, get_agent
 from inmanta import agent, config, const, data, execute
-from inmanta.agent.agent import Agent
 from inmanta.agent import config as agent_config
+from inmanta.agent.agent import Agent
 from inmanta.ast import CompilerException
 from inmanta.config import Config
+from inmanta.const import AgentStatus
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_PARAM, SLICE_SESSION_MANAGER
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.util import get_compiler_version
@@ -1443,6 +1443,7 @@ async def test_autostart_mapping(server, client, clienthelper, resource_containe
             result = await client.list_agents(tid=environment)
             assert result.code == 200
             return len([x for x in result.result["agents"] if x["state"] == "up"]) == nr_agents
+
         return _check_wait_condition
 
     async def assert_session_state(expected_agent_states: Dict[str, AgentStatus], expected_agent_instances: List[str]) -> None:
@@ -1463,7 +1464,7 @@ async def test_autostart_mapping(server, client, clienthelper, resource_containe
             if agent_name not in expected_agent_instances:
                 assert agent_name not in agents
             elif state == AgentStatus.down:
-                assert (agents[agent_name].expired is not None)
+                assert agents[agent_name].expired is not None
             else:
                 assert agents[agent_name].expired is None
 

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -1386,15 +1386,13 @@ def ps_diff(original, current_process, diff=0):
 
 
 @pytest.mark.asyncio(timeout=15)
-async def test_autostart_mapping(server, client, clienthelper, resource_container, environment, no_agent_backoff, caplog):
+async def test_autostart_mapping(server, client, clienthelper, resource_container, environment, no_agent_backoff):
     """
         Test whether an autostarted agent updates its agent-map correctly when the autostart_agent_map is updated on the server.
 
         The handler code in the resource_container is not available to the autostarted agent. When the agent loads these
         resources it will mark them as unavailable. There is only one agent started when deploying is checked.
     """
-    caplog.set_level(logging.DEBUG)
-
     env_uuid = uuid.UUID(environment)
     agent_manager = server.get_slice(SLICE_AGENT_MANAGER)
     current_process = psutil.Process()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -403,11 +403,7 @@ async def agent_factory(server):
         return a
 
     yield create_agent
-    gather_future = asyncio.gather(*[agent.stop() for agent in started_agents], return_exceptions=True)
-    stop_agents_result = await asyncio.wait_for(gather_future, timeout=30)
-    for elem in stop_agents_result:
-        if isinstance(elem, Exception):
-            raise elem
+    await asyncio.gather(*[agent.stop() for agent in started_agents])
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ import time
 import traceback
 import uuid
 from tempfile import mktemp
-from typing import Dict, Optional, List
+from typing import Dict, List, Optional
 
 import asyncpg
 import pkg_resources
@@ -392,7 +392,7 @@ async def agent_factory(server):
         hostname: Optional[str] = None,
         agent_map: Optional[Dict[str, str]] = None,
         code_loader: bool = False,
-        agent_names: List[str] = []
+        agent_names: List[str] = [],
     ) -> None:
         a = Agent(hostname=hostname, environment=environment, agent_map=agent_map, code_loader=code_loader)
         for agent_name in agent_names:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -383,7 +383,7 @@ async def autostarted_agent(server, environment):
     """ Configure agent1 as an autostarted agent.
     """
     env = await data.Environment.get_by_id(uuid.UUID(environment))
-    await env.set(data.AUTOSTART_AGENT_MAP, {"agent1": ""})
+    await env.set(data.AUTOSTART_AGENT_MAP, {"internal": "", "agent1": ""})
     await env.set(data.AUTO_DEPLOY, True)
     await env.set(data.PUSH_ON_AUTO_DEPLOY, True)
     await env.set(data.AUTOSTART_AGENT_DEPLOY_SPLAY_TIME, 0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -353,7 +353,7 @@ async def agent_multi(server_multi, environment_multi):
     config.Config.set("config", "agent-deploy-interval", "0")
     config.Config.set("config", "agent-repair-interval", "0")
     a = Agent(hostname="node1", environment=environment_multi, agent_map={"agent1": "localhost"}, code_loader=False)
-    a.add_end_point_name("agent1")
+    await a.add_end_point_name("agent1")
     await a.start()
     await utils.retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 
@@ -369,7 +369,7 @@ async def agent(server, environment):
     config.Config.set("config", "agent-deploy-interval", "0")
     config.Config.set("config", "agent-repair-interval", "0")
     a = Agent(hostname="node1", environment=environment, agent_map={"agent1": "localhost"}, code_loader=False)
-    a.add_end_point_name("agent1")
+    await a.add_end_point_name("agent1")
     await a.start()
     await utils.retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 

--- a/tests/db/test_v2_to_v3.py
+++ b/tests/db/test_v2_to_v3.py
@@ -36,7 +36,8 @@ async def migrate_v2_to_v3(hard_clean_db, hard_clean_db_post, postgresql_client:
     ibl = InmantaBootloader()
 
     await ibl.start()
-    async_finalizer(ibl.stop)
+    yield
+    await ibl.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/db/test_v3_to_v4.py
+++ b/tests/db/test_v3_to_v4.py
@@ -46,9 +46,8 @@ async def migrate_v3_to_v4(hard_clean_db, hard_clean_db_post, postgresql_client:
 
     # When the bootloader is started, it also executes the migration to v4
     await ibl.start()
-    async_finalizer(ibl.stop)
-
     yield resource_version_id_dict
+    await ibl.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_env_settings.py
+++ b/tests/server/test_env_settings.py
@@ -91,8 +91,8 @@ async def test_environment_settings(client, server, environment_default):
 
     # Internal agent is missing
     result = await client.set_setting(tid=environment_default, id=data.AUTOSTART_AGENT_MAP, value={"agent1": ""})
-    assert "The internal agent must be present in the autostart_agent_map" in result.result["message"]
     assert result.code == 500
+    assert "The internal agent must be present in the autostart_agent_map" in result.result["message"]
     # Assert agent_map didn't change
     result = await client.get_setting(tid=environment_default, id=data.AUTOSTART_AGENT_MAP)
     assert result.code == 200

--- a/tests/server/test_env_settings.py
+++ b/tests/server/test_env_settings.py
@@ -85,15 +85,30 @@ async def test_environment_settings(client, server, environment_default):
     result = await client.delete_setting(tid=environment_default, id=data.AUTOSTART_AGENT_DEPLOY_SPLAY_TIME)
     assert result.code == 200
 
+    agent_map = {"internal": "", "agent1": "", "agent2": "localhost", "agent3": "user@agent3"}
     result = await client.set_setting(
         tid=environment_default,
         id=data.AUTOSTART_AGENT_MAP,
-        value={"agent1": "", "agent2": "localhost", "agent3": "user@agent3"},
+        value=agent_map,
     )
     assert result.code == 200
 
+    # Internal agent is missing
+    result = await client.set_setting(tid=environment_default, id=data.AUTOSTART_AGENT_MAP, value={"agent1": ""})
+    assert "The internal agent must be present in the autostart_agent_map" in result.result["message"]
+    assert result.code == 500
+    # Assert agent_map didn't change
+    result = await client.get_setting(tid=environment_default, id=data.AUTOSTART_AGENT_MAP)
+    assert result.code == 200
+    assert result.result["value"] == agent_map
+
     result = await client.set_setting(tid=environment_default, id=data.AUTOSTART_AGENT_MAP, value="")
     assert result.code == 500
+    assert "Agent map should be a dict" in result.result["message"]
+    # Assert agent_map didn't change
+    result = await client.get_setting(tid=environment_default, id=data.AUTOSTART_AGENT_MAP)
+    assert result.code == 200
+    assert result.result["value"] == agent_map
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_env_settings.py
+++ b/tests/server/test_env_settings.py
@@ -86,11 +86,7 @@ async def test_environment_settings(client, server, environment_default):
     assert result.code == 200
 
     agent_map = {"internal": "", "agent1": "", "agent2": "localhost", "agent3": "user@agent3"}
-    result = await client.set_setting(
-        tid=environment_default,
-        id=data.AUTOSTART_AGENT_MAP,
-        value=agent_map,
-    )
+    result = await client.set_setting(tid=environment_default, id=data.AUTOSTART_AGENT_MAP, value=agent_map,)
     assert result.code == 200
 
     # Internal agent is missing

--- a/tests/server/test_incremental_deploy.py
+++ b/tests/server/test_incremental_deploy.py
@@ -130,7 +130,7 @@ class MultiVersionSetup(object):
 
         a = Agent(hostname="node1", environment=environment, agent_map={e: "localhost" for e in endpoints}, code_loader=False)
         for e in endpoints:
-            a.add_end_point_name(e)
+            await a.add_end_point_name(e)
         await a.start()
         await utils.retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 

--- a/tests/test_2way_protocol.py
+++ b/tests/test_2way_protocol.py
@@ -22,6 +22,7 @@ import uuid
 import pytest
 from pytest import fixture
 from tornado.gen import sleep
+from typing import List
 
 # Methods need to be defined before the Client class is loaded by Python
 from inmanta import protocol  # NOQA
@@ -51,7 +52,7 @@ class SessionSpy(SessionListener, ServerSlice):
         self.expires = 0
         self.__sessions = []
 
-    async def new_session(self, session):
+    async def new_session(self, session, endpoint_names_snapshot: List[str]):
         self.__sessions.append(session)
 
     @protocol.handle(get_status_x)
@@ -65,7 +66,7 @@ class SessionSpy(SessionListener, ServerSlice):
 
         return 200, {"agents": status_list}
 
-    def expire(self, session, timeout):
+    async def expire(self, session, endpoint_names_snapshot: List[str]):
         self.__sessions.remove(session)
         print(session._sid)
         self.expires += 1

--- a/tests/test_2way_protocol.py
+++ b/tests/test_2way_protocol.py
@@ -18,11 +18,11 @@
 
 import logging
 import uuid
+from typing import List
 
 import pytest
 from pytest import fixture
 from tornado.gen import sleep
-from typing import List
 
 # Methods need to be defined before the Client class is loaded by Python
 from inmanta import protocol  # NOQA

--- a/tests/test_2way_protocol.py
+++ b/tests/test_2way_protocol.py
@@ -115,7 +115,7 @@ async def test_2way_protocol(unused_tcp_port, no_tid_check, postgres_db, databas
     await rs.start()
 
     agent = Agent("agent")
-    agent.add_end_point_name("agent")
+    await agent.add_end_point_name("agent")
     agent.set_environment(uuid.uuid4())
     await agent.start()
 
@@ -160,7 +160,7 @@ async def test_agent_timeout(unused_tcp_port, no_tid_check, async_finalizer, pos
 
     # agent 1
     agent = Agent("agent")
-    agent.add_end_point_name("agent")
+    await agent.add_end_point_name("agent")
     agent.set_environment(env)
     await agent.start()
     async_finalizer(agent.stop)
@@ -171,7 +171,7 @@ async def test_agent_timeout(unused_tcp_port, no_tid_check, async_finalizer, pos
 
     # agent 2
     agent2 = Agent("agent")
-    agent2.add_end_point_name("agent")
+    await agent2.add_end_point_name("agent")
     agent2.set_environment(env)
     await agent2.start()
     async_finalizer(agent2.stop)
@@ -218,7 +218,7 @@ async def test_server_timeout(unused_tcp_port, no_tid_check, async_finalizer, po
 
     # agent 1
     agent = Agent("agent")
-    agent.add_end_point_name("agent")
+    await agent.add_end_point_name("agent")
     agent.set_environment(env)
     await agent.start()
     async_finalizer(agent.stop)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -20,7 +20,6 @@ import asyncio
 import concurrent
 import logging
 import uuid
-import json
 
 import pytest
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -16,23 +16,24 @@
     Contact: code@inmanta.com
 """
 
-import pytest
-import uuid
 import asyncio
-import logging
 import concurrent
+import logging
+import uuid
+
+import pytest
 
 from inmanta import config, protocol
-from inmanta.agent import reporting, Agent
+from inmanta.agent import Agent, reporting
 from inmanta.agent.handler import HandlerContext, InvalidOperation
 from inmanta.data.model import AttributeStateChange
 from inmanta.resources import Id, PurgeableResource
-from inmanta.server import SLICE_SESSION_MANAGER, SLICE_AGENT_MANAGER
+from inmanta.server import SLICE_AGENT_MANAGER, SLICE_SESSION_MANAGER
 from inmanta.server.bootloader import InmantaBootloader
 from utils import retry_limited
 
-
 logger = logging.getLogger(__name__)
+
 
 @pytest.mark.slowtest
 @pytest.mark.asyncio

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -15,10 +15,11 @@
 
     Contact: code@inmanta.com
 """
-import pytest
 import os
-import uuid
 import subprocess
+import uuid
+
+import pytest
 
 from inmanta.agent import reporting
 from inmanta.agent.handler import HandlerContext, InvalidOperation
@@ -85,7 +86,8 @@ async def test_agent_cannot_retrieve_autostart_agent_map(unused_tcp_port_factory
     free_port = unused_tcp_port_factory()
     config_file = tmpdir.join("inmanta.cfg")
     with open(config_file, "w") as f:
-        f.write(f"""[config]
+        f.write(
+            f"""[config]
 state-dir={state_dir}
 environment={uuid.uuid4()}
 use_autostart_agent_map=true
@@ -93,11 +95,10 @@ use_autostart_agent_map=true
 [agent_rest_transport]
 port={free_port}
 host=127.0.0.1
-        """)
-    try:
-        completed_process = subprocess.run(
-            ["inmanta", "-vvv", "-c", config_file, "agent"], stdout=subprocess.PIPE, timeout=10
+        """
         )
+    try:
+        completed_process = subprocess.run(["inmanta", "-vvv", "-c", config_file, "agent"], stdout=subprocess.PIPE, timeout=10)
         assert completed_process.returncode == 1
         assert "Failed to retrieve the autostart_agent_map setting from the server" in completed_process.stdout.decode()
     except subprocess.TimeoutExpired as e:

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -470,7 +470,14 @@ async def test_session_renewal(init_dataclasses_and_load_schema):
     tid = env.id
     endpoint = "vm1"
     session = Session(
-        sessionstore=session_manager, sid=sid, hang_interval=1, timout=1, tid=tid, endpoint_names=[endpoint], nodename="test", disable_expire_check=True
+        sessionstore=session_manager,
+        sid=sid,
+        hang_interval=1,
+        timout=1,
+        tid=tid,
+        endpoint_names=[endpoint],
+        nodename="test",
+        disable_expire_check=True,
     )
 
     await assert_agent_db_state(tid, nr_procs=0, nr_non_expired_procs=0, nr_agent_instances=0, nr_non_expired_instances=0)
@@ -504,8 +511,14 @@ async def test_fix_corrupted_database(init_dataclasses_and_load_schema):
     tid = env.id
     endpoint = "vm1"
     session = Session(
-        sessionstore=session_manager, sid=sid, hang_interval=1, timout=1, tid=tid, endpoint_names=[endpoint],
-        nodename="node1", disable_expire_check=True
+        sessionstore=session_manager,
+        sid=sid,
+        hang_interval=1,
+        timout=1,
+        tid=tid,
+        endpoint_names=[endpoint],
+        nodename="node1",
+        disable_expire_check=True,
     )
 
     await assert_agent_db_state(tid, nr_procs=0, nr_non_expired_procs=0, nr_agent_instances=0, nr_non_expired_instances=0)

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -29,7 +29,7 @@ from inmanta.agent import Agent, agent
 from inmanta.const import AgentAction, AgentStatus
 from inmanta.protocol import Result
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_AUTOSTARTED_AGENT_MANAGER
-from inmanta.server.agentmanager import AgentManager, SessionManager, SessionAction
+from inmanta.server.agentmanager import AgentManager, SessionAction, SessionManager
 from inmanta.server.protocol import Session
 from utils import UNKWN, assert_equal_ish, retry_limited
 
@@ -125,6 +125,7 @@ def assert_state_agents_retry(
         except AssertionError:
             return False
         return True
+
     return func
 
 
@@ -576,7 +577,9 @@ async def test_fix_corrupted_database(init_dataclasses_and_load_schema):
     await assert_agent_db_state(tid, nr_procs=1, nr_non_expired_procs=0, nr_agent_instances=2, nr_non_expired_instances=1)
 
     # Session registration should fix the inconsistency
-    await agent_manager._register_session(session=session, endpoint_names_snapshot=session.endpoint_names, now=datetime.datetime.now())
+    await agent_manager._register_session(
+        session=session, endpoint_names_snapshot=session.endpoint_names, now=datetime.datetime.now()
+    )
     await assert_agent_db_state(tid, nr_procs=1, nr_non_expired_procs=1, nr_agent_instances=3, nr_non_expired_instances=1)
     instance_one_after_fix = await data.AgentInstance.get_by_id(instance_one.id)
     assert instance_one_after_fix.expired is not None

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -140,7 +140,7 @@ async def test_primary_selection(init_dataclasses_and_load_schema):
     assert not am.is_primary(env, uuid4(), "agent2")
 
     # alive
-    am.seen(ts1, ["agent1", "agent2"])
+    am.seen(ts1)
     await futures.proccess()
     assert len(am.sessions) == 1
     await assert_agents(env.id, AgentStatus.paused, AgentStatus.up, AgentStatus.down, sid2=ts1.id)
@@ -355,7 +355,7 @@ async def test_expire_all_sessions_in_db(init_dataclasses_and_load_schema):
     await assert_agents(env.id, AgentStatus.paused, AgentStatus.up, AgentStatus.down, sid2=ts1.id)
 
     # alive
-    am.seen(ts1, ["agent1", "agent2"])
+    am.seen(ts1)
     await futures.proccess()
     assert len(am.sessions) == 1
     await assert_agents(env.id, AgentStatus.paused, AgentStatus.up, AgentStatus.down, sid2=ts1.id)
@@ -393,7 +393,7 @@ async def test_expire_all_sessions_in_db(init_dataclasses_and_load_schema):
     await assert_agents(env.id, AgentStatus.paused, AgentStatus.up, AgentStatus.down, sid2=ts1.id)
 
     # alive
-    am.seen(ts1, ["agent1", "agent2"])
+    am.seen(ts1)
     await futures.proccess()
     assert len(am.sessions) == 1
     await assert_agents(env.id, AgentStatus.paused, AgentStatus.up, AgentStatus.down, sid2=ts1.id)
@@ -539,7 +539,7 @@ async def test_session_creation_fails(server, environment, caplog):
     env_id = UUID(environment)
     agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
     a = Agent(hostname="node1", environment=environment, agent_map={"agent1": "localhost"}, code_loader=False)
-    a.add_end_point_name("agent1")
+    await a.add_end_point_name("agent1")
     await a.start()
 
     # Wait until session is created
@@ -570,7 +570,7 @@ async def test_session_creation_fails(server, environment, caplog):
     caplog.clear()
 
     a = Agent(hostname="node1", environment=environment, agent_map={"agent1": "localhost"}, code_loader=False)
-    a.add_end_point_name("agent1")
+    await a.add_end_point_name("agent1")
     await a.start()
 
     # Verify that session creation fails and server state is stays consistent
@@ -607,7 +607,7 @@ async def test_agent_actions(server, client, async_finalizer):
         agent_map = {agent_name: "localhost" for agent_name in agent_names}
         a = agent.Agent(hostname="node1", environment=env_id, agent_map=agent_map, code_loader=False)
         for agent_name in agent_names:
-            a.add_end_point_name(agent_name)
+            await a.add_end_point_name(agent_name)
         await a.start()
         async_finalizer(a.stop)
         env_to_agent_map[env_id] = a

--- a/tests/test_extension_loading.py
+++ b/tests/test_extension_loading.py
@@ -28,8 +28,8 @@ import yaml
 import inmanta.server
 import inmanta_ext
 from inmanta.config import feature_file_config
-from inmanta.server import SLICE_AGENT_MANAGER, SLICE_SERVER, SLICE_SESSION_MANAGER, SLICE_TRANSPORT, config
-from inmanta.server.agentmanager import AgentManager
+from inmanta.server import SLICE_AGENT_MANAGER, SLICE_SERVER, SLICE_SESSION_MANAGER, SLICE_TRANSPORT, config, SLICE_AUTOSTARTED_AGENT_MANAGER
+from inmanta.server.agentmanager import AgentManager, AutostartedAgentManager
 from inmanta.server.bootloader import InmantaBootloader, PluginLoadFailed
 from inmanta.server.extensions import BoolFeature, FeatureManager, InvalidFeature, InvalidSliceNameException, StringListFeature
 from inmanta.server.protocol import Server, ServerSlice
@@ -111,13 +111,15 @@ def test_phase_3():
         server.add_slice(XTestSlice())
         server.add_slice(inmanta.server.server.Server())
         server.add_slice(AgentManager())
+        server.add_slice(AutostartedAgentManager())
 
         order = server._get_slice_sequence()
         print([s.name for s in order])
         assert [s.name for s in order] == [
-            SLICE_SERVER,
             SLICE_SESSION_MANAGER,
             SLICE_AGENT_MANAGER,
+            SLICE_SERVER,
+            SLICE_AUTOSTARTED_AGENT_MANAGER,
             SLICE_TRANSPORT,
             "testplugin.testslice",
         ]

--- a/tests/test_extension_loading.py
+++ b/tests/test_extension_loading.py
@@ -28,7 +28,14 @@ import yaml
 import inmanta.server
 import inmanta_ext
 from inmanta.config import feature_file_config
-from inmanta.server import SLICE_AGENT_MANAGER, SLICE_SERVER, SLICE_SESSION_MANAGER, SLICE_TRANSPORT, config, SLICE_AUTOSTARTED_AGENT_MANAGER
+from inmanta.server import (
+    SLICE_AGENT_MANAGER,
+    SLICE_AUTOSTARTED_AGENT_MANAGER,
+    SLICE_SERVER,
+    SLICE_SESSION_MANAGER,
+    SLICE_TRANSPORT,
+    config,
+)
 from inmanta.server.agentmanager import AgentManager, AutostartedAgentManager
 from inmanta.server.bootloader import InmantaBootloader, PluginLoadFailed
 from inmanta.server.extensions import BoolFeature, FeatureManager, InvalidFeature, InvalidSliceNameException, StringListFeature

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -202,8 +202,8 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
         Test the server to manage the updates on a model during agent deploy
     """
     agent = Agent("localhost", {"nvblah": "localhost"}, environment=environment_multi, code_loader=False)
-    agent.add_end_point_name("vm1.dev.inmanta.com")
-    agent.add_end_point_name("vm2.dev.inmanta.com")
+    await agent.add_end_point_name("vm1.dev.inmanta.com")
+    await agent.add_end_point_name("vm2.dev.inmanta.com")
     await agent.start()
     aclient = agent._client
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -30,7 +30,14 @@ from inmanta.agent import handler
 from inmanta.agent.agent import Agent
 from inmanta.export import upload_code
 from inmanta.protocol import Client
-from inmanta.server import SLICE_AGENT_MANAGER, SLICE_ORCHESTRATION, SLICE_RESOURCE, SLICE_SERVER, SLICE_SESSION_MANAGER, SLICE_AUTOSTARTED_AGENT_MANAGER
+from inmanta.server import (
+    SLICE_AGENT_MANAGER,
+    SLICE_AUTOSTARTED_AGENT_MANAGER,
+    SLICE_ORCHESTRATION,
+    SLICE_RESOURCE,
+    SLICE_SERVER,
+    SLICE_SESSION_MANAGER,
+)
 from inmanta.server import config as opt
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.util import get_compiler_version, hash_file


### PR DESCRIPTION
# Description

This PR adds support to update the environment setting autostart_agent_map without agent restart.

closes #1839 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
