### PR TITLE
Issue/2253 resource action log via cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added merging of similar compile requests to the compile queue (#2137)
 - Export all handler's / resource's module's plugin source files so helper functions can be used from sibling modules (#2162)
 - Added documentation on how a string is matched against a regex defined in a regex-based typedef (#2214)
+- Added support to query the resource action log of a resource via the CLI (#2253)
 
 ## Bug fixes
 - Restore support to pass mocking information to the compiler

--- a/src/inmanta/main.py
+++ b/src/inmanta/main.py
@@ -22,7 +22,7 @@ import os
 import uuid
 from collections import defaultdict
 from time import sleep
-from typing import Callable, Dict, List, Optional, cast
+from typing import Callable, Dict, List, Optional, cast, Any, Union
 
 import click
 import texttable
@@ -91,11 +91,11 @@ class Client(object):
 
             raise Exception(("An error occurred while requesting %s" % key_name) + msg)
 
-    def get_list(self, method_name: str, key_name: Optional[str] = None, arguments: JsonType = {}) -> List[Dict[str, str]]:
+    def get_list(self, method_name: str, key_name: Optional[str] = None, arguments: JsonType = {}) -> List[Dict[str, Any]]:
         """
             Same as do request, but return type is a list of dicts
         """
-        return cast(List[Dict[str, str]], self.do_request(method_name, key_name, arguments, False))
+        return cast(List[Dict[str, Any]], self.do_request(method_name, key_name, arguments, False))
 
     def get_dict(self, method_name: str, key_name: Optional[str] = None, arguments: JsonType = {}) -> Dict[str, str]:
         """
@@ -807,15 +807,12 @@ def resource_action_log(ctx: click.Context) -> None:
     pass
 
 
-def validate_resource_version_id(ctx: click.Context, param: str, value: str) -> ResourceVersionIdStr:
-    try:
-        rvid = Id.parse_id(value)
-    except Exception:
+def validate_resource_version_id(
+    ctx: click.Context, option: Union[click.Option, click.Parameter], value: Any
+) -> ResourceVersionIdStr:
+    if not Id.is_resource_version_id(value):
         raise click.BadParameter(value)
-    if rvid.resource_version_str() != value:
-        raise click.BadParameter(f"Version is missing in resource version id ({value})")
-    else:
-        return value
+    return value
 
 
 @resource_action_log.command(name="list")

--- a/src/inmanta/main.py
+++ b/src/inmanta/main.py
@@ -823,10 +823,10 @@ def validate_resource_version_id(
 @click.option("--action", help="Only list this resource action", type=click.Choice([ra.value for ra in ResourceAction]))
 @click.pass_obj
 def resource_action_log_list(client: Client, environment: str, rvid: ResourceVersionIdStr, action: Optional[str]) -> None:
-    tid = client.to_environment_id(environment)
     """
         List the resource action log for a specific Resource.
     """
+    tid = client.to_environment_id(environment)
     ra_logs = client.get_list("get_resource", "logs", arguments=dict(tid=tid, id=rvid, logs=True, log_action=action))
     headers = ["Action ID", "Action", "Started", "Finished", "Status"]
     rows = [[log["action_id"], log["action"], log["started"], log["finished"], log.get("status", "")] for log in ra_logs]

--- a/src/inmanta/main.py
+++ b/src/inmanta/main.py
@@ -821,20 +821,11 @@ def validate_resource_version_id(ctx: click.Context, param: str, value: str) -> 
 @resource_action_log.command(name="list")
 @click.option("--environment", "-e", help="The ID or name of the environment to use", required=True)
 @click.option(
-    "--rvid",
-    help="The resource version ID of the resource",
-    callback=validate_resource_version_id,
-    required=True,
+    "--rvid", help="The resource version ID of the resource", callback=validate_resource_version_id, required=True,
 )
-@click.option(
-    "--action",
-    help="Only list this resource action",
-    type=click.Choice([ra.value for ra in ResourceAction])
-)
+@click.option("--action", help="Only list this resource action", type=click.Choice([ra.value for ra in ResourceAction]))
 @click.pass_obj
-def resource_action_log_list(
-    client: Client, environment: str, rvid: ResourceVersionIdStr, action: Optional[str]
-) -> None:
+def resource_action_log_list(client: Client, environment: str, rvid: ResourceVersionIdStr, action: Optional[str]) -> None:
     tid = client.to_environment_id(environment)
     """
         List the resource action log for a specific Resource.
@@ -851,24 +842,18 @@ def resource_action_log_list(
 @resource_action_log.command(name="show-messages")
 @click.option("--environment", "-e", help="The ID or name of the environment to use", required=True)
 @click.option(
-    "--rvid",
-    help="The resource version ID of the resource",
-    callback=validate_resource_version_id,
-    required=True,
+    "--rvid", help="The resource version ID of the resource", callback=validate_resource_version_id, required=True,
 )
 @click.option("--action-id", type=click.UUID, help="The ID of the resource action record", required=True)
 @click.pass_obj
-def resource_action_log_show(
-    client: Client, environment: str, rvid: ResourceVersionIdStr, action_id: uuid.UUID
-) -> None:
+def resource_action_log_show(client: Client, environment: str, rvid: ResourceVersionIdStr, action_id: uuid.UUID) -> None:
     """
         Show the log messages for a specific entry in the resource action log.
     """
     tid = client.to_environment_id(environment)
     action_logs = [
         action_log
-        for action_log
-        in client.get_list("get_resource", "logs", arguments=dict(tid=tid, id=rvid, logs=True))
+        for action_log in client.get_list("get_resource", "logs", arguments=dict(tid=tid, id=rvid, logs=True))
         if action_log["action_id"] == str(action_id)
     ]
     if not action_logs:

--- a/src/inmanta/main.py
+++ b/src/inmanta/main.py
@@ -22,7 +22,7 @@ import os
 import uuid
 from collections import defaultdict
 from time import sleep
-from typing import Callable, Dict, List, Optional, cast, Any, Union
+from typing import Any, Callable, Dict, List, Optional, Union, cast
 
 import click
 import texttable

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -476,6 +476,11 @@ PARSE_ID_REGEX = re.compile(
     r"(?P<attr>[^=]+)=(?P<value>[^\]]+)\])(,v=(?P<version>[0-9]+))?$"
 )
 
+PARSE_RVID_REGEX = re.compile(
+    r"^(?P<id>(?P<type>(?P<ns>[\w-]+::)+(?P<class>[\w-]+))\[(?P<hostname>[^,]+),"
+    r"(?P<attr>[^=]+)=(?P<value>[^\]]+)\]),v=(?P<version>[0-9]+)$"
+)
+
 
 class Id(object):
     """
@@ -599,6 +604,14 @@ class Id(object):
 
         id_obj = Id(parts["type"], parts["hostname"], parts["attr"], parts["value"], version)
         return id_obj
+
+    @classmethod
+    def is_resource_version_id(cls, value: str) -> bool:
+        """
+            Check whether the given value is a resource version id
+        """
+        result = PARSE_RVID_REGEX.search(value)
+        return result is not None
 
     entity_type = property(get_entity_type)
     agent_name = property(get_agent_name)

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -472,12 +472,12 @@ class ManagedResource(Resource):
 
 
 PARSE_ID_REGEX = re.compile(
-    r"^(?P<id>(?P<type>(?P<ns>[\w-]+::)+(?P<class>[\w-]+))\[(?P<hostname>[^,]+),"
+    r"^(?P<id>(?P<type>(?P<ns>[\w-]+(::[\w-]+)*)::(?P<class>[\w-]+))\[(?P<hostname>[^,]+),"
     r"(?P<attr>[^=]+)=(?P<value>[^\]]+)\])(,v=(?P<version>[0-9]+))?$"
 )
 
 PARSE_RVID_REGEX = re.compile(
-    r"^(?P<id>(?P<type>(?P<ns>[\w-]+::)+(?P<class>[\w-]+))\[(?P<hostname>[^,]+),"
+    r"^(?P<id>(?P<type>(?P<ns>[\w-]+(::[\w-]+)*)::(?P<class>[\w-]+))\[(?P<hostname>[^,]+),"
     r"(?P<attr>[^=]+)=(?P<value>[^\]]+)\]),v=(?P<version>[0-9]+)$"
 )
 

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -479,7 +479,7 @@ PARSE_ID_REGEX = re.compile(
 
 class Id(object):
     """
-        A unique id that idenfies a resource that is managed by an agent
+        A unique id that identifies a resource that is managed by an agent
     """
 
     def __init__(self, entity_type: str, agent_name: str, attribute: str, attribute_value: str, version: int = 0) -> None:

--- a/tests/agent_server/conftest.py
+++ b/tests/agent_server/conftest.py
@@ -55,17 +55,6 @@ async def stop_agent(server, agent):
     await retry_limited(lambda: len(agentmanager.sessions) == prelen - 1, 10)
 
 
-def get_resource(version, key="key1", agent="agent1", value="value1"):
-    return {
-        "key": key,
-        "value": value,
-        "id": f"test::Resource[{agent},key={key}],v=%d" % version,
-        "send_event": False,
-        "purged": False,
-        "requires": [],
-    }
-
-
 async def _deploy_resources(client, environment, resources, version, push, agent_trigger_method=None):
     result = await client.put_version(
         tid=environment,

--- a/tests/agent_server/test_agent_timeout.py
+++ b/tests/agent_server/test_agent_timeout.py
@@ -21,7 +21,7 @@ import pytest
 
 from agent_server.conftest import get_agent
 from inmanta import config
-from utils import log_index, retry_limited, get_resource
+from utils import get_resource, log_index, retry_limited
 
 
 @pytest.mark.asyncio

--- a/tests/agent_server/test_agent_timeout.py
+++ b/tests/agent_server/test_agent_timeout.py
@@ -19,9 +19,9 @@ import logging
 
 import pytest
 
-from agent_server.conftest import get_agent, get_resource
+from agent_server.conftest import get_agent
 from inmanta import config
-from utils import log_index, retry_limited
+from utils import log_index, retry_limited, get_resource
 
 
 @pytest.mark.asyncio

--- a/tests/agent_server/test_deploy_trigger.py
+++ b/tests/agent_server/test_deploy_trigger.py
@@ -20,7 +20,7 @@ import logging
 import pytest
 
 from agent_server.conftest import _deploy_resources, get_agent
-from utils import log_contains, log_doesnt_contain, retry_limited, get_resource
+from utils import get_resource, log_contains, log_doesnt_contain, retry_limited
 
 
 @pytest.mark.asyncio(timeout=150)

--- a/tests/agent_server/test_deploy_trigger.py
+++ b/tests/agent_server/test_deploy_trigger.py
@@ -19,8 +19,8 @@ import logging
 
 import pytest
 
-from agent_server.conftest import _deploy_resources, get_agent, get_resource
-from utils import log_contains, log_doesnt_contain, retry_limited
+from agent_server.conftest import _deploy_resources, get_agent
+from utils import log_contains, log_doesnt_contain, retry_limited, get_resource
 
 
 @pytest.mark.asyncio(timeout=150)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -979,3 +979,14 @@ async def mocked_compiler_service_block(server, monkeypatch):
     monkey_patch_compiler_service(monkeypatch, server, True, runner_queue)
 
     yield runner_queue
+
+
+def get_resource(version, key="key1", agent="agent1", value="value1"):
+    return {
+        "key": key,
+        "value": value,
+        "id": f"test::Resource[{agent},key={key}],v=%d" % version,
+        "send_event": False,
+        "purged": False,
+        "requires": [],
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -979,14 +979,3 @@ async def mocked_compiler_service_block(server, monkeypatch):
     monkey_patch_compiler_service(monkeypatch, server, True, runner_queue)
 
     yield runner_queue
-
-
-def get_resource(version, key="key1", agent="agent1", value="value1"):
-    return {
-        "key": key,
-        "value": value,
-        "id": f"test::Resource[{agent},key={key}],v=%d" % version,
-        "send_event": False,
-        "purged": False,
-        "requires": [],
-    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,7 @@ import pytest
 from inmanta import data
 from inmanta.const import Change, ResourceAction, ResourceState
 from inmanta.util import get_compiler_version
-from utils import log_contains, get_resource
+from utils import get_resource, log_contains
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -419,7 +419,7 @@ async def test_list_actionlog(server, environment, client, cli, agent, clienthel
     resource_id = resource1["id"].rsplit(",", maxsplit=1)[0]
     result = await cli.run("action-log", "list", "-e", str(environment), "--rvid", resource_id)
     assert result.exit_code != 0
-    assert "Invalid value for '--rvid': Version is missing in resource version id" in result.stderr
+    assert f"Invalid value for '--rvid': {resource_id}" in result.stderr
 
     # Incorrect format resource version id
     result = await cli.run("action-log", "list", "-e", str(environment), "--rvid", "test")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -344,6 +344,7 @@ async def test_list_actionlog(server, environment, client, cli, agent, clienthel
     """
         Test the `inmanta-cli action-log list` command.
     """
+
     def assert_nr_records_in_output_table(output: str, nr_records: int) -> None:
         lines = [line.strip() for line in output.split("\n") if line.strip() and line.strip().startswith("|")]
         actual_nr_of_records = len(lines) - 1  # Exclude the header

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -341,6 +341,9 @@ async def test_pause_agent(server, cli):
 
 @pytest.mark.asyncio
 async def test_list_actionlog(server, environment, client, cli, agent, clienthelper):
+    """
+        Test the `inmanta-cli action-log list` command.
+    """
     def assert_nr_records_in_output_table(output: str, nr_records: int) -> None:
         lines = [line.strip() for line in output.split("\n") if line.strip() and line.strip().startswith("|")]
         actual_nr_of_records = len(lines) - 1  # Exclude the header
@@ -428,6 +431,9 @@ async def test_list_actionlog(server, environment, client, cli, agent, clienthel
 
 @pytest.mark.asyncio
 async def test_show_messages_actionlog(server, environment, client, cli, agent, clienthelper):
+    """
+        Test the `inmanta-cli action-log show-messages` command.
+    """
     result = await client.reserve_version(tid=environment)
     assert result.code == 200
     version = result.result["data"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@
 
     Contact: code@inmanta.com
 """
+import datetime
 import logging
 import os
 import uuid
@@ -22,12 +23,11 @@ from typing import Dict
 
 import pytest
 
-import datetime
+from conftest import get_resource
 from inmanta import data
+from inmanta.const import Change, ResourceAction, ResourceState
 from inmanta.util import get_compiler_version
 from utils import log_contains
-from inmanta.const import ResourceAction, ResourceState, Change
-from conftest import get_resource
 
 
 @pytest.mark.asyncio
@@ -375,12 +375,12 @@ async def test_list_actionlog(server, environment, client, cli, agent, clienthel
                 "msg": "Deployment failed",
                 "timestamp": datetime.datetime.now().isoformat(timespec="microseconds"),
                 "args": [],
-                "status": ResourceState.failed.value
+                "status": ResourceState.failed.value,
             },
         ],
         changes={},
         change=Change.nochange,
-        send_events=False
+        send_events=False,
     )
     assert result.code == 200
     result = await agent._client.resource_action_update(
@@ -401,7 +401,7 @@ async def test_list_actionlog(server, environment, client, cli, agent, clienthel
         ],
         changes={},
         change=Change.nochange,
-        send_events=False
+        send_events=False,
     )
     assert result.code == 200
 
@@ -411,9 +411,7 @@ async def test_list_actionlog(server, environment, client, cli, agent, clienthel
     assert_nr_records_in_output_table(result.output, nr_records=2)  # 1 store action + 1 deploy action
 
     # Get deploy resource actions for resource1
-    result = await cli.run(
-        "action-log", "list", "-e", str(environment), "--rvid", resource1["id"], "--action", "deploy"
-    )
+    result = await cli.run("action-log", "list", "-e", str(environment), "--rvid", resource1["id"], "--action", "deploy")
     assert result.exit_code == 0
     assert_nr_records_in_output_table(result.output, nr_records=1)  # 1 deploy action
 
@@ -462,7 +460,7 @@ async def test_show_messages_actionlog(server, environment, client, cli, agent, 
         ],
         changes={},
         change=Change.nochange,
-        send_events=False
+        send_events=False,
     )
     assert result.code == 200
 
@@ -473,14 +471,7 @@ async def test_show_messages_actionlog(server, environment, client, cli, agent, 
     action_id = result.result["logs"][0]["action_id"]
 
     result = await cli.run(
-        "action-log",
-        "show-messages",
-        "-e",
-        str(environment),
-        "--rvid",
-        resource1["id"],
-        "--action-id",
-        str(action_id)
+        "action-log", "show-messages", "-e", str(environment), "--rvid", resource1["id"], "--action-id", str(action_id)
     )
     assert result.exit_code == 0
     assert "DEBUG Started deployment" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,11 +23,10 @@ from typing import Dict
 
 import pytest
 
-from conftest import get_resource
 from inmanta import data
 from inmanta.const import Change, ResourceAction, ResourceState
 from inmanta.util import get_compiler_version
-from utils import log_contains
+from utils import log_contains, get_resource
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,9 +22,12 @@ from typing import Dict
 
 import pytest
 
+import datetime
 from inmanta import data
 from inmanta.util import get_compiler_version
 from utils import log_contains
+from inmanta.const import ResourceAction, ResourceState, Change
+from conftest import get_resource
 
 
 @pytest.mark.asyncio
@@ -335,3 +338,150 @@ async def test_pause_agent(server, cli):
     for action in ["pause", "unpause"]:
         result = await cli.run("agent", action, "-e", str(env1.id))
         assert result.exit_code != 0
+
+
+@pytest.mark.asyncio
+async def test_list_actionlog(server, environment, client, cli, agent, clienthelper):
+    def assert_nr_records_in_output_table(output: str, nr_records: int) -> None:
+        lines = [line.strip() for line in output.split("\n") if line.strip() and line.strip().startswith("|")]
+        actual_nr_of_records = len(lines) - 1  # Exclude the header
+        assert nr_records == actual_nr_of_records
+
+    result = await client.reserve_version(tid=environment)
+    assert result.code == 200
+    version = result.result["data"]
+
+    resource1 = get_resource(version, key="test1")
+    resource2 = get_resource(version, key="test2")
+    await clienthelper.put_version_simple(resources=[resource1, resource2], version=version)
+
+    result = await agent._client.resource_action_update(
+        tid=environment,
+        resource_ids=[resource1["id"]],
+        action_id=uuid.uuid4(),
+        action=ResourceAction.deploy,
+        started=datetime.datetime.now(),
+        finished=datetime.datetime.now(),
+        status=ResourceState.failed,
+        messages=[
+            {
+                "level": "INFO",
+                "msg": "Deploying",
+                "timestamp": datetime.datetime.now().isoformat(timespec="microseconds"),
+                "args": [],
+            },
+            {
+                "level": "ERROR",
+                "msg": "Deployment failed",
+                "timestamp": datetime.datetime.now().isoformat(timespec="microseconds"),
+                "args": [],
+                "status": ResourceState.failed.value
+            },
+        ],
+        changes={},
+        change=Change.nochange,
+        send_events=False
+    )
+    assert result.code == 200
+    result = await agent._client.resource_action_update(
+        tid=environment,
+        resource_ids=[resource2["id"]],
+        action_id=uuid.uuid4(),
+        action=ResourceAction.deploy,
+        started=datetime.datetime.now(),
+        finished=datetime.datetime.now(),
+        status=ResourceState.deployed,
+        messages=[
+            {
+                "level": "INFO",
+                "msg": "Deployed successfully",
+                "timestamp": datetime.datetime.now().isoformat(timespec="microseconds"),
+                "args": [],
+            },
+        ],
+        changes={},
+        change=Change.nochange,
+        send_events=False
+    )
+    assert result.code == 200
+
+    # Get all resource actions for resource1
+    result = await cli.run("action-log", "list", "-e", str(environment), "--rvid", resource1["id"])
+    assert result.exit_code == 0
+    assert_nr_records_in_output_table(result.output, nr_records=2)  # 1 store action + 1 deploy action
+
+    # Get deploy resource actions for resource1
+    result = await cli.run(
+        "action-log", "list", "-e", str(environment), "--rvid", resource1["id"], "--action", "deploy"
+    )
+    assert result.exit_code == 0
+    assert_nr_records_in_output_table(result.output, nr_records=1)  # 1 deploy action
+
+    # Resource id is provided instead of resource version id
+    resource_id = resource1["id"].rsplit(",", maxsplit=1)[0]
+    result = await cli.run("action-log", "list", "-e", str(environment), "--rvid", resource_id)
+    assert result.exit_code != 0
+    assert "Invalid value for '--rvid': Version is missing in resource version id" in result.stderr
+
+    # Incorrect format resource version id
+    result = await cli.run("action-log", "list", "-e", str(environment), "--rvid", "test")
+    assert result.exit_code != 0
+    assert "Invalid value for '--rvid': test" in result.stderr
+
+
+@pytest.mark.asyncio
+async def test_show_messages_actionlog(server, environment, client, cli, agent, clienthelper):
+    result = await client.reserve_version(tid=environment)
+    assert result.code == 200
+    version = result.result["data"]
+
+    resource1 = get_resource(version, key="test1")
+    await clienthelper.put_version_simple(resources=[resource1], version=version)
+
+    result = await agent._client.resource_action_update(
+        tid=environment,
+        resource_ids=[resource1["id"]],
+        action_id=uuid.uuid4(),
+        action=ResourceAction.deploy,
+        started=datetime.datetime.now(),
+        finished=datetime.datetime.now(),
+        status=ResourceState.deployed,
+        messages=[
+            {
+                "level": "DEBUG",
+                "msg": "Started deployment",
+                "timestamp": datetime.datetime.now().isoformat(timespec="microseconds"),
+                "args": [],
+            },
+            {
+                "level": "INFO",
+                "msg": "Deployed successfully",
+                "timestamp": datetime.datetime.now().isoformat(timespec="microseconds"),
+                "args": [],
+            },
+        ],
+        changes={},
+        change=Change.nochange,
+        send_events=False
+    )
+    assert result.code == 200
+
+    # Obtain action_id
+    result = await client.get_resource(tid=environment, id=resource1["id"], logs=True, log_action=ResourceAction.deploy)
+    assert result.code == 200
+    assert len(result.result["logs"]) == 1
+    action_id = result.result["logs"][0]["action_id"]
+
+    result = await cli.run(
+        "action-log",
+        "show-messages",
+        "-e",
+        str(environment),
+        "--rvid",
+        resource1["id"],
+        "--action-id",
+        str(action_id)
+    )
+    assert result.exit_code == 0
+    assert "DEBUG Started deployment" in result.output
+    assert "INFO Deployed successfully" in result.output

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -20,7 +20,7 @@ import pytest
 
 from inmanta import resources
 from inmanta.ast import ExternalException
-from inmanta.resources import ResourceException, resource
+from inmanta.resources import ResourceException, resource, Id
 
 
 class Base(resources.Resource):
@@ -302,3 +302,12 @@ def test_resource_invalid_agent_name_entity(snippetcompiler):
     )
     with pytest.raises(ExternalException):
         snippetcompiler.do_export()
+
+
+def test_is_resource_version_id():
+    """
+         Test whether the is_resource_version_id() method of the Id class works correctly.
+    """
+    assert Id.is_resource_version_id("test::Resource[agent,key=id],v=3")
+    assert not Id.is_resource_version_id("test::Resource[agent,key=id]")
+    assert not Id.is_resource_version_id("test::Resource")

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -20,7 +20,7 @@ import pytest
 
 from inmanta import resources
 from inmanta.ast import ExternalException
-from inmanta.resources import Id, ResourceException, resource, PARSE_ID_REGEX, PARSE_RVID_REGEX
+from inmanta.resources import PARSE_ID_REGEX, PARSE_RVID_REGEX, Id, ResourceException, resource
 
 
 class Base(resources.Resource):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -20,7 +20,7 @@ import pytest
 
 from inmanta import resources
 from inmanta.ast import ExternalException
-from inmanta.resources import ResourceException, resource, Id
+from inmanta.resources import Id, ResourceException, resource
 
 
 class Base(resources.Resource):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -20,7 +20,7 @@ import pytest
 
 from inmanta import resources
 from inmanta.ast import ExternalException
-from inmanta.resources import Id, ResourceException, resource
+from inmanta.resources import Id, ResourceException, resource, PARSE_ID_REGEX, PARSE_RVID_REGEX
 
 
 class Base(resources.Resource):
@@ -309,5 +309,83 @@ def test_is_resource_version_id():
          Test whether the is_resource_version_id() method of the Id class works correctly.
     """
     assert Id.is_resource_version_id("test::Resource[agent,key=id],v=3")
+    assert Id.is_resource_version_id("test::mod::Resource[agent,key=id],v=3")
     assert not Id.is_resource_version_id("test::Resource[agent,key=id]")
+    assert not Id.is_resource_version_id("test::mod::Resource[agent,key=id]")
     assert not Id.is_resource_version_id("test::Resource")
+
+
+def test_parse_id_regex():
+    result = PARSE_ID_REGEX.search("test::Resource[agent,key=id],v=3")
+    assert result is not None
+    assert result.group("id") == "test::Resource[agent,key=id]"
+    assert result.group("type") == "test::Resource"
+    assert result.group("ns") == "test"
+    assert result.group("class") == "Resource"
+    assert result.group("hostname") == "agent"
+    assert result.group("attr") == "key"
+    assert result.group("value") == "id"
+    assert result.group("version") == "3"
+
+    result = PARSE_ID_REGEX.search("test::submodule::Resource[agent,key=id],v=3")
+    assert result is not None
+    assert result.group("id") == "test::submodule::Resource[agent,key=id]"
+    assert result.group("type") == "test::submodule::Resource"
+    assert result.group("ns") == "test::submodule"
+    assert result.group("class") == "Resource"
+    assert result.group("hostname") == "agent"
+    assert result.group("attr") == "key"
+    assert result.group("value") == "id"
+    assert result.group("version") == "3"
+
+    result = PARSE_ID_REGEX.search("test::Resource[agent,key=id]")
+    assert result is not None
+    assert result.group("id") == "test::Resource[agent,key=id]"
+    assert result.group("type") == "test::Resource"
+    assert result.group("ns") == "test"
+    assert result.group("class") == "Resource"
+    assert result.group("hostname") == "agent"
+    assert result.group("attr") == "key"
+    assert result.group("value") == "id"
+    assert result.group("version") is None
+
+    result = PARSE_ID_REGEX.search("test::submodule::Resource[agent,key=id]")
+    assert result is not None
+    assert result.group("id") == "test::submodule::Resource[agent,key=id]"
+    assert result.group("type") == "test::submodule::Resource"
+    assert result.group("ns") == "test::submodule"
+    assert result.group("class") == "Resource"
+    assert result.group("hostname") == "agent"
+    assert result.group("attr") == "key"
+    assert result.group("value") == "id"
+    assert result.group("version") is None
+
+
+def test_parse_rvid_regex():
+    result = PARSE_RVID_REGEX.search("test::Resource[agent,key=id],v=3")
+    assert result is not None
+    assert result.group("id") == "test::Resource[agent,key=id]"
+    assert result.group("type") == "test::Resource"
+    assert result.group("ns") == "test"
+    assert result.group("class") == "Resource"
+    assert result.group("hostname") == "agent"
+    assert result.group("attr") == "key"
+    assert result.group("value") == "id"
+    assert result.group("version") == "3"
+
+    result = PARSE_RVID_REGEX.search("test::submodule::Resource[agent,key=id],v=3")
+    assert result is not None
+    assert result.group("id") == "test::submodule::Resource[agent,key=id]"
+    assert result.group("type") == "test::submodule::Resource"
+    assert result.group("ns") == "test::submodule"
+    assert result.group("class") == "Resource"
+    assert result.group("hostname") == "agent"
+    assert result.group("attr") == "key"
+    assert result.group("value") == "id"
+    assert result.group("version") == "3"
+
+    result = PARSE_RVID_REGEX.search("test::Resource[agent,key=id]")
+    assert result is None
+
+    result = PARSE_RVID_REGEX.search("test::submodule::Resource[agent,key=id]")
+    assert result is None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,12 +21,11 @@ import json
 import logging
 import time
 import uuid
+from typing import Any, Dict
 
 from inmanta import data
 from inmanta.protocol import Client
 from inmanta.util import get_compiler_version
-
-from typing import Dict, Any
 
 
 async def retry_limited(fun, timeout):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,6 +26,8 @@ from inmanta import data
 from inmanta.protocol import Client
 from inmanta.util import get_compiler_version
 
+from typing import Dict, Any
+
 
 async def retry_limited(fun, timeout):
     async def fun_wrapper():
@@ -286,3 +288,14 @@ class ClientHelper(object):
             compiler_version=get_compiler_version(),
         )
         assert res.code == 200, res.result
+
+
+def get_resource(version: int, key: str = "key1", agent: str = "agent1", value: str = "value1") -> Dict[str, Any]:
+    return {
+        "key": key,
+        "value": value,
+        "id": f"test::Resource[{agent},key={key}],v=%d" % version,
+        "send_event": False,
+        "purged": False,
+        "requires": [],
+    }


### PR DESCRIPTION
# Description

 Added support to query the action log of a resource via the CLI.

closes #2253 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
