### PR TITLE
Clean up old compile reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Fixed
 - Fixed issue of autostarted agents not being restarted on environment setting change (#2049)
 
+## Added
+- Added cleanup mechanism of old compile reports (#2054)
+
 # v 2020.2 (2020-04-24) Changes in this release:
 
 ## Breaking changes

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1524,6 +1524,15 @@ class Compile(BaseDocument):
         )
         return results
 
+    @classmethod
+    async def delete_older_than(
+        cls, oldest_retained_date: datetime.datetime, connection: Optional[asyncpg.Connection] = None
+    ) -> int:
+        query = "DELETE FROM " + cls.table_name() + " WHERE completed <= $1::date"
+        result = await cls._execute_query(query, oldest_retained_date, connection=connection)
+        record_count = int(result.split(" ")[1])
+        return record_count
+
     def to_dto(self) -> m.CompileRun:
         return m.CompileRun(
             id=self.id,

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1531,7 +1531,7 @@ class Compile(BaseDocument):
     async def delete_older_than(
         cls, oldest_retained_date: datetime.datetime, connection: Optional[asyncpg.Connection] = None
     ) -> None:
-        query = "DELETE FROM " + cls.table_name() + " WHERE completed <= $1::date"
+        query = "DELETE FROM " + cls.table_name() + " WHERE completed <= $1::timestamp"
         await cls._execute_query(query, oldest_retained_date, connection=connection)
 
     def to_dto(self) -> m.CompileRun:

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -37,6 +37,7 @@ from inmanta.const import DONE_STATES, UNDEPLOYABLE_NAMES, AgentStatus, Resource
 from inmanta.data import model as m
 from inmanta.data import schema
 from inmanta.resources import Id
+from inmanta.server import config
 from inmanta.types import JsonType, PrimitiveTypes
 
 LOGGER = logging.getLogger(__name__)
@@ -251,7 +252,9 @@ class BaseDocument(object, metaclass=DocumentMeta):
         if not cls._connection_pool:
             return
         try:
-            await cls._connection_pool.close()
+            await asyncio.wait_for(cls._connection_pool.close(), config.db_connection_timeout.get())
+        except asyncio.TimeoutError:
+            cls._connection_pool.terminate()
         finally:
             cls._connection_pool = None
 
@@ -1527,11 +1530,9 @@ class Compile(BaseDocument):
     @classmethod
     async def delete_older_than(
         cls, oldest_retained_date: datetime.datetime, connection: Optional[asyncpg.Connection] = None
-    ) -> int:
+    ) -> None:
         query = "DELETE FROM " + cls.table_name() + " WHERE completed <= $1::date"
-        result = await cls._execute_query(query, oldest_retained_date, connection=connection)
-        record_count = int(result.split(" ")[1])
-        return record_count
+        await cls._execute_query(query, oldest_retained_date, connection=connection)
 
     def to_dto(self) -> m.CompileRun:
         return m.CompileRun(

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -205,9 +205,9 @@ server_version_to_keep = Option(
 server_compiler_report_retention = Option(
     "server",
     "compiler_report_retention",
-    7,
+    604800,
     """The server regularly cleans up old compiler reports.
-    This options specifies the number of days to keep old compiler reports for""",
+    This options specifies the number of seconds to keep old compiler reports for. The default is seven days""",
     is_time,
 )
 

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -202,6 +202,24 @@ server_version_to_keep = Option(
     is_int,
 )
 
+server_compiler_report_retention = Option(
+    "server",
+    "compiler_report_retention",
+    7,
+    """The server regularly cleans up old compiler reports.
+    This options specifies the number of days to keep old compiler reports for""",
+    is_time,
+)
+
+server_cleanup_compiler_reports_interval = Option(
+    "server",
+    "cleanup_compiler_reports_interval",
+    3600,
+    """Number of seconds between old compile report cleanups.
+    see :inmanta.config:option:`server.compiler_report_retention`""",
+    is_time,
+)
+
 server_address: Option[str] = Option(
     "server",
     "server_address",

--- a/src/inmanta/server/protocol.py
+++ b/src/inmanta/server/protocol.py
@@ -286,8 +286,8 @@ class ServerSlice(inmanta.protocol.endpoints.CallTarget, TaskHandler):
         return self._handlers
 
     # utility methods for extensions developers
-    def schedule(self, call: Union[Callable, Coroutine], interval: int = 60) -> None:
-        self._sched.add_action(call, interval)
+    def schedule(self, call: Union[Callable, Coroutine], interval: int = 60, initial_delay: Optional[float] = None) -> None:
+        self._sched.add_action(call, interval, initial_delay)
 
     def add_static_handler(self, location: str, path: str, default_filename: Optional[str] = None, start: bool = False) -> None:
         """

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -340,6 +340,16 @@ class CompilerService(ServerSlice):
     async def start(self) -> None:
         await super(CompilerService, self).start()
         await self._recover()
+        self.schedule(self._cleanup, opt.server_cleanup_compiler_reports_interval.get())
+        self.add_background_task(self._cleanup())
+
+    async def _cleanup(self) -> None:
+        oldest_retained_date = datetime.datetime.now() - datetime.timedelta(days=opt.server_compiler_report_retention.get())
+        LOGGER.info(f"Cleaning up compile reports that are older than {oldest_retained_date}")
+        try:
+            await data.Compile.delete_older_than(oldest_retained_date)
+        except Exception:
+            LOGGER.error("The following exception occured while cleaning up old compiler reports", exc_info=True)
 
     async def request_recompile(
         self,

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -340,12 +340,11 @@ class CompilerService(ServerSlice):
     async def start(self) -> None:
         await super(CompilerService, self).start()
         await self._recover()
-        self.schedule(self._cleanup, opt.server_cleanup_compiler_reports_interval.get())
-        self.add_background_task(self._cleanup())
+        self.schedule(self._cleanup, opt.server_cleanup_compiler_reports_interval.get(), initial_delay=0)
 
     async def _cleanup(self) -> None:
         oldest_retained_date = datetime.datetime.now() - datetime.timedelta(days=opt.server_compiler_report_retention.get())
-        LOGGER.info(f"Cleaning up compile reports that are older than {oldest_retained_date}")
+        LOGGER.info("Cleaning up compile reports that are older than %s", oldest_retained_date)
         try:
             await data.Compile.delete_older_than(oldest_retained_date)
         except Exception:

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -343,7 +343,7 @@ class CompilerService(ServerSlice):
         self.schedule(self._cleanup, opt.server_cleanup_compiler_reports_interval.get(), initial_delay=0)
 
     async def _cleanup(self) -> None:
-        oldest_retained_date = datetime.datetime.now() - datetime.timedelta(days=opt.server_compiler_report_retention.get())
+        oldest_retained_date = datetime.datetime.now() - datetime.timedelta(seconds=opt.server_compiler_report_retention.get())
         LOGGER.info("Cleaning up compile reports that are older than %s", oldest_retained_date)
         try:
             await data.Compile.delete_older_than(oldest_retained_date)

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -16,6 +16,7 @@
     Contact: code@inmanta.com
 """
 import asyncio
+import datetime
 import logging
 import os
 import shutil
@@ -27,6 +28,7 @@ from typing import List
 import pytest
 
 from inmanta import config, data
+from inmanta.data import Compile, Report
 from inmanta.server import SLICE_COMPILER, SLICE_SERVER
 from inmanta.server import config as server_config
 from inmanta.server.protocol import Server
@@ -590,3 +592,75 @@ async def test_compileservice_queue(mocked_compiler_service_block, server, clien
     result = await client.get_compile_queue(environment)
     assert len(result.result["queue"]) == 0
     assert result.code == 200
+
+
+@pytest.fixture
+async def old_compile_report(server, client, environment):
+    now = datetime.datetime.now()
+    time_of_compile = now - datetime.timedelta(days=30)
+    compile_id = uuid.UUID("c00cc33f-f70f-4800-ad01-ff042f67118f")
+    old_compile = {
+        "id": compile_id,
+        "remote_id": uuid.UUID("c9a10da1-9bf6-4152-8461-98adc02c4cee"),
+        "environment": uuid.UUID(environment),
+        "requested": time_of_compile,
+        "started": time_of_compile,
+        "completed": time_of_compile,
+        "do_export": True,
+        "force_update": True,
+        "metadata": {"type": "api", "message": "Recompile trigger through API call"},
+        "environment_variables": {},
+        "success": True,
+        "handled": True,
+        "version": 1,
+    }
+    await Compile(**old_compile).insert()
+    new_compile = {**old_compile, "id": uuid.uuid4(), "requested": now, "started": now, "completed": now}
+    await Compile(**new_compile).insert()
+
+    report1 = {
+        "id": uuid.UUID("2baa0175-9169-40c5-a546-64d646f62da6"),
+        "started": time_of_compile,
+        "completed": time_of_compile,
+        "command": "",
+        "name": "Init",
+        "errstream": "",
+        "outstream": "Using extra environment variables during compile \n",
+        "returncode": 0,
+        "compile": compile_id,
+    }
+    report2 = {
+        **report1,
+        "id": uuid.UUID("2a86d2a0-666f-4cca-b0a8-13e0379128d5"),
+        "command": "python -m inmanta.app -vvv export -X",
+        "name": "Recompiling configuration model",
+    }
+    await Report(**report1).insert()
+    await Report(**report2).insert()
+    yield compile_id
+
+
+@pytest.mark.asyncio
+async def test_compileservice_cleanup(server, client, environment, old_compile_report):
+    # There is a new and an older report in the database
+    result = await client.get_reports(environment)
+    assert result.code == 200
+    assert len(result.result["reports"]) == 2
+
+    result = await client.get_report(old_compile_report)
+    assert result.code == 200
+    assert len(result.result["report"]["reports"]) > 0
+
+    compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
+    await compilerslice._cleanup()
+
+    # The old report is deleted after cleanup
+    result = await client.get_report(old_compile_report)
+    assert result.code == 404
+    reports_after_cleanup = await Report.get_list(compile=old_compile_report)
+    assert len(reports_after_cleanup) == 0
+
+    # The new report is still there
+    result = await client.get_reports(environment)
+    assert result.code == 200
+    assert len(result.result["reports"]) == 1

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -29,8 +29,11 @@ import pytest
 
 from inmanta import config, data
 from inmanta.data import Compile, Report
+from inmanta.deploy import cfg_env
 from inmanta.server import SLICE_COMPILER, SLICE_SERVER
 from inmanta.server import config as server_config
+from inmanta.server import protocol
+from inmanta.server.bootloader import InmantaBootloader
 from inmanta.server.protocol import Server
 from inmanta.server.services.compilerservice import CompilerService, CompileRun, CompileStateListener
 from inmanta.util import ensure_directory_exist
@@ -594,15 +597,48 @@ async def test_compileservice_queue(mocked_compiler_service_block, server, clien
     assert result.code == 200
 
 
+@pytest.fixture(scope="function")
+async def server_with_frequent_cleanups(server_pre_start, server_config, async_finalizer):
+    config.Config.set("server", "compiler_report_retention", "3")
+    config.Config.set("server", "cleanup_compiler_reports_interval", "1")
+    ibl = InmantaBootloader()
+    await ibl.start()
+    yield ibl.restserver
+    await asyncio.wait_for(ibl.stop(), 15)
+
+
+@pytest.fixture(scope="function")
+def client_for_cleanup(server_with_frequent_cleanups):
+    client = protocol.Client("client")
+    yield client
+
+
+@pytest.fixture(scope="function")
+async def environment_for_cleanup(client_for_cleanup, server_with_frequent_cleanups):
+    """
+        Create a project and environment. This fixture returns the uuid of the environment
+    """
+    result = await client_for_cleanup.create_project("env-test")
+    assert result.code == 200
+    project_id = result.result["project"]["id"]
+
+    result = await client_for_cleanup.create_environment(project_id=project_id, name="dev")
+    env_id = result.result["environment"]["id"]
+
+    cfg_env.set(env_id)
+
+    yield env_id
+
+
 @pytest.fixture
-async def old_compile_report(server, client, environment):
+async def old_compile_report(server_with_frequent_cleanups, environment_for_cleanup):
     now = datetime.datetime.now()
     time_of_compile = now - datetime.timedelta(days=30)
     compile_id = uuid.UUID("c00cc33f-f70f-4800-ad01-ff042f67118f")
     old_compile = {
         "id": compile_id,
         "remote_id": uuid.UUID("c9a10da1-9bf6-4152-8461-98adc02c4cee"),
-        "environment": uuid.UUID(environment),
+        "environment": uuid.UUID(environment_for_cleanup),
         "requested": time_of_compile,
         "started": time_of_compile,
         "completed": time_of_compile,
@@ -641,26 +677,47 @@ async def old_compile_report(server, client, environment):
 
 
 @pytest.mark.asyncio
-async def test_compileservice_cleanup(server, client, environment, old_compile_report):
+async def test_compileservice_cleanup(
+    server_with_frequent_cleanups, client_for_cleanup, environment_for_cleanup, old_compile_report
+):
     # There is a new and an older report in the database
-    result = await client.get_reports(environment)
+    result = await client_for_cleanup.get_reports(environment_for_cleanup)
     assert result.code == 200
     assert len(result.result["reports"]) == 2
 
-    result = await client.get_report(old_compile_report)
+    result = await client_for_cleanup.get_report(old_compile_report)
     assert result.code == 200
     assert len(result.result["report"]["reports"]) > 0
 
-    compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
+    compilerslice: CompilerService = server_with_frequent_cleanups.get_slice(SLICE_COMPILER)
     await compilerslice._cleanup()
 
     # The old report is deleted after cleanup
-    result = await client.get_report(old_compile_report)
+    result = await client_for_cleanup.get_report(old_compile_report)
     assert result.code == 404
     reports_after_cleanup = await Report.get_list(compile=old_compile_report)
     assert len(reports_after_cleanup) == 0
 
     # The new report is still there
-    result = await client.get_reports(environment)
+    result = await client_for_cleanup.get_reports(environment_for_cleanup)
     assert result.code == 200
     assert len(result.result["reports"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_compileservice_cleanup_on_trigger(client_for_cleanup, environment_for_cleanup, old_compile_report):
+    # Two reports are in the table
+    result = await client_for_cleanup.get_reports(environment_for_cleanup)
+    assert result.code == 200
+    assert len(result.result["reports"]) == 2
+
+    result = await client_for_cleanup.get_report(old_compile_report)
+    assert result.code == 200
+    assert len(result.result["report"]["reports"]) > 0
+
+    await asyncio.sleep(4)
+
+    # Both reports should be deleted after the triggered cleanup
+    result = await client_for_cleanup.get_reports(environment_for_cleanup)
+    assert result.code == 200
+    assert len(result.result["reports"]) == 0

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -599,7 +599,7 @@ async def test_compileservice_queue(mocked_compiler_service_block, server, clien
 
 @pytest.fixture(scope="function")
 async def server_with_frequent_cleanups(server_pre_start, server_config, async_finalizer):
-    config.Config.set("server", "compiler_report_retention", "3")
+    config.Config.set("server", "compiler_report_retention", "2")
     config.Config.set("server", "cleanup_compiler_reports_interval", "1")
     ibl = InmantaBootloader()
     await ibl.start()
@@ -704,6 +704,7 @@ async def test_compileservice_cleanup(
     assert len(result.result["reports"]) == 1
 
 
+@pytest.mark.slowtest
 @pytest.mark.asyncio
 async def test_compileservice_cleanup_on_trigger(client_for_cleanup, environment_for_cleanup, old_compile_report):
     # Two reports are in the table
@@ -715,7 +716,7 @@ async def test_compileservice_cleanup_on_trigger(client_for_cleanup, environment
     assert result.code == 200
     assert len(result.result["report"]["reports"]) > 0
 
-    await asyncio.sleep(4)
+    await asyncio.sleep(3)
 
     # Both reports should be deleted after the triggered cleanup
     result = await client_for_cleanup.get_reports(environment_for_cleanup)


### PR DESCRIPTION
# Description

Cleans up old compiler reports periodically

closes #2054 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
