### PR TITLE
removed dependency on typing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ requires = [
     "pyyaml",
     "texttable",
     "tornado",
-    "typing",
     "PyJWT",
     "cryptography",
     "jinja2",


### PR DESCRIPTION
# Description

The typing library has become part of the standard python library since python 3.5
Importing it in higher versions should not cause problems, but it does: https://github.com/python/typing/issues/573

As we only support 3.6 and up, it can be safely removed.

# Self Check:



- [ ] ~~Attached issue to pull request~~
- [ ] ~~Changelog entry~~
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
