### PR TITLE
Issue/2106 cancel resourceactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Cancel scheduled deploy operations of an agent when that agent is paused (#2077)
 - Fix agent-names config type (#2071)
 - Ensure the internal agent is always present in the autostart_agent_map of auto-started agents (#2101)
+- Cancel scheduled ResourceActions when AgentInstance is stopped (#2106)
 
 ## Added
 - Added cleanup mechanism of old compile reports (#2054)

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -608,6 +608,7 @@ class AgentInstance(object):
         self._get_resource_timeout = 0
 
     async def stop(self) -> None:
+        self._nq.cancel()
         self.provider_thread_pool.shutdown(wait=False)
         self.thread_pool.shutdown(wait=False)
 

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -630,6 +630,9 @@ class AgentInstance(object):
     def is_enabled(self) -> bool:
         return self._enabled
 
+    def is_stopped(self) -> bool:
+        return self._stopped
+
     def unpause(self) -> Apireturn:
         if self._stopped:
             return 403, "Cannot unpause stopped agent instance"

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -3408,12 +3408,21 @@ async def test_agentinstance_stops_deploying_when_stopped(
     agent_instance = agent._instances["agent1"]
     assert not agent_instance._nq.finished()
     assert agent_instance.is_enabled()
+    assert not agent_instance.is_stopped()
 
     await agent.remove_end_point_name("agent1")
 
     assert "agent1" not in agent._instances
     assert agent_instance._nq.finished()
     assert not agent_instance.is_enabled()
+    assert agent_instance.is_stopped()
+
+    # Agent cannot be unpaused after it is stopped
+    return_code, _ = agent_instance.unpause()
+    assert return_code == 403
+    assert agent_instance._nq.finished()
+    assert not agent_instance.is_enabled()
+    assert agent_instance.is_stopped()
 
     # Cleanly stop in flight coroutines
     await resource_container.wait_for_done_with_waiters(

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -3407,11 +3407,13 @@ async def test_agentinstance_stops_deploying_when_stopped(
     assert "agent1" in agent._instances
     agent_instance = agent._instances["agent1"]
     assert not agent_instance._nq.finished()
+    assert agent_instance.is_enabled()
 
     await agent.remove_end_point_name("agent1")
 
     assert "agent1" not in agent._instances
     assert agent_instance._nq.finished()
+    assert not agent_instance.is_enabled()
 
     # Cleanly stop in flight coroutines
     await resource_container.wait_for_done_with_waiters(

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -3373,30 +3373,30 @@ async def test_agentinstance_stops_deploying_when_stopped(
     """
     version = await clienthelper.get_version()
     resources = [
-            {
-                "key": "key1",
-                "value": "value1",
-                "id": f"test::Resource[agent1,key=key1],v={version}",
-                "send_event": False,
-                "purged": False,
-                "requires": [],
-            },
-            {
-                "key": "key2",
-                "value": "value2",
-                "id": f"test::Wait[agent1,key=key2],v={version}",
-                "send_event": False,
-                "purged": False,
-                "requires": [f"test::Resource[agent1,key=key1],v={version}"],
-            },
-            {
-                "key": "key3",
-                "value": "value3",
-                "id": f"test::Wait[agent1,key=key3],v={version}",
-                "send_event": False,
-                "purged": False,
-                "requires": [f"test::Resource[agent1,key=key2],v={version}"],
-            },
+        {
+            "key": "key1",
+            "value": "value1",
+            "id": f"test::Resource[agent1,key=key1],v={version}",
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+        {
+            "key": "key2",
+            "value": "value2",
+            "id": f"test::Wait[agent1,key=key2],v={version}",
+            "send_event": False,
+            "purged": False,
+            "requires": [f"test::Resource[agent1,key=key1],v={version}"],
+        },
+        {
+            "key": "key3",
+            "value": "value3",
+            "id": f"test::Wait[agent1,key=key3],v={version}",
+            "send_event": False,
+            "purged": False,
+            "requires": [f"test::Resource[agent1,key=key2],v={version}"],
+        },
     ]
 
     await _deploy_resources(client, environment, resources, version, push=True)


### PR DESCRIPTION
# Description

When an AgentInstance is stopped:
* Cancel all ResourceActions scheduled on that AgentInstance.
* Disable the deploy/repair timers.

closes #2106 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
