### PR TITLE
removed typing from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,6 @@ texttable==1.6.2
 tornado==6.0.4
 tox==3.14.6
 tox-venv==0.4.0
-typing==3.7.4.1
 asyncpg==0.20.1
 pytest-postgresql==2.3.0
 pytest-env==0.6.2

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -28,7 +28,6 @@ requires = [
     "pytest-env",
     "pytest-postgresql",
     "tornado",
-    "typing",
 ]
 
 this_directory = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
# Description

removed typing from requirements.txt as it is a built-in for all supported python versions and breaks pip

see python/typing#573

* Short description here *

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~~Attached issue to pull request~~
- [ ] ~~Changelog entry~~
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
