### PR TITLE
Pin inmanta-sphinx dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ cookiecutter==1.7.2
 cryptography==2.9.2
 execnet==1.7.1
 graphviz==0.14
-inmanta-sphinx>=1.0.0
+inmanta-sphinx==1.3.0
 netifaces==0.10.9
 ply==3.11
 pytest-cover==3.0.0


### PR DESCRIPTION
# Description

Pin the inmanta-sphinx dependency. This is required to make the documentation builds of releases repeatable.