### PR TITLE
Add event listener to environment service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
  - Added tags to openapi definition (#1751)
  - Added support to pause an agent (#1128, #1982)
  - Plugins are now imported in the inmanta_plugins package to allow importing submodules (#507)
+ - Added event listener to Environment Service (#1996)
 
 # v 2020.1 (2020-02-19) Changes in this release:
 

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -427,5 +427,5 @@ class EnvironmentService(protocol.ServerSlice):
                     await listener.environment_action_cleared(updated_env)
                 if action == EnvironmentAction.updated:
                     await listener.environment_action_updated(updated_env, original_env)
-            except Exception as e:
-                LOGGER.warning(f"Notifying listener of {action} failed with the following exception", e)
+            except Exception:
+                LOGGER.warning(f"Notifying listener of {action} failed with the following exception", exc_info=True)


### PR DESCRIPTION
# Description

To allow other server slices to get notified about events concerning environments.

closes #1996 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
