### PR TITLE
Issue/2079 log primary in database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Fixed
 - Fixed issue of autostarted agents not being restarted on environment setting change (#2049)
+- Log primary for agent correctly in the database when pausing/unpausing agents (#2079)
 
 ## Added
 - Added cleanup mechanism of old compile reports (#2054)

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -681,10 +681,18 @@ async def test_agent_actions(server, client, async_finalizer):
 
     async def assert_agents_paused(expected_statuses: Dict[Tuple[UUID, str], bool]) -> None:
         for (env_id, agent_name), paused in expected_statuses.items():
+            # Check in-memory session state
             live_session_found = (env_id, agent_name) in agent_manager.tid_endpoint_to_session
             assert live_session_found != paused
+            # Check database state
             agent_from_db = await data.Agent.get_one(environment=env_id, name=agent_name)
             assert agent_from_db.paused == paused
+            assert (agent_from_db.primary is None) == paused
+            if not paused:
+                live_session = agent_manager.tid_endpoint_to_session[(env_id, agent_name)]
+                agent_instance = await data.AgentInstance.get_by_id(agent_from_db.id_primary)
+                assert agent_instance.process == live_session.id
+            # Check agent state
             assert env_to_agent_map[env_id]._instances[agent_name].is_enabled() != paused
 
     await assert_agents_paused(

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -690,7 +690,7 @@ async def test_agent_actions(server, client, async_finalizer):
             assert (agent_from_db.primary is None) == paused
             if not paused:
                 live_session = agent_manager.tid_endpoint_to_session[(env_id, agent_name)]
-                agent_instance = await data.AgentInstance.get_by_id(agent_from_db.id_primary)
+                agent_instance = await data.AgentInstance.get_by_id(agent_from_db.primary)
                 assert agent_instance.process == live_session.id
             # Check agent state
             assert env_to_agent_map[env_id]._instances[agent_name].is_enabled() != paused


### PR DESCRIPTION
# Description

This PR ensures that the primary for a certain agent is logged correctly in the database when that agent is paused or unpaused.

closes #2079 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
