### PR TITLE
Use the namespace-files option in the show-options directive

### DIFF
--- a/docs/reference/config-namespaces/core.conf
+++ b/docs/reference/config-namespaces/core.conf
@@ -1,0 +1,5 @@
+inmanta.deploy
+inmanta.export
+inmanta.server.config
+inmanta.agent.config
+inmanta.compiler.config

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -8,9 +8,5 @@ This document lists all options for the inmanta server and inmanta agent.
 The options are listed per config section.
 
 .. show-options::
+    :namespace-files: ./config-namespaces/*.conf
 
-    inmanta.deploy
-    inmanta.export
-    inmanta.server.config
-    inmanta.agent.config
-    inmanta.compiler.config


### PR DESCRIPTION
# Description

Store the namespaces that contain the `Option()` definitions in a separate file.