### PR TITLE
removed unneeded warning (#2125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Agent cross environment communication bug (#2163)
 - Fixed an issue where an argument missing from a request would result in a http-500 error instead of 400 (#2152)
 - Ensure agent is in proper state after URI change (#2138)
+- Removed warning about collecting requirements for project that has not been loaded completely on initial compile (#2125)
 
 ## Added
 - Added cleanup mechanism of old compile reports (#2054)

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -614,9 +614,6 @@ class Project(ModuleLike):
         """
             Collect the list of all requirements of all modules in the project.
         """
-        if not self.loaded:
-            LOGGER.warning("collecting requirements on project that has not been loaded completely")
-
         specs = {}  # type: Dict[str, List[Requirement]]
         merge_specs(specs, self.requires())
         for module in self.modules.values():


### PR DESCRIPTION
# Description

removed warning about collecting requirements for project that has not been loaded completely on initial compile

closes #2125

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- ~~[x] Type annotations are present~~
- ~~[x] Code is clear and sufficiently documented~~
- ~~[x] No (preventable) type errors (check using make mypy or make mypy-diff)~~
- ~~[x] Sufficient test cases (reproduces the bug/tests the requested feature)~~
- ~~[x] Correct, in line with design~~
- ~~[x] End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
