### PR TITLE
improved reporting of PluginExceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Expose compile data as exported by `inmanta compile --export-compile-data` via API (inmanta/inmanta-telco#54)
 - Added `typedmethod` decorator `strict_typing` parameter to  allow `Any` types for those few cases where it's required (#2301)
 
+## Upgrade notes
+
+- Option `inmanta compile --json` is renamed to `inmanta compile --export-compile-data`
+
 ## Bug fixes
 - Restore support to pass mocking information to the compiler
 - Disallow parameters mapped to a header to be passed via the body instead (#2151)
@@ -23,6 +27,7 @@
 - Don't add path params as query params to the url in the client (#2246)
 - Allow Optional as return type for typedmethods (#2277)
 - Made Dict- and SequenceProxy serializable to allow exporter to wrap dict and list attributes in other data structures (#2121)
+- Improved reporting of `PluginException` (#2304) 
 
 # Release 2020.3 (2020-07-02)
 

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -656,9 +656,31 @@ class ExplicitPluginException(ExternalException):
         self.__cause__: PluginException
 
     def export(self) -> export.Error:
-        error: export.Error = super().export()
-        error.category = export.ErrorCategory.plugin
-        return error
+        location: Optional[Location] = self.get_location()
+        module: Optional[str] = self.__cause__.__class__.__module__
+        name: str = self.__cause__.__class__.__qualname__
+        return export.Error(
+            type=name if module is None else "%s.%s" % (module, name),
+            message=self.__cause__.message,
+            location=location.export() if location is not None else None,
+            category=export.ErrorCategory.plugin,
+        )
+
+    def format_trace(self, indent: str = "", indent_level: int = 0) -> str:
+        """Make a representation of this exception and its causes"""
+        out = indent * indent_level + self.format()
+
+        out += "\n" + indent * indent_level + "caused by:\n"
+
+        msg_line = self.__cause__.message
+        out += (indent * (indent_level + 1)) + msg_line + "\n"
+
+        part = traceback.format_exception_only(self.__cause__.__class__, self.__cause__)
+
+        for line in part:
+            out += indent * (indent_level + 1) + line
+
+        return out
 
 
 class WrappingRuntimeException(RuntimeException):

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -633,7 +633,8 @@ class ExternalException(RuntimeException):
 
     def format_trace(self, indent: str = "", indent_level: int = 0) -> str:
         """Make a representation of this exception and its causes"""
-        out = indent * indent_level + self.format()
+
+        out = indent * indent_level + self.format().replace("\n", "\n" + indent * indent_level)
 
         part = traceback.format_exception_only(self.__cause__.__class__, self.__cause__)
         out += "\n" + indent * indent_level + "caused by:\n"
@@ -666,21 +667,8 @@ class ExplicitPluginException(ExternalException):
             category=export.ErrorCategory.plugin,
         )
 
-    def format_trace(self, indent: str = "", indent_level: int = 0) -> str:
-        """Make a representation of this exception and its causes"""
-        out = indent * indent_level + self.format()
-
-        out += "\n" + indent * indent_level + "caused by:\n"
-
-        msg_line = self.__cause__.message
-        out += (indent * (indent_level + 1)) + msg_line + "\n"
-
-        part = traceback.format_exception_only(self.__cause__.__class__, self.__cause__)
-
-        for line in part:
-            out += indent * (indent_level + 1) + line
-
-        return out
+    def get_message(self) -> str:
+        return self.msg + "\n" + self.__cause__.message
 
 
 class WrappingRuntimeException(RuntimeException):

--- a/tests/compiler/test_compile_export.py
+++ b/tests/compiler/test_compile_export.py
@@ -96,17 +96,43 @@ x = 1
 
 
 @pytest.mark.parametrize(
-    "snippet,exception,category",
+    "snippet,exception,category,message,report_exnc",
     [
-        ("1 = 1", ParserException, ast_export.ErrorCategory.parser),
-        ("x.n = 1", NotFoundException, ast_export.ErrorCategory.runtime),
-        ("import tests tests::raise_exception('my message')", ExplicitPluginException, ast_export.ErrorCategory.plugin),
+        (
+            "1 = 1",
+            ParserException,
+            ast_export.ErrorCategory.parser,
+            "Syntax error at token 1",
+            "inmanta.parser.ParserException",
+        ),
+        (
+            "x.n = 1",
+            NotFoundException,
+            ast_export.ErrorCategory.runtime,
+            "variable x not found",
+            "inmanta.ast.NotFoundException",
+        ),
+        (
+            "import tests tests::raise_exception('my message')",
+            ExplicitPluginException,
+            ast_export.ErrorCategory.plugin,
+            "my message",
+            "inmanta.plugins.PluginException",
+        ),
     ],
 )
 def test_export_compile_data_to_file_categories(
-    snippetcompiler, snippet: str, exception: Type[CompilerException], category: ast_export.ErrorCategory, tempfile_export
+    snippetcompiler,
+    snippet: str,
+    exception: Type[CompilerException],
+    category: ast_export.ErrorCategory,
+    message,
+    report_exnc,
+    tempfile_export,
 ) -> None:
     snippetcompiler.setup_for_snippet(snippet)
     compile_data: CompileData = tempfile_export(exception)
     assert len(compile_data.errors) == 1
     assert compile_data.errors[0].category == category
+    assert message == compile_data.errors[0].message
+    assert report_exnc == compile_data.errors[0].type

--- a/tests/compiler/test_compile_export.py
+++ b/tests/compiler/test_compile_export.py
@@ -116,7 +116,7 @@ x = 1
             "import tests tests::raise_exception('my message')",
             ExplicitPluginException,
             ast_export.ErrorCategory.plugin,
-            "my message",
+            "Test: my message",
             "inmanta.plugins.PluginException",
         ),
     ],

--- a/tests/compiler/test_compile_export.py
+++ b/tests/compiler/test_compile_export.py
@@ -117,7 +117,7 @@ x = 1
             ExplicitPluginException,
             ast_export.ErrorCategory.plugin,
             "Test: my message",
-            "inmanta.plugins.PluginException",
+            "inmanta_plugins.tests.TestPluginException",
         ),
     ],
 )

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -109,6 +109,21 @@ Test()
     )
 
 
+def test_plugin_exception(snippetcompiler):
+    snippetcompiler.setup_for_error(
+        """
+import tests
+tests::raise_exception('my message')
+        """,
+        """  PluginException in plugin tests::raise_exception
+  Test: my message (reported in tests::raise_exception('my message') ({dir}/main.cf:3))
+  caused by:
+    inmanta_plugins.tests.TestPluginException: my message
+""",
+        indent_offset=1,
+    )
+
+
 def test_dataflow_exception(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """

--- a/tests/compiler/test_plugins.py
+++ b/tests/compiler/test_plugins.py
@@ -236,6 +236,6 @@ tests::raise_exception("%s")
         compiler.do_compile()
         assert False, "Expected ExplicitPluginException"
     except ExplicitPluginException as e:
-        assert e.__cause__.message == msg
+        assert e.__cause__.message == "Test: " + msg
     except Exception as e:
         assert False, "Expected ExplicitPluginException, got %s" % e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -827,13 +827,13 @@ class SnippetCompilationTest(KeepOnFail):
     async def do_export_and_deploy(self, include_status=False, do_raise=True):
         return await off_main_thread(lambda: self._do_export(deploy=True, include_status=include_status, do_raise=do_raise))
 
-    def setup_for_error(self, snippet, shouldbe):
+    def setup_for_error(self, snippet, shouldbe, indent_offset=0):
         self.setup_for_snippet(snippet)
         try:
             compiler.do_compile()
             assert False, "Should get exception"
         except CompilerException as e:
-            text = e.format_trace(indent="  ")
+            text = e.format_trace(indent="  ", indent_level=indent_offset)
             print(text)
             shouldbe = shouldbe.format(dir=self.project_dir)
             assert shouldbe == text

--- a/tests/data/modules/tests/plugins/__init__.py
+++ b/tests/data/modules/tests/plugins/__init__.py
@@ -44,6 +44,11 @@ def get_id(instance: "std::Entity") -> "string":
     return resources.to_id(instance)
 
 
+class TestPluginException(PluginException):
+    def __init__(self, msg):
+        super().__init__("Test: " + msg)
+
+
 @plugin
 def raise_exception(message: "string") -> None:
-    raise PluginException(message)
+    raise TestPluginException(message)


### PR DESCRIPTION
# Description

Modified the ExplicitPluginException to

1. report the PluginException that caused to to the compiler json output instead of itself
2. when printing the stack trace, also report the error message of the PluginException

closes #2304

# example 

```bash
inmanta compile --export-compile-data 
PluginException in plugin find_subnet_for (reported in find_subnet_for(self.ip_address,self.host.**.subnets) (**/full_service_model.cf:63))
caused by:
  Could not find a subnet for ip 192.168.100.10
  inmanta_plugins.**.NoSubnetFoundForIp: 192.168.100.10
```

```json
{
    "errors": [
        {
            "category": "plugin_exception",
            "type": "inmanta_plugins.**.NoSubnetFoundForIp",
            "message": "Could not find a subnet for ip 192.168.100.10",
            "location": {
                "uri": "**/model/full_service_model.cf",
                "range": {
                    "start": {
                        "line": 62,
                        "character": 0
                    },
                    "end": {
                        "line": 63,
                        "character": 0
                    }
                }
            }
        }
    ]
}
```

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
