### PR TITLE
Include inmanta-cli docs in sphinx docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
  - Autostarted agents can load a new value for the autostart_agent_map setting without agent restart (#1839)
  - Added protected environment option (#1997)
  - Added warning when trying to override a built-in type with a typedef (#81)
+ - Added inmanta-cli documentation to the docs (#1992)
 
 # v 2020.1 (2020-02-19) Changes in this release:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ import sys, os, pkg_resources
 extensions = [
     'sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig', 'sphinx.ext.viewcode',
     'sphinxarg.ext', 'sphinxcontrib.inmanta.config', 'sphinxcontrib.inmanta.dsl', 'sphinx_tabs.tabs',
-    'sphinxcontrib.inmanta.environmentsettings',
+    'sphinxcontrib.inmanta.environmentsettings', 'sphinx_click.ext'
 ]
 
 

--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -18,6 +18,11 @@ inmanta
 
 inmanta-cli
 ###########
+
+The ``inmanta-cli`` command can be used to interact with the inmanta server and agents,
+including manage projects, environments, parameters and more.
+The following reference explains the available subcommands.
+
 .. click:: inmanta.main:cmd
    :prog: inmanta-cli
    :show-nested:

--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -16,6 +16,8 @@ inmanta
    :func: cmd_parser
    :prog: inmanta
 
+inmanta-cli
+###########
 .. click:: inmanta.main:cmd
    :prog: inmanta-cli
    :show-nested:

--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -16,7 +16,6 @@ inmanta
    :func: cmd_parser
    :prog: inmanta
 
-inmanta-cli
-###########
-
-Use ``inmanta-cli --help``
+.. click:: inmanta.main:cmd
+   :prog: inmanta-cli
+   :show-nested:

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,7 @@ setuptools==46.1.3
 pip==20.0.2
 docstring-parser==0.6.1
 bumpversion==0.5.3
+sphinx-click==2.3.2
 
 # Transitive dependencies
 MarkupSafe==1.1.1


### PR DESCRIPTION
# Description

With https://sphinx-click.readthedocs.io/en/latest/

closes #1992 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
