### PR TITLE
added merging of compiles when added to compile queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Decoding of REST return value for content type html with utf-8 charset (#2074)
 - Empty list option in config no longer interpreted as list of empty string (#2097)
 - Correct closing of agentcache
-- Agent cross environment communication bug (#2163) 
+- Agent cross environment communication bug (#2163)
 - Fixed an issue where an argument missing from a request would result in a http-500 error instead of 400 (#2152)
 
 ## Added
@@ -30,6 +30,7 @@
 - Redirect stdout and stderr to /var/log/inmanta/agent.{out,err} for agent service (#2091)
 - Added resource name to log lines in agent log.
 - Better reporting of json decoding errors on requests (#2107)
+- Added merging of similar compile requests to the compile queue (#2137)
 
 ## Breaking changes
 - Updated Attribute.get_type() to return the full type instead of just the base type (inmanta/inmanta-sphinx#29)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pytest-xdist==1.32.0
 pytest==5.4.3
 python-dateutil==2.8.1
 pyyaml==5.3.1
-pytest-timeout==1.3.4
+pytest-timeout==1.4.0
 six==1.15.0
 sphinx-argparse==0.2.5
 sphinx-autodoc-annotation==1.0-1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ cryptography==2.9.2
 execnet==1.7.1
 graphviz==0.14
 inmanta-sphinx>=1.0.0
+more_itertools==8.4.0
 netifaces==0.10.9
 ply==3.11
 pytest-cover==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ cryptography==2.9.2
 execnet==1.7.1
 graphviz==0.14
 inmanta-sphinx>=1.0.0
-more_itertools==8.4.0
 netifaces==0.10.9
 ply==3.11
 pytest-cover==3.0.0

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1396,7 +1396,7 @@ class Compile(BaseDocument):
         :param do_export: should this compiler perform an export
         :param force_update: should this compile definitely update
         :param metadata: exporter metadata to be passed to the compiler
-        :param environment_variable: environment variables to be passed to the compiler
+        :param environment_variables: environment variables to be passed to the compiler
         :param succes: was the compile successful
         :param handled: were all registered handlers executed?
         :param version: version exported by this compile

--- a/src/inmanta/db/versions/v5.py
+++ b/src/inmanta/db/versions/v5.py
@@ -17,8 +17,14 @@
 """
 from asyncpg import Connection
 
-DISABLED = True
+DISABLED = False
 
 
 async def update(connection: Connection) -> None:
-    await connection.execute("")
+    await connection.execute(
+        """
+-- Compile queue might be collapsed if it contains similar compile requests.
+-- In that case, substitute_compile_id will reference the actually compiled request.
+ALTER TABLE public.compile ADD COLUMN substitute_compile_id uuid REFERENCES public.compile (id);
+        """
+    )

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -459,10 +459,11 @@ class CompilerService(ServerSlice):
             )
         await asyncio.sleep(wait)
 
+        compile_merge_key: Hashable = CompilerService._compile_merge_key(compile)
         merge_candidates: List[data.Compile] = [
             c
             for c in await data.Compile.get_next_compiles_for_environment(compile.environment)
-            if not c.id == compile.id and CompilerService._compile_merge_key(c) == CompilerService._compile_merge_key(compile)
+            if not c.id == compile.id and CompilerService._compile_merge_key(c) == compile_merge_key
         ]
         # set force_update == True iff any compile request has force_update == True
         force_update: bool = any(c.force_update for c in chain([compile], merge_candidates))

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -29,12 +29,12 @@ import uuid
 from asyncio import CancelledError, Task
 from itertools import chain
 from logging import Logger
+from more_itertools import unique_everseen
 from tempfile import NamedTemporaryFile
 from typing import Dict, Hashable, List, Optional, Tuple, cast
 
 import dateutil
 import dateutil.parser
-from more_itertools import unique_everseen
 
 import inmanta.data.model as model
 from inmanta import config, const, data, protocol, server

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -388,7 +388,7 @@ class CompilerService(ServerSlice):
 
     @staticmethod
     def _compile_merge_key(c: data.Compile) -> Hashable:
-        return c.to_dto().json(include={"environment", "do_export", "environment_variables"})
+        return c.to_dto().json(include={"environment", "started", "do_export", "environment_variables"})
 
     async def _queue(self, compile: data.Compile) -> None:
         async with self._global_lock:

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -30,7 +30,7 @@ from asyncio import CancelledError, Task
 from itertools import chain
 from logging import Logger
 from tempfile import NamedTemporaryFile
-from typing import Dict, Hashable, List, Optional, Tuple, TypeVar, cast
+from typing import Dict, Hashable, List, Optional, Tuple, cast
 
 import dateutil
 import dateutil.parser
@@ -471,10 +471,11 @@ class CompilerService(ServerSlice):
         end = datetime.datetime.now()
         await compile.update_fields(completed=end, success=success, version=version)
         awaitables = [
-            merge_candidate.update_fields(started=compile.started, completed=end, success=success, version=version)
+            merge_candidate.update_fields(
+                started=compile.started, completed=end, success=success, version=version, substitute_compile_id=compile.id
+            )
             for merge_candidate in merge_candidates
         ]
-        # TODO: attach report somehow
         await asyncio.gather(*awaitables)
         if self.is_stopping():
             return

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -29,7 +29,6 @@ import uuid
 from asyncio import CancelledError, Task
 from itertools import chain
 from logging import Logger
-from more_itertools import unique_everseen
 from tempfile import NamedTemporaryFile
 from typing import Dict, Hashable, List, Optional, Tuple, cast
 
@@ -44,6 +43,7 @@ from inmanta.server import config as opt
 from inmanta.server.protocol import ServerSlice
 from inmanta.types import Apireturn, ArgumentTypes, JsonType, Warnings
 from inmanta.util import ensure_directory_exist
+from more_itertools import unique_everseen
 
 RETURNCODE_INTERNAL_ERROR = -1
 

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -43,7 +43,6 @@ from inmanta.server import config as opt
 from inmanta.server.protocol import ServerSlice
 from inmanta.types import Apireturn, ArgumentTypes, JsonType, Warnings
 from inmanta.util import ensure_directory_exist
-from more_itertools import unique_everseen
 
 RETURNCODE_INTERNAL_ERROR = -1
 
@@ -532,4 +531,4 @@ class CompilerService(ServerSlice):
             Get the current compiler queue on the server
         """
         compiles = await data.Compile.get_next_compiles_for_environment(env.id)
-        return [x.to_dto() for x in unique_everseen(compiles, CompilerService._compile_merge_key)]
+        return [x.to_dto() for x in compiles]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -931,7 +931,7 @@ class CompileRunnerMock(object):
         self._runner_queue = runner_queue
         self.block = False
 
-    async def run(self) -> bool:
+    async def run(self, force_update: Optional[bool] = False) -> bool:
         now = datetime.datetime.now()
         returncode = 1 if self._make_compile_fail else 0
         report = data.Report(

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -136,7 +136,8 @@ async def test_scheduler(server_config, init_dataclasses_and_load_schema, caplog
     async def request_compile(env: data.Environment) -> uuid.UUID:
         """Request compile for given env, return remote_id"""
         u1 = uuid.uuid4()
-        await cs.request_recompile(env, False, False, u1)
+        # add unique environment variables to prevent merging in request_recompile
+        await cs.request_recompile(env, False, False, u1, env_vars={"uuid": u1})
         results = await data.Compile.get_by_remote_id(env.id, u1)
         assert len(results) == 1
         assert results[0].remote_id == u1

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -23,7 +23,7 @@ import shutil
 import subprocess
 import uuid
 from asyncio import Semaphore
-from typing import List
+from typing import List, Optional
 
 import pytest
 
@@ -98,7 +98,7 @@ async def test_scheduler(server_config, init_dataclasses_and_load_schema, caplog
             self.done = False
             self.version = None
 
-        async def run(self):
+        async def run(self, force_update: Optional[bool] = False):
             self.started = True
             await self.lock.acquire()
             self.done = True

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -400,9 +400,9 @@ async def test_e2e_recompile_failure(compilerservice: CompilerService):
     await env.insert()
 
     u1 = uuid.uuid4()
-    await compilerservice.request_recompile(env, False, False, u1)
+    await compilerservice.request_recompile(env, False, False, u1, env_vars={"my_unique_var": str(u1)})
     u2 = uuid.uuid4()
-    await compilerservice.request_recompile(env, False, False, u2)
+    await compilerservice.request_recompile(env, False, False, u2, env_vars={"my_unique_var": str(u2)})
 
     assert await compilerservice.is_compiling(env.id) == 200
 


### PR DESCRIPTION
# Description

Remedies the filling of the compile queue with a lot of very similar compiles by merging them into one.

closes #2137

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
