### PR TITLE
Don't add path params as query params to the url in the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Constrain agent name to string values (#2172)
 - Fix for allowing comments in the requirements.txt file of modules (#2206)
 - Allow equality checks between types to support optional value overrides (#2243)
+- Don't add path params as query params to the url in the client (#2246)
 
 # Release 2020.3 (2020-07-02)
 

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -734,6 +734,8 @@ class MethodProperties(object):
         for i in range(len(args)):
             msg[argspec.args[i]] = args[i]
 
+        path_params = {k for k, v in msg.items() if v is not None and f"<{k}>" in self._path.path}
+
         url = self.get_call_url(msg)
 
         headers = {}
@@ -749,7 +751,7 @@ class MethodProperties(object):
                     del msg[arg_name]
 
         if self.operation not in ("POST", "PUT", "PATCH"):
-            qs_map = {k: v for k, v in msg.items() if v is not None and k != "id"}
+            qs_map = {k: v for k, v in msg.items() if v is not None and k not in path_params}
 
             # encode arguments in url
             if len(qs_map) > 0:


### PR DESCRIPTION
# Description

closes #2246 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
