### PR TITLE
added test cases for session events on agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Redirect stdout and stderr to /var/log/inmanta/agent.{out,err} for agent service (#2091)
 - Added resource name to log lines in agent log.
 - Better reporting of json decoding errors on requests (#2107)
+- Faster recovery of agent sessions 
 
 ## Breaking changes
 - Updated Attribute.get_type() to return the full type instead of just the base type (inmanta/inmanta-sphinx#29)

--- a/src/inmanta/protocol/endpoints.py
+++ b/src/inmanta/protocol/endpoints.py
@@ -202,9 +202,16 @@ class SessionEndpoint(Endpoint, CallTarget):
         await super(SessionEndpoint, self).stop()
 
     async def on_reconnect(self) -> None:
+        """
+        Called when a connection becomes active. i.e. when a first heartbeat is received after startup or
+        a first hearbeat after an :py:`on_disconnect`
+        """
         pass
 
     async def on_disconnect(self) -> None:
+        """
+        Called when the connection is lost unexpectedly (not on shutdown)
+        """
         pass
 
     async def perform_heartbeat(self) -> None:
@@ -223,6 +230,7 @@ class SessionEndpoint(Endpoint, CallTarget):
                     tid=str(self._env_id),
                     endpoint_names=list(self.end_point_names),
                     nodename=self.node_name,
+                    no_hang=not connected,
                 )
                 LOGGER.log(3, "returned heartbeat for %s", str(self.sessionid))
                 if result.code == 200:

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -280,7 +280,7 @@ def clear_environment(id: uuid.UUID):
     arg_options=ENV_OPTS,
     client_types=[const.ClientType.agent],
 )
-def heartbeat(sid: uuid.UUID, tid: uuid.UUID, endpoint_names: list, nodename: str):
+def heartbeat(sid: uuid.UUID, tid: uuid.UUID, endpoint_names: list, nodename: str, no_hang: bool = False):
     """
         Send a heartbeat to the server
 
@@ -288,6 +288,7 @@ def heartbeat(sid: uuid.UUID, tid: uuid.UUID, endpoint_names: list, nodename: st
         :param tid: The environment this node and its agents belongs to
         :param endpoint_names: The names of the endpoints on this node
         :param nodename: The name of the node from which the heart beat comes
+        :param no_hang: don't use this call for long polling, but for connectivity check
 
         also registered as API method, because it is called with an invalid SID the first time
     """

--- a/tests/test_2way_protocol.py
+++ b/tests/test_2way_protocol.py
@@ -242,11 +242,11 @@ async def test_server_timeout(unused_tcp_port, no_tid_check, async_finalizer, po
     await agent.start()
     async_finalizer(agent.stop)
 
-    await assert_agent_counter(agent, 1, 0)
-
     # wait till up
     await retry_limited(lambda: len(server.get_sessions()) == 1, 10)
     assert len(server.get_sessions()) == 1
+
+    await assert_agent_counter(agent, 1, 0)
 
     await rs.stop()
 


### PR DESCRIPTION
# Description
added test cases for session events on agent

also discovered that re-connection is delayed with one
longpoll interval if the agent considered the session expired,
but the server doesn't.

This potentially rare, so perhaps we should not specially handle this.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [] ~~Attached issue to pull request~~
- [X] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
