### PR TITLE
Set required loglevel for test case.

### DIFF
--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -787,6 +787,7 @@ async def test_exception_occurs_while_processing_session_action(server, environm
 
 @pytest.mark.asyncio
 async def test_restart_on_environment_setting(server, client, environment, caplog):
+    caplog.set_level(logging.DEBUG)
     response = await client.environment_settings_set(tid=environment, id="autostart_agent_deploy_interval", value=300)
     assert response.code == 200
 

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -787,17 +787,17 @@ async def test_exception_occurs_while_processing_session_action(server, environm
 
 @pytest.mark.asyncio
 async def test_restart_on_environment_setting(server, client, environment, caplog):
-    caplog.set_level(logging.DEBUG)
-    response = await client.environment_settings_set(tid=environment, id="autostart_agent_deploy_interval", value=300)
-    assert response.code == 200
+    with caplog.at_level(logging.DEBUG):
+        response = await client.environment_settings_set(tid=environment, id="autostart_agent_deploy_interval", value=300)
+        assert response.code == 200
 
-    def check_log_contains(caplog, loggerpart, level, msg):
-        for record in caplog.get_records("call"):
-            logger_name, log_level, message = record.name, record.levelno, record.message
-            if msg in message and loggerpart in logger_name and level == log_level:
-                return True
-        return False
+        def check_log_contains(caplog, loggerpart, level, msg):
+            for record in caplog.get_records("call"):
+                logger_name, log_level, message = record.name, record.levelno, record.message
+                if msg in message and loggerpart in logger_name and level == log_level:
+                    return True
+            return False
 
-    await retry_limited(
-        lambda: check_log_contains(caplog, "inmanta.server.agentmanager", logging.DEBUG, "Restarting agents in environment"), 10
-    )
+        await retry_limited(
+            lambda: check_log_contains(caplog, "inmanta.server.agentmanager", logging.DEBUG, "Restarting agents in environment"), 10
+        )

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -799,5 +799,8 @@ async def test_restart_on_environment_setting(server, client, environment, caplo
             return False
 
         await retry_limited(
-            lambda: check_log_contains(caplog, "inmanta.server.agentmanager", logging.DEBUG, "Restarting agents in environment"), 10
+            lambda: check_log_contains(
+                caplog, "inmanta.server.agentmanager", logging.DEBUG, "Restarting agents in environment"
+            ),
+            10,
         )


### PR DESCRIPTION
# Description

Set the loglevel of the `test_restart_on_environment_setting()` testcase to DEBUG, since the test case requires it. 