### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -53,7 +53,7 @@ Glossary
     module
         A :term:`configuration model` consists of multiple configuration modules. A module provides
         a partial and reusable configuration model and its related resources such as files,
-        templates, ... The :doc:`module developer guide<module_developers/modules>` provides more details.
+        templates, ... The :doc:`module developer guide <model_developers/modules>` provides more details.
 
     resource handler
         See :term:`handler`


### PR DESCRIPTION
# Description

A typo lead to a broken link

closes #2017 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- ~[ ] Changelog entry~
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
