### PR TITLE
Cleanup after compile_138 test

### DIFF
--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -141,6 +141,10 @@ class TestCompileIssue138(CompilerBaseTest, unittest.TestCase):
             is not None
         )
 
+    def tearDown(self):
+        super().tearDown()
+        shutil.rmtree(os.path.join(self.project_dir, "libs", "std"))
+
 
 class TestCompileluginTyping(CompilerBaseTest, unittest.TestCase):
     def __init__(self, methodName="runTest"):  # noqa: N803


### PR DESCRIPTION
# Description

Remove the downloaded std module after the test.

closes #2026 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
~Changelog entry~
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- ~[ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
