### PR TITLE
Issue/2301 typedmethod argument type any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added link to the PDF version of the documentation
 - Added environment setting for agent_trigger_method (#2025)
 - Expose compile data as exported by `inmanta compile --export-compile-data` via API (inmanta/inmanta-telco#54)
+- Added `typedmethod` decorator `strict\_typing` parameter to  allow `Any` types for those few cases where it's required (#2301)
 
 ## Bug fixes
 - Restore support to pass mocking information to the compiler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Added link to the PDF version of the documentation
 - Added environment setting for agent_trigger_method (#2025)
 - Expose compile data as exported by `inmanta compile --export-compile-data` via API (inmanta/inmanta-telco#54)
-- Added `typedmethod` decorator `strict\_typing` parameter to  allow `Any` types for those few cases where it's required (#2301)
+- Added `typedmethod` decorator `strict_typing` parameter to  allow `Any` types for those few cases where it's required (#2301)
 
 ## Bug fixes
 - Restore support to pass mocking information to the compiler

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -375,6 +375,7 @@ class MethodProperties(object):
         envelope: bool,
         typed: bool = False,
         envelope_key: str = const.ENVELOPE_KEY,
+        strict_typing: bool = True,
     ) -> None:
         """
             Decorator to identify a method as a RPC call. The arguments of the decorator are used by each transport to build
@@ -416,6 +417,7 @@ class MethodProperties(object):
         self._api_prefix = api_prefix
         self._envelope = envelope
         self._envelope_key = envelope_key
+        self._strict_typing = strict_typing
         self.function = function
 
         self._parsed_docstring = docstring_parser.parse(text=function.__doc__, style=docstring_parser.styles.Style.rest)
@@ -469,6 +471,7 @@ class MethodProperties(object):
 
             For arguments the following types are supported:
             - Simpletypes: BaseModel, datetime, Enum, uuid.UUID, str, float, int, bool
+            - Simpletypes includes Any iff strict_typing == False
             - List[Simpletypes]: A list of simple types
             - Dict[str, Simpletypes]: A dict with string keys and simple types
 
@@ -492,38 +495,51 @@ class MethodProperties(object):
             if arg not in type_hints:
                 raise InvalidMethodDefinition(f"{arg} in function {self.function} has no type annotation.")
 
-            self._validate_type_arg(arg, type_hints[arg], allow_none_type=True, in_url=self.arguments_in_url())
+            self._validate_type_arg(
+                arg, type_hints[arg], strict=self.strict_typing, allow_none_type=True, in_url=self.arguments_in_url()
+            )
 
-        self._validate_return_type(type_hints["return"])
+        self._validate_return_type(type_hints["return"], strict=self.strict_typing)
 
-    def _validate_return_type(self, arg_type: Type) -> None:
+    def _validate_return_type(self, arg_type: Type, *, strict: bool = True) -> None:
         """ Validate the return type
         """
         # Note: we cannot call issubclass on a generic type!
         arg = "return type"
 
         if typing_inspect.is_generic_type(arg_type) and issubclass(typing_inspect.get_origin(arg_type), ReturnValue):
-            self._validate_type_arg(arg, typing_inspect.get_args(arg_type, evaluate=True)[0], allow_none_type=True)
+            self._validate_type_arg(
+                arg, typing_inspect.get_args(arg_type, evaluate=True)[0], strict=strict, allow_none_type=True
+            )
 
         elif not typing_inspect.is_generic_type(arg_type) and isinstance(arg_type, type) and issubclass(arg_type, ReturnValue):
             raise InvalidMethodDefinition("ReturnValue should have a type specified.")
 
         else:
-            self._validate_type_arg(arg, arg_type, allow_none_type=True)
+            self._validate_type_arg(arg, arg_type, allow_none_type=True, strict=strict)
 
-    def _validate_type_arg(self, arg: str, arg_type: Type, allow_none_type: bool = False, in_url: bool = False) -> None:
+    def _validate_type_arg(
+        self, arg: str, arg_type: Type, *, strict: bool = True, allow_none_type: bool = False, in_url: bool = False
+    ) -> None:
         """ Validate the given type arg recursively
 
             :param arg: The name of the argument
             :param arg_type: The annotated type fo the argument
+            :param strict: If true, does not allow `Any`.
+            :param allow_none_type: If true, allow `None` as the type for this argument
             :param in_url: This argument is passed in the URL
         """
+
+        if arg_type is Any:
+            if strict:
+                raise InvalidMethodDefinition(f"Invalid type for argument {arg}: Any type is not allowed in strict mode")
+            return
 
         if typing_inspect.is_union_type(arg_type):
             # Make sure there is only one list and one dict in the union, otherwise we cannot process the arguments
             cnt: Dict[str, int] = defaultdict(lambda: 0)
             for sub_arg in typing_inspect.get_args(arg_type, evaluate=True):
-                self._validate_type_arg(arg, sub_arg, allow_none_type, in_url)
+                self._validate_type_arg(arg, sub_arg, strict=strict, allow_none_type=allow_none_type, in_url=in_url)
 
                 if typing_inspect.is_generic_type(sub_arg):
                     # there is a difference between python 3.6 and >=3.7
@@ -553,7 +569,7 @@ class MethodProperties(object):
                 )
 
             elif len(args) == 1:  # A generic list
-                self._validate_type_arg(arg, args[0], allow_none_type, in_url)
+                self._validate_type_arg(arg, args[0], strict=strict, allow_none_type=allow_none_type, in_url=in_url)
 
             elif len(args) == 2:  # Generic Dict
                 if not issubclass(args[0], str):
@@ -561,7 +577,7 @@ class MethodProperties(object):
                         f"Type {arg_type} of argument {arg} must be a Dict with str keys and not {args[0].__name__}"
                     )
 
-                self._validate_type_arg(arg, args[1], allow_none_type=True, in_url=in_url)
+                self._validate_type_arg(arg, args[1], strict=strict, allow_none_type=True, in_url=in_url)
 
             elif len(args) > 2:
                 raise InvalidMethodDefinition(f"Failed to validate type {arg_type} of argument {arg}.")
@@ -616,6 +632,10 @@ class MethodProperties(object):
     @property
     def envelope_key(self) -> str:
         return self._envelope_key
+
+    @property
+    def strict_typing(self) -> bool:
+        return self._strict_typing
 
     @property
     def api_version(self) -> int:

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -396,6 +396,7 @@ class MethodProperties(object):
             :param envelope: Put the response of the call under an envelope key.
             :param typed: Is the method definition typed or not
             :param envelope_key: The envelope key to use
+            :param strict_typing: If true, does not allow `Any` when validating argument types
         """
         if api is None:
             api = not server_agent and not agent_server
@@ -525,7 +526,7 @@ class MethodProperties(object):
 
             :param arg: The name of the argument
             :param arg_type: The annotated type fo the argument
-            :param strict: If true, does not allow `Any`.
+            :param strict: If true, does not allow `Any`
             :param allow_none_type: If true, allow `None` as the type for this argument
             :param in_url: This argument is passed in the URL
         """

--- a/src/inmanta/protocol/decorators.py
+++ b/src/inmanta/protocol/decorators.py
@@ -138,6 +138,7 @@ def typedmethod(
     api_version: int = 1,
     api_prefix: str = "api",
     envelope_key: str = const.ENVELOPE_KEY,
+    strict_typing: bool = True,
 ) -> Callable[..., Callable]:
     """
         Decorator to identify a method as a RPC call. The arguments of the decorator are used by each transport to build
@@ -162,6 +163,9 @@ def typedmethod(
         :param api_version: The version of the api this method belongs to
         :param api_prefix: The prefix of the method: /<prefix>/v<version>/<method_name>
         :param envelope_key: The envelope key to use.
+        :param strict_typing: If true, does not allow `Any`. Setting this option to False is heavily discouraged except for some
+            few very specific cases where the type system does not allow the strict type to be specified, for example in case of
+            infinite recursion.
     """
 
     def wrapper(func: MethodT) -> MethodT:
@@ -182,6 +186,7 @@ def typedmethod(
             True,
             True,
             envelope_key,
+            strict_typing=strict_typing,
         )
         common.MethodProperties.register_method(properties)
         return func

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -256,6 +256,8 @@ class CallArguments(object):
                 )
 
             el_type = typing_inspect.get_args(arg_type, evaluate=True)[0]
+            if el_type is Any:
+                return
             for el in value:
                 if typing_inspect.is_union_type(el_type):
                     self._validate_union_return(el_type, el)
@@ -269,6 +271,8 @@ class CallArguments(object):
                 )
 
             el_type = typing_inspect.get_args(arg_type, evaluate=True)[1]
+            if el_type is Any:
+                return
             for k, v in value.items():
                 if not isinstance(k, str):
                     raise exceptions.ServerError("Keys of return dict need to be strings.")
@@ -304,7 +308,12 @@ class CallArguments(object):
             # Both isubclass and isinstance fail on this type
             # This check needs to be first because isinstance fails on generic types.
             # TODO: also validate the value inside a ReturnValue
-            if typing_inspect.is_union_type(return_type):
+            if return_type is Any:
+                return common.Response.create(
+                    ReturnValue(response=result), config.properties.envelope, config.properties.envelope_key
+                )
+
+            elif typing_inspect.is_union_type(return_type):
                 self._validate_union_return(return_type, result)
                 return common.Response.create(
                     ReturnValue(response=result), config.properties.envelope, config.properties.envelope_key

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -24,7 +24,7 @@ import threading
 import time
 import uuid
 from enum import Enum
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Union
 
 import pytest
 import tornado

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -24,7 +24,7 @@ import threading
 import time
 import uuid
 from enum import Enum
-from typing import Dict, Iterator, List, Optional, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import pytest
 import tornado
@@ -1676,3 +1676,40 @@ async def test_2277_typedmethod_return_optional(async_finalizer, return_value: o
         assert response.result == {"data": return_value}
     else:
         assert response.code == 400
+
+
+def test_method_strict_exception() -> None:
+    with pytest.raises(InvalidMethodDefinition, match="Invalid type for argument arg: Any type is not allowed in strict mode"):
+
+        @protocol.typedmethod(path="/testmethod", operation="POST", client_types=[const.ClientType.api])
+        def test_method(arg: Any) -> None:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_method_nonstrict_allowed(async_finalizer) -> None:
+    @protocol.typedmethod(path="/zipsingle", operation="POST", client_types=[const.ClientType.api], strict_typing=False)
+    def merge_dicts(one: Dict[str, Any], other: Dict[str, int], any_arg: Any) -> Dict[str, Any]:
+        """
+            Merge two dicts.
+        """
+
+    class TestSlice(ServerSlice):
+        @protocol.handle(merge_dicts)
+        async def merge_dicts_impl(self, one: Dict[str, Any], other: Dict[str, int], any_arg: Any) -> Dict[str, Any]:
+            return {**one, **other}
+
+    server: Server = Server()
+    server_slice: ServerSlice = TestSlice("my_test_slice")
+    server.add_slice(server_slice)
+    await server.start()
+    async_finalizer.add(server_slice.stop)
+    async_finalizer.add(server.stop)
+
+    client: protocol.Client = protocol.Client("client")
+
+    one: Dict[str, Any] = {"my": {"nested": {"keys": 42}}}
+    other: Dict[str, int] = {"single_level": 42}
+    response: Result = await client.merge_dicts(one, other, None)
+    assert response.code == 200
+    assert response.result == {"data": {**one, **other}}


### PR DESCRIPTION
# Description

Added `typedmethod` decorator `strict\_typing` parameter to  allow `Any` types for those few cases where it's required

closes #2301

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
