### PR TITLE
Added documentation on regex matching in regex-based typedefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New features
 - Added merging of similar compile requests to the compile queue (#2137)
 - Export all handler's / resource's module's plugin source files so helper functions can be used from sibling modules (#2162)
+- Added documentation on how a string is matched against a regex defined in a regex-based typedef (#2214)
 
 ## Bug fixes
 - Restore support to pass mocking information to the compiler

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -128,6 +128,9 @@ Constrained primitive types add additional constraints to the basic primitive ty
 :ref:`condition<lang-conditions>`. The name of the constrained primitive type must not collide with the name of a variable or
 type in the same lexical scope.
 
+A regex matches a given string when zero or more characters at the beginning of that string match the regular expression. A
+dollar sign should be used at the end of the regex if a full string match is required.
+
 .. code-block:: antlr
 
     typedef : 'typedef' ID 'as' PRIMITIVE 'matching' condition|regex;


### PR DESCRIPTION
# Description

Added documentation on how a string is matched against a regex defined in a regex-based typedef.

closes #2214 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [x] End user documentation is included or an issue is created for end-user documentation

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
