### PR TITLE
added __eq__ methods to types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Handle skipped and unavailable as failures when calculating increments (#2184)
 - Constrain agent name to string values (#2172)
 - Fix for allowing comments in the requirements.txt file of modules (#2206)
+- Allow equality checks between types to support optional value overrides (#2243)
 
 # Release 2020.3 (2020-07-02)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ cryptography==2.9.2
 execnet==1.7.1
 graphviz==0.14.1
 inmanta-sphinx==1.3.0
+more-itertools==8.4.0
 netifaces==0.10.9
 ply==3.11
 pytest-cover==3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ default_section=FIRSTPARTY
 # When tox runs isort it does not label all 1st and 3rd party packages correct, this causes a difference in sorting between
 # normal and tox. This list forces these packages
 known_first_party=inmanta,inmanta_ext,inmanta_plugins
-known_third_party=pytest,psutil,pydantic,pkg_resources,openapi_spec_validator,docstring_parser,cookiecutter
+known_third_party=pytest,psutil,pydantic,pkg_resources,openapi_spec_validator,docstring_parser,cookiecutter,more_itertools
 skip=tests/data
 
 [mypy]

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -177,6 +177,11 @@ class NullableType(Type):
     def with_base_type(self, base_type: Type) -> Type:
         return NullableType(self.element_type.with_base_type(base_type))
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, NullableType):
+            return NotImplemented
+        return self.element_type == other.element_type
+
 
 class Primitive(Type):
     """
@@ -204,6 +209,11 @@ class Primitive(Type):
 
     def type_string_internal(self) -> str:
         return "Primitive"
+
+    def __eq__(self, other: object) -> bool:
+        if other.__class__ != self.__class__:
+            return NotImplemented
+        return True
 
 
 class Number(Primitive):
@@ -408,6 +418,11 @@ class TypedList(List):
     def with_base_type(self, base_type: Type) -> Type:
         return TypedList(base_type)
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TypedList):
+            return NotImplemented
+        return self.element_type == other.element_type
+
 
 class LiteralList(TypedList):
     """
@@ -427,6 +442,11 @@ class LiteralList(TypedList):
 
     def with_base_type(self, base_type: Type) -> Type:
         return self
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, LiteralList):
+            return NotImplemented
+        return True
 
 
 class Dict(Type):
@@ -500,6 +520,11 @@ class LiteralDict(TypedDict):
 
     def type_string(self) -> str:
         return "dict"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, LiteralDict):
+            return NotImplemented
+        return True
 
 
 class Union(Type):

--- a/tests/compiler/test_typing.py
+++ b/tests/compiler/test_typing.py
@@ -340,3 +340,24 @@ def test_types_base_type(snippetcompiler, base_type: inmanta_type.Type) -> None:
         assert t.get_base_type().type_string() == base_type.type_string()
         # verify with_base_type is round-trip compatible
         assert t.with_base_type(base_type).type_string() == t.type_string()
+
+
+def test_2243_override_optional(snippetcompiler) -> None:
+    # make sure this compiles without errors
+    snippetcompiler.setup_for_snippet(
+        """
+entity Parent:
+    bool? val
+end
+
+implement Parent using std::none
+
+entity Child extends Parent:
+    bool? val = false
+end
+
+implement Child using std::none
+
+Child()
+        """,
+    )

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -18,10 +18,10 @@
 
 import typing
 from functools import reduce
-from more_itertools import pairwise
 from typing import Tuple
 
 import pytest
+from more_itertools import pairwise
 
 from inmanta.ast import Namespace, RuntimeException
 from inmanta.ast.attribute import Attribute

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -18,10 +18,10 @@
 
 import typing
 from functools import reduce
+from more_itertools import pairwise
 from typing import Tuple
 
 import pytest
-from more_itertools import pairwise
 
 from inmanta.ast import Namespace, RuntimeException
 from inmanta.ast.attribute import Attribute


### PR DESCRIPTION
# Description

Allow equality checks between types to support optional value overrides

closes #2243

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
