### PR TITLE
updated Attribute.validate to take multi and nullable into account

### DIFF
--- a/src/inmanta/ast/attribute.py
+++ b/src/inmanta/ast/attribute.py
@@ -98,8 +98,14 @@ class Attribute(Locatable):
         """
             Validate a value that is going to be assigned to this attribute
         """
-        if not isinstance(value, Unknown):
-            self.type.validate(value)
+        if isinstance(value, Unknown):
+            return
+        validation_type: Type = self.type
+        if self.is_multi():
+            validation_type = TypedList(validation_type)
+        if self.is_optional():
+            validation_type = NullableType(validation_type)
+        validation_type.validate(value)
 
     def get_new_result_variable(self, instance: "Instance", queue: QueueScheduler) -> ResultVariable:
         if self.__multi:


### PR DESCRIPTION
# Description

`Attribute.validate` now takes multi and nullable into account.

closes #2031

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] ~~Changelog entry~~
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
