### PR TITLE
fixed empty config list being read as list of empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Ensure the internal agent is always present in the autostart_agent_map of auto-started agents (#2101)
 - Cancel scheduled ResourceActions when AgentInstance is stopped (#2106)
 - Decoding of REST return value for content type html with utf-8 charset (#2074)
+- Empty list option in config no longer interpreted as list of empty string (#2097)
 
 ## Added
 - Added cleanup mechanism of old compile reports (#2054)

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -201,7 +201,7 @@ def is_bool(value: str) -> bool:
 
 def is_list(value: str) -> List[str]:
     """List of comma-separated values"""
-    return [x.strip() for x in value.split(",")]
+    return [] if value == "" else [x.strip() for x in value.split(",")]
 
 
 def is_map(map_in: str) -> Dict[str, str]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -333,3 +333,15 @@ async def test_bind_port(unused_tcp_port, async_finalizer, client, caplog):
     log_sequence = LogSequence(caplog, allow_errors=False)
     log_sequence.assert_not("py.warnings", logging.WARNING, deprecation_line_log_line)
     log_sequence.assert_not("py.warnings", logging.WARNING, ignoring_log_line)
+
+
+def test_option_is_list():
+    option: Option = Option("test", "list", "default,values", "documentation", cfg.is_list)
+    option.set("some,values")
+    assert option.get() == ["some", "values"]
+
+
+def test_option_is_list_empty():
+    option: Option = Option("test", "list", "default,values", "documentation", cfg.is_list)
+    option.set("")
+    assert option.get() == []


### PR DESCRIPTION
# Description

fixed empty config list being read as list of empty string

#2097

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
