### PR TITLE
Issue/2101 internal agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixed
 - Fixed issue of autostarted agents not being restarted on environment setting change (#2049)
 - Log primary for agent correctly in the database when pausing/unpausing agents (#2079)
+- Ensure the internal agent is always present in the autostart_agent_map of auto-started agents (#2101)
 
 ## Added
 - Added cleanup mechanism of old compile reports (#2054)

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -816,7 +816,7 @@ class AutostartedAgentManager(ServerSlice):
         # set in a previous version of the orchestrator which didn't have this constraint. This code fixes the inconsistency.
         if "internal" not in agent_map:
             agent_map["internal"] = "local:"
-            await env.set(data.AUTOSTART_AGENT_MAP, agent_map)
+            await env.set(data.AUTOSTART_AGENT_MAP, dict(agent_map))
 
         agents = [agent for agent in agents if agent in agent_map]
         needsstart = restart

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -803,6 +803,13 @@ class AutostartedAgentManager(ServerSlice):
 
         agent_map: Dict[str, str]
         agent_map = await env.get(data.AUTOSTART_AGENT_MAP)
+
+        # The internal agent should always be present in the autostart_agent_map. If it's not, this autostart_agent_map was
+        # set in a previous version of the orchestrator which didn't have this constraint. This code fixes the inconsistency.
+        if "internal" not in agent_map:
+            agent_map["internal"] = "local:"
+            await env.set(data.AUTOSTART_AGENT_MAP, agent_map)
+
         agents = [agent for agent in agents if agent in agent_map]
         needsstart = restart
         if len(agents) == 0:


### PR DESCRIPTION
# Description

This PR ensures that the internal agent is always present in the autostart_agent_map when the auto-started agent is started.

closes #2101 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
