### PR TITLE
Add clarification for agent-deploy-interval setting

### DIFF
--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -80,7 +80,7 @@ agent_deploy_interval = Option(
     "config",
     "agent-deploy-interval",
     0,
-    "The number of seconds between two (incremental) deployment runs of the agent.",
+    "The number of seconds between two (incremental) deployment runs of the agent. Set this to 0 to disable the scheduled deploy runs.",
     is_time,
     predecessor_option=agent_interval,
 )


### PR DESCRIPTION
# Description

Clarify that setting the agent-deploy-interval to zero disables the timer.