### PR TITLE
added resource name to log lines in agent log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Extended documentation of autostarted agent settings (#2040)
 - Typing Improvements
 - Redirect stdout and stderr to /var/log/inmanta/agent.{out,err} for agent service (#2091)
+- Added resource name to log lines in agent log.
 
 
 # v 2020.2 (2020-04-24) Changes in this release:

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -327,7 +327,7 @@ class HandlerContext(object):
         else:
             exc_info = False
         log = data.LogLine.log(level, msg, **kwargs)
-        LOGGER.log(level, log._data["msg"], exc_info=exc_info)
+        self.logger.log(level, "resource %s: %s", self._resource.id.resource_version_str(), log._data["msg"], exc_info=exc_info)
         self._logs.append(log)
 
     def debug(self, msg: str, *args, **kwargs) -> None:

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -15,12 +15,14 @@
 
     Contact: code@inmanta.com
 """
+import logging
+
 import pytest
 
 from inmanta import resources
 from inmanta.agent.handler import CRUDHandler, HandlerContext, ResourcePurged
 from inmanta.resources import Id, PurgeableResource, resource
-from utils import no_error_in_logs
+from utils import log_contains, no_error_in_logs
 
 
 @pytest.mark.parametrize(
@@ -41,6 +43,7 @@ def test_CRUD_handler_purged_response(purged_desired, purged_actual, excn, creat
     """
     purged_actual and excn are conceptually equivalent, this test case serves to prove that they are in fact, equivalent
     """
+    caplog.set_level(logging.DEBUG)
 
     class DummyCrud(CRUDHandler):
         def __init__(self):
@@ -81,3 +84,4 @@ def test_CRUD_handler_purged_response(purged_desired, purged_actual, excn, creat
     assert handler.created == create
     assert handler.deleted == delete
     no_error_in_logs(caplog)
+    log_contains(caplog, "inmanta.agent.handler", logging.DEBUG, "resource aa::Aa[aa,aa=aa],v=1: Calling read_resource")


### PR DESCRIPTION
# Description

added resource name to log lines in agent log

quick fix, no issue attached

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
