### PR TITLE
added warning when overwriting built-in type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
  - Plugins are now imported in the inmanta_plugins package to allow importing submodules (#507)
  - Added event listener to Environment Service (#1996)
  - Added protected environment option (#1997)
+ - Added warning when trying to override a built-in type with a typedef (#81)
 
 # v 2020.1 (2020-02-19) Changes in this release:
 

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -24,6 +24,7 @@ import inmanta.warnings as inmanta_warnings
 from inmanta.ast import (
     AttributeReferenceAnchor,
     CompilerDeprecationWarning,
+    CompilerRuntimeWarning,
     DuplicateException,
     Import,
     IndexException,
@@ -42,7 +43,7 @@ from inmanta.ast.constraint.expression import Equals
 from inmanta.ast.entity import Default, Entity, EntityLike, Implement, Implementation
 from inmanta.ast.statements import BiStatement, ExpressionStatement, Literal, Statement, TypeDefinitionStatement
 from inmanta.ast.statements.generator import Constructor
-from inmanta.ast.type import ConstraintType, NullableType, Type, TypedList
+from inmanta.ast.type import ConstraintType, NullableType, Type, TypedList, TYPES
 from inmanta.execute.runtime import ExecutionUnit, QueueScheduler, Resolver, ResultVariable
 
 from . import DefinitionStatement
@@ -413,6 +414,8 @@ class DefineTypeConstraint(TypeDefinitionStatement):
         self.type = ConstraintType(self.namespace, str(name))
         self.type.location = name.get_location()
         self.comment = None
+        if self.name in TYPES:
+            inmanta_warnings.warn(CompilerRuntimeWarning(self, "Trying to override a built-in type: %s" % self.name))
 
     def get_expression(self) -> ExpressionStatement:
         """

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -43,7 +43,7 @@ from inmanta.ast.constraint.expression import Equals
 from inmanta.ast.entity import Default, Entity, EntityLike, Implement, Implementation
 from inmanta.ast.statements import BiStatement, ExpressionStatement, Literal, Statement, TypeDefinitionStatement
 from inmanta.ast.statements.generator import Constructor
-from inmanta.ast.type import ConstraintType, NullableType, Type, TypedList, TYPES
+from inmanta.ast.type import TYPES, ConstraintType, NullableType, Type, TypedList
 from inmanta.execute.runtime import ExecutionUnit, QueueScheduler, Resolver, ResultVariable
 
 from . import DefinitionStatement

--- a/tests/compiler/test_warnings.py
+++ b/tests/compiler/test_warnings.py
@@ -241,7 +241,5 @@ typedef string as number matching self > 0
         assert len(w) == 1
         assert issubclass(w[0].category, CompilerRuntimeWarning)
         assert str(w[0].message) == (
-            "Trying to override a built-in type: string (reported in Type(string) ({dir}/test.cf:2:9))".format(
-                dir=snippetcompiler.project_dir
-            )
+            "Trying to override a built-in type: string (reported in Type(string) ({snippetcompiler.project_dir}/test.cf:2:9))"
         )

--- a/tests/compiler/test_warnings.py
+++ b/tests/compiler/test_warnings.py
@@ -241,5 +241,5 @@ typedef string as number matching self > 0
         assert len(w) == 1
         assert issubclass(w[0].category, CompilerRuntimeWarning)
         assert str(w[0].message) == (
-            "Trying to override a built-in type: string (reported in Type(string) ({snippetcompiler.project_dir}/test.cf:2:9))"
+            "Trying to override a built-in type: string (reported in Type(string) ({snippetcompiler.project_dir}/main.cf:2:9))"
         )

--- a/tests/compiler/test_warnings.py
+++ b/tests/compiler/test_warnings.py
@@ -239,7 +239,7 @@ typedef string as number matching self > 0
     with warnings.catch_warnings(record=True) as w:
         compiler.do_compile()
         assert len(w) == 1
-        assert issubclass(w[0].category, CompilerDeprecationWarning)
+        assert issubclass(w[0].category, CompilerRuntimeWarning)
         assert str(w[0].message) == (
             "Trying to override a built-in type: string (reported in Type(string) ({dir}/test.cf:2:9))".format(
                 dir=snippetcompiler.project_dir

--- a/tests/compiler/test_warnings.py
+++ b/tests/compiler/test_warnings.py
@@ -228,3 +228,20 @@ implement A using std::none
         assert len(w) == 1
         assert issubclass(w[0].category, CompilerDeprecationWarning)
         assert str(w[0].message) == message
+
+
+def test_2030_type_overwrite_warning(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+typedef string as number matching self > 0
+        """,
+    )
+    with warnings.catch_warnings(record=True) as w:
+        compiler.do_compile()
+        assert len(w) == 1
+        assert issubclass(w[0].category, CompilerDeprecationWarning)
+        assert str(w[0].message) == (
+            "Trying to override a built-in type: string (reported in Type(string) ({dir}/test.cf:2:9))".format(
+                dir=snippetcompiler.project_dir
+            )
+        )


### PR DESCRIPTION
# Description

Adds warning for typedefs where name == built-in type name

closes #2030

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
