### PR TITLE
fixed rest endpoint return value decoding for html with charset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fix agent-names config type (#2071)
 - Ensure the internal agent is always present in the autostart_agent_map of auto-started agents (#2101)
 - Cancel scheduled ResourceActions when AgentInstance is stopped (#2106)
-- Decoding of REST return value for content type html with charset set (#2074)
+- Decoding of REST return value for content type html with utf-8 charset (#2074)
 
 ## Added
 - Added cleanup mechanism of old compile reports (#2054)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix agent-names config type (#2071)
 - Ensure the internal agent is always present in the autostart_agent_map of auto-started agents (#2101)
 - Cancel scheduled ResourceActions when AgentInstance is stopped (#2106)
+- Decoding of REST return value for content type html with charset set (#2074)
 
 ## Added
 - Added cleanup mechanism of old compile reports (#2054)

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -73,6 +73,7 @@ if TYPE_CHECKING:
 LOGGER: logging.Logger = logging.getLogger(__name__)
 
 HTML_ENCODING = "ISO-8859-1"
+UTF8_ENCODING = "UTF-8"
 CONTENT_TYPE = "Content-Type"
 JSON_CONTENT = "application/json"
 HTML_CONTENT = "text/html"

--- a/src/inmanta/protocol/rest/client.py
+++ b/src/inmanta/protocol/rest/client.py
@@ -147,8 +147,10 @@ class RESTClient(RESTBase):
 
         if content_type is None or content_type == common.JSON_CONTENT:
             return common.Result(code=response.code, result=self._decode(response.body))
-        elif content_type == common.HTML_CONTENT or content_type == common.HTML_CONTENT_WITH_UTF8_CHARSET:
+        elif content_type == common.HTML_CONTENT:
             return common.Result(code=response.code, result=response.body.decode(common.HTML_ENCODING))
+        elif content_type == common.HTML_CONTENT_WITH_UTF8_CHARSET:
+            return common.Result(code=response.code, result=response.body.decode(common.UTF8_ENCODING))
         else:
             # Any other content-type will leave the encoding unchanged
             return common.Result(code=response.code, result=response.body)

--- a/src/inmanta/protocol/rest/client.py
+++ b/src/inmanta/protocol/rest/client.py
@@ -147,7 +147,7 @@ class RESTClient(RESTBase):
 
         if content_type is None or content_type == common.JSON_CONTENT:
             return common.Result(code=response.code, result=self._decode(response.body))
-        elif content_type == common.HTML_CONTENT:
+        elif content_type == common.HTML_CONTENT or content_type == common.HTML_CONTENT_WITH_UTF8_CHARSET:
             return common.Result(code=response.code, result=response.body.decode(common.HTML_ENCODING))
         else:
             # Any other content-type will leave the encoding unchanged

--- a/src/inmanta/protocol/rest/server.py
+++ b/src/inmanta/protocol/rest/server.py
@@ -98,8 +98,10 @@ class RESTHandler(tornado.web.RequestHandler):
     def _encode_body(self, body: ReturnTypes, content_type: str) -> Union[ReturnTypes, bytes]:
         if content_type == common.JSON_CONTENT:
             return common.json_encode(body)
-        if content_type == common.HTML_CONTENT or content_type == common.HTML_CONTENT_WITH_UTF8_CHARSET:
+        if content_type == common.HTML_CONTENT:
             return body.encode(common.HTML_ENCODING)
+        if content_type == common.HTML_CONTENT_WITH_UTF8_CHARSET:
+            return body.encode(common.UTF8_ENCODING)
         return body
 
     async def _call(self, kwargs: Dict[str, str], http_method: str, call_config: common.UrlMethod) -> None:

--- a/src/inmanta/protocol/rest/server.py
+++ b/src/inmanta/protocol/rest/server.py
@@ -98,7 +98,7 @@ class RESTHandler(tornado.web.RequestHandler):
     def _encode_body(self, body: ReturnTypes, content_type: str) -> Union[ReturnTypes, bytes]:
         if content_type == common.JSON_CONTENT:
             return common.json_encode(body)
-        if content_type == common.HTML_CONTENT:
+        if content_type == common.HTML_CONTENT or content_type == common.HTML_CONTENT_WITH_UTF8_CHARSET:
             return body.encode(common.HTML_ENCODING)
         return body
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1356,7 +1356,7 @@ async def test_html_content_type_with_utf8_encoding(unused_tcp_port, postgres_db
     """
     configure(unused_tcp_port, database_name, postgres_db.port)
 
-    html_content = "<html><body>test</body></html>".encode(encoding="utf-8")
+    html_content = "<html><body>test</body></html>"
 
     @protocol.typedmethod(path="/test", operation="GET", client_types=["api"])
     def test_method() -> ReturnValue[str]:  # NOQA


### PR DESCRIPTION
# Description

REST endpoint return value didn't get decoded if content type was html with utf-8 charset. This caused a test to fail in some instances because it expected a `str` but got a `bytes` object instead.

closes #2074

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] ~~Type annotations are present~~
- [x] ~~Code is clear and sufficiently documented~~
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] ~~Correct, in line with design~~
- [x] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
