### PR TITLE
Issue/sphinx29 list attributes reported as basetype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@
 - Redirect stdout and stderr to /var/log/inmanta/agent.{out,err} for agent service (#2091)
 - Added resource name to log lines in agent log.
 
+## Breaking changes
+- Updated Attribute.get_type() to return the full type instead of just the base type (inmanta/inmanta-sphinx#29)
+- Overriding parent attribute type with the same base type but different modifiers (e.g. override `number` with `number[]`)
+    is no longer allowed. This was previously possible due to bug (#2132)
+
 
 # v 2020.2 (2020-04-24) Changes in this release:
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -80,7 +80,7 @@ Attributes
 ----------
 
 .. autoclass:: inmanta.ast.attribute.Attribute
-    :members: validate
+    :members: validate, get_basetype, basetype, get_type, type
     :undoc-members:
 
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -80,7 +80,7 @@ Attributes
 ----------
 
 .. autoclass:: inmanta.ast.attribute.Attribute
-    :members: validate, get_basetype, basetype, get_type, type
+    :members: validate, get_type, type
     :undoc-members:
 
 
@@ -91,7 +91,7 @@ The `inmanta.ast.type` module contains a representation of inmanta types, as wel
 those types.
 
 .. autoclass:: inmanta.ast.type.Type
-    :members: validate, type_string, is_primitive
+    :members: validate, type_string, is_primitive, get_base_type, with_base_type
     :undoc-members:
 
 .. autoclass:: inmanta.ast.type.NullableType

--- a/src/inmanta/ast/attribute.py
+++ b/src/inmanta/ast/attribute.py
@@ -184,6 +184,11 @@ class RelationAttribute(Attribute):
         out.set_type(self.get_basetype())
         return out
 
+    def get_type(self) -> "Type":
+        return self.get_basetype()
+
+    type: "Type" = property(get_type)
+
     def is_optional(self) -> bool:
         return self.low == 0
 

--- a/src/inmanta/ast/attribute.py
+++ b/src/inmanta/ast/attribute.py
@@ -133,7 +133,7 @@ class Attribute(Locatable):
 
     def is_multi(self) -> bool:
         """
-            Returns true iff this attribute expects a list of values of its type.
+            Returns true iff this attribute expects a list of values of its base type.
             Deprecated but still used internally.
         """
         return self.__multi

--- a/src/inmanta/ast/attribute.py
+++ b/src/inmanta/ast/attribute.py
@@ -53,31 +53,24 @@ class Attribute(Locatable):
         self.__name: str = name
         entity.add_attribute(self)
         self.__entity = entity
-        self.__basetype = value_type
         self.__multi = multi
         self.__nullable = nullable
+
+        self.__type: Type = value_type
+        if multi:
+            self.__type = TypedList(self.__type)
+        if nullable:
+            self.__type = NullableType(self.__type)
+
         self.low = 0 if nullable else 1
         self.comment = None  # type: Optional[str]
         self.end: Optional[RelationAttribute] = None
-
-    def get_basetype(self) -> "Type":
-        """
-            Get the base type of this attribute, not taking into account modifiers such as `[]` and `?`.
-        """
-        return self.__basetype
-
-    basetype: "Type" = property(get_basetype)
 
     def get_type(self) -> "Type":
         """
             Get the type of this attribute.
         """
-        tp: Type = self.basetype
-        if self.is_multi():
-            tp = TypedList(tp)
-        if self.is_optional():
-            tp = NullableType(tp)
-        return tp
+        return self.__type
 
     type: "Type" = property(get_type)
 
@@ -117,30 +110,32 @@ class Attribute(Locatable):
         self.type.validate(value)
 
     def get_new_result_variable(self, instance: "Instance", queue: QueueScheduler) -> ResultVariable:
-        if self.__multi:
-            mytype = TypedList(self.__basetype)
-        else:
-            mytype = self.__basetype
-
         out: ResultVariable["Instance"]
 
-        if self.__nullable:
+        if self.is_optional():
             # be a 0-1 relation
             self.end = None
             self.low = 0
             self.high = 1
             out = DeprecatedOptionVariable(self, instance, queue)
-            mytype = NullableType(mytype)
         else:
             out = ResultVariable()
 
-        out.set_type(mytype)
+        out.set_type(self.type)
         return out
 
     def is_optional(self) -> bool:
+        """
+            Returns true iff this attribute accepts null values.
+            Deprecated but still used internally.
+        """
         return self.__nullable
 
     def is_multi(self) -> bool:
+        """
+            Returns true iff this attribute expects a list of values of its type.
+            Deprecated but still used internally.
+        """
         return self.__multi
 
     def final(self, excns: List[CompilerException]) -> None:
@@ -181,13 +176,8 @@ class RelationAttribute(Attribute):
             out = OptionVariable(self, instance, queue)  # type: ResultVariable
         else:
             out = ListVariable(self, instance, queue)  # type: ResultVariable
-        out.set_type(self.get_basetype())
+        out.set_type(self.type)
         return out
-
-    def get_type(self) -> "Type":
-        return self.get_basetype()
-
-    type: "Type" = property(get_type)
 
     def is_optional(self) -> bool:
         return self.low == 0

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -434,7 +434,7 @@ vm.files[path="/etc/motd"]
                 self, "short index lookup is only possible on bi-drectional relations, %s is unidirectional" % relation
             )
 
-        self.type = relation.get_basetype()
+        self.type = relation.type
 
         self.type.lookup_index(
             list(

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -434,7 +434,7 @@ vm.files[path="/etc/motd"]
                 self, "short index lookup is only possible on bi-drectional relations, %s is unidirectional" % relation
             )
 
-        self.type = relation.get_type()
+        self.type = relation.get_basetype()
 
         self.type.lookup_index(
             list(

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -227,7 +227,7 @@ class DefineEntity(TypeDefinitionStatement):
                         # allow compatible attributes
                         my_attr = add_attributes[attr_name]
 
-                        if my_attr.basetype == other_attr.basetype:
+                        if my_attr.type == other_attr.type:
                             add_attributes[attr_name] = other_attr
                         else:
                             raise DuplicateException(my_attr, other_attr, "Incompatible attributes")

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -227,7 +227,7 @@ class DefineEntity(TypeDefinitionStatement):
                         # allow compatible attributes
                         my_attr = add_attributes[attr_name]
 
-                        if my_attr.type == other_attr.type:
+                        if my_attr.basetype == other_attr.basetype:
                             add_attributes[attr_name] = other_attr
                         else:
                             raise DuplicateException(my_attr, other_attr, "Incompatible attributes")

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -172,7 +172,7 @@ class NullableType(Type):
         self.element_type.normalize()
 
     def get_base_type(self) -> Type:
-        return self.element_type
+        return self.element_type.get_base_type()
 
     def with_base_type(self, base_type: Type) -> Type:
         return NullableType(self.element_type.with_base_type(base_type))

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -123,6 +123,19 @@ class Type(Locatable):
         """
         return False
 
+    def get_base_type(self) -> "Type":
+        """
+            Returns the base type for this type, i.e. the plain type without modifiers such as expressed by
+            `[]` and `?` in the :term:`DSL`.
+        """
+        return self
+
+    def with_base_type(self, base_type: "Type") -> "Type":
+        """
+            Returns the type formed by replacing this type's base type with the supplied type.
+        """
+        return base_type
+
 
 class NamedType(Type, Named):
     def get_double_defined_exception(self, other: "NamedType") -> "DuplicateException":
@@ -135,28 +148,34 @@ class NullableType(Type):
         Represents a nullable type in the Inmanta :term:`DSL`. For example `NullableType(Number())` represents `number?`.
     """
 
-    def __init__(self, basetype: Type) -> None:
+    def __init__(self, element_type: Type) -> None:
         Type.__init__(self)
-        self.basetype: Type = basetype
+        self.element_type: Type = element_type
 
     def validate(self, value: Optional[object]) -> bool:
         if isinstance(value, NoneValue):
             return True
 
-        return self.basetype.validate(value)
+        return self.element_type.validate(value)
 
     def _wrap_type_string(self, string: str) -> str:
         return "%s?" % string
 
     def type_string(self) -> Optional[str]:
-        base_type_string: Optional[str] = self.basetype.type_string()
+        base_type_string: Optional[str] = self.element_type.type_string()
         return None if base_type_string is None else self._wrap_type_string(base_type_string)
 
     def type_string_internal(self) -> str:
-        return self._wrap_type_string(self.basetype.type_string_internal())
+        return self._wrap_type_string(self.element_type.type_string_internal())
 
     def normalize(self) -> None:
-        self.basetype.normalize()
+        self.element_type.normalize()
+
+    def get_base_type(self) -> Type:
+        return self.element_type
+
+    def with_base_type(self, base_type: Type) -> Type:
+        return NullableType(self.element_type.with_base_type(base_type))
 
 
 class Primitive(Type):
@@ -383,6 +402,12 @@ class TypedList(List):
     def get_location(self) -> Location:
         return None
 
+    def get_base_type(self) -> Type:
+        return self.element_type
+
+    def with_base_type(self, base_type: Type) -> Type:
+        return TypedList(base_type)
+
 
 class LiteralList(TypedList):
     """
@@ -395,6 +420,13 @@ class LiteralList(TypedList):
 
     def type_string(self) -> str:
         return "list"
+
+    def get_base_type(self) -> Type:
+        # The `list` type is not multi, thus it is the base type itself
+        return self
+
+    def with_base_type(self, base_type: Type) -> Type:
+        return self
 
 
 class Dict(Type):

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -618,9 +618,9 @@ class ModelExporter(object):
                 return model.DirectValue(value)
 
         def convert_attribute(attr):
-            type_string: Optional[str] = attr.type.type_string()
+            type_string: Optional[str] = attr.basetype.type_string()
             if type_string is None:
-                raise Exception("Type %s can not be represented in the inmanta DSL" % attr.type)
+                raise Exception("Type %s can not be represented in the inmanta DSL" % attr.basetype)
             return model.Attribute(
                 type_string, attr.is_optional(), attr.is_multi(), convert_comment(attr.comment), location(attr)
             )

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -618,9 +618,9 @@ class ModelExporter(object):
                 return model.DirectValue(value)
 
         def convert_attribute(attr):
-            type_string: Optional[str] = attr.basetype.type_string()
+            type_string: Optional[str] = attr.type.get_base_type().type_string()
             if type_string is None:
-                raise Exception("Type %s can not be represented in the inmanta DSL" % attr.basetype)
+                raise Exception("Type %s can not be represented in the inmanta DSL" % attr.type.get_base_type())
             return model.Attribute(
                 type_string, attr.is_optional(), attr.is_multi(), convert_comment(attr.comment), location(attr)
             )

--- a/tests/compiler/test_typing.py
+++ b/tests/compiler/test_typing.py
@@ -324,3 +324,18 @@ end
 
     assert "lst" in attrs
     assert isinstance(attrs["lst"].type, inmanta_type.List)
+
+
+@pytest.mark.parametrize("base_type", inmanta_type.TYPES.values())
+def test_types_base_type(snippetcompiler, base_type: inmanta_type.Type) -> None:
+    modified_types: typing.List[inmanta_type.Type] = [
+        base_type,
+        inmanta_type.TypedList(base_type),
+        inmanta_type.NullableType(base_type),
+        inmanta_type.NullableType(inmanta_type.TypedList(base_type)),
+    ]
+    for t in modified_types:
+        # verify get_base_type returns the inmanta base type
+        assert t.get_base_type().type_string() == base_type.type_string()
+        # verify with_base_type is round-trip compatible
+        assert t.with_base_type(base_type).type_string() == t.type_string()

--- a/tests/compiler/test_typing.py
+++ b/tests/compiler/test_typing.py
@@ -259,3 +259,21 @@ int("0.0")
         """,
         "Failed to cast '0.0' to int (reported in int('0.0') ({dir}/main.cf:2))",
     )
+
+
+@pytest.mark.parametrize(
+    "parent_modifier,child_modifier", [("[]", ""), ("", "[]"), ("?", ""), ("", "?"),],
+)
+def test_2132_inheritance_type_override(snippetcompiler, parent_modifier: str, child_modifier: str):
+    snippetcompiler.setup_for_error(
+        f"""
+entity Parent:
+    number{parent_modifier} n
+end
+
+entity Child extends Parent:
+    number{child_modifier} n
+end
+        """,
+        "Incompatible attributes (original at ({dir}/main.cf:7)) (duplicate at ({dir}/main.cf:3))",
+    )

--- a/tests/compiler/test_typing.py
+++ b/tests/compiler/test_typing.py
@@ -16,8 +16,9 @@
     Contact: code@inmanta.com
 """
 
-import pytest
 import typing
+
+import pytest
 
 import inmanta.ast.type as inmanta_type
 import inmanta.compiler as compiler

--- a/tests/compiler/test_typing.py
+++ b/tests/compiler/test_typing.py
@@ -17,9 +17,13 @@
 """
 
 import pytest
+import typing
 
+import inmanta.ast.type as inmanta_type
 import inmanta.compiler as compiler
 from inmanta.ast import AttributeException, Namespace, TypingException
+from inmanta.ast.attribute import Attribute
+from inmanta.ast.entity import Entity
 from inmanta.ast.type import Bool, Integer, Number, String
 
 
@@ -262,9 +266,9 @@ int("0.0")
 
 
 @pytest.mark.parametrize(
-    "parent_modifier,child_modifier", [("[]", ""), ("", "[]"), ("?", ""), ("", "?"),],
+    "parent_modifier,child_modifier", [("[]", ""), ("", "[]"), ("?", ""), ("", "?")],
 )
-def test_2132_inheritance_type_override(snippetcompiler, parent_modifier: str, child_modifier: str):
+def test_2132_inheritance_type_override(snippetcompiler, parent_modifier: str, child_modifier: str) -> None:
     snippetcompiler.setup_for_error(
         f"""
 entity Parent:
@@ -277,3 +281,46 @@ end
         """,
         "Incompatible attributes (original at ({dir}/main.cf:7)) (duplicate at ({dir}/main.cf:3))",
     )
+
+
+def test_attribute_type(snippetcompiler) -> None:
+    snippetcompiler.setup_for_snippet(
+        """
+entity A:
+    number n
+    number[] ns
+    number? maybe_n
+    number[]? maybe_ns
+    list lst
+end
+        """,
+    )
+    types: typing.Dict[str, inmanta_type.Type]
+    (types, scopes) = compiler.do_compile()
+    assert "__config__::A" in types
+    entity = types["__config__::A"]
+    assert isinstance(entity, Entity)
+    attrs: typing.Dict[str, Attribute] = entity.get_attributes()
+
+    assert "n" in attrs
+    assert isinstance(attrs["n"].type, Number)
+
+    assert "ns" in attrs
+    ns_type: inmanta_type.Type = attrs["ns"].type
+    assert isinstance(ns_type, inmanta_type.TypedList)
+    assert isinstance(ns_type.element_type, Number)
+
+    assert "maybe_n" in attrs
+    maybe_n_type: inmanta_type.Type = attrs["maybe_n"].type
+    assert isinstance(maybe_n_type, inmanta_type.NullableType)
+    assert isinstance(maybe_n_type.element_type, Number)
+
+    assert "maybe_ns" in attrs
+    maybe_ns_type: inmanta_type.Type = attrs["maybe_ns"].type
+    assert isinstance(maybe_ns_type, inmanta_type.NullableType)
+    maybe_ns_element_type: inmanta_type.Type = maybe_ns_type.element_type
+    assert isinstance(maybe_ns_element_type, inmanta_type.TypedList)
+    assert isinstance(maybe_ns_element_type.element_type, Number)
+
+    assert "lst" in attrs
+    assert isinstance(attrs["lst"].type, inmanta_type.List)


### PR DESCRIPTION
# Description

Updates `Attribute.get_type()` to return the full type instead of just the base type. Adds `get_base_type()` and `with_base_type(base_type)` methods to `inmanta.ast.type.Type` to be used in the `lsm` module etc.

closes inmanta/inmanta-sphinx#29
closes #2132

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
