### PR TITLE
updated inmanta.ast.Type.type_string() to return the DSL type representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
  - Ensure correct version is used in api docs (#1994)
  - Fixed double assignment error resulting from combining constructor kwargs with default values (#2003)
  - Fixed recursive unwrapping of dict return values from plugins (#2004)
+ - Type.type_string is now defined as returning the representation of the type in the inmanta DSL (inmanta/lsm#75)
 
 ## Added
  - Experimental data trace, root cause and graphic data flow visualization applications (#1820, #1831, #1821, #1822)

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -618,8 +618,11 @@ class ModelExporter(object):
                 return model.DirectValue(value)
 
         def convert_attribute(attr):
+            type_string: Optional[str] = attr.type.type_string()
+            if type_string is None:
+                raise Exception("Type %s can not be represented in the inmanta DSL" % attr.type)
             return model.Attribute(
-                attr.type.type_string(), attr.is_optional(), attr.is_multi(), convert_comment(attr.comment), location(attr)
+                type_string, attr.is_optional(), attr.is_multi(), convert_comment(attr.comment), location(attr)
             )
 
         def convert_relation(relation: RelationAttribute):

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -1,0 +1,40 @@
+"""
+    Copyright 2020 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+from typing import Tuple
+
+import pytest
+
+from inmanta.ast.type import TYPES, NullableType, Type, TypedList
+
+
+@pytest.mark.parametrize("base_type_string", TYPES.keys())
+@pytest.mark.parametrize("multi", [True, False])
+@pytest.mark.parametrize("nullable", [True, False])
+def test_dsl_types_type_string(base_type_string: str, multi: bool, nullable: bool):
+    def apply_multi_if(tp: Type, type_string: str) -> Tuple[Type, str]:
+        return (TypedList(tp), "%s[]" % type_string) if multi else (tp, type_string)
+
+    def apply_nullable_if(tp: Type, type_string: str) -> Tuple[Type, str]:
+        return (NullableType(tp), "%s?" % type_string) if nullable else (tp, type_string)
+
+    assert base_type_string in TYPES
+    tp, type_string = apply_nullable_if(*apply_multi_if(TYPES[base_type_string], base_type_string))
+
+    assert tp.type_string() == type_string
+    assert str(tp) == type_string


### PR DESCRIPTION
# Description

`Type.type_string()` is now defined as returning the representation of the type in the inmanta DSL.

closes inmanta/lsm#75
related to inmanta/lsm#82

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
