### PR TITLE
Issue/2317 output formatting of new compiler data api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Add support for inmanta-cli click plugins
 - Added link to the PDF version of the documentation
 - Added environment setting for agent_trigger_method (#2025)
-- Expose compile data as exported by `inmanta compile --export-compile-data` via API (inmanta/inmanta-telco#54)
+- Expose compile data as exported by `inmanta compile --export-compile-data` via API (inmanta/inmanta-telco#54, #2317)
 - Added `typedmethod` decorator `strict_typing` parameter to  allow `Any` types for those few cases where it's required (#2301)
 
 ## Upgrade notes

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1567,7 +1567,7 @@ class Compile(BaseDocument):
             force_update=self.force_update,
             metadata=self.metadata,
             environment_variables=self.environment_variables,
-            compile_data=self.compile_data,
+            compile_data=None if self.compile_data is None else m.CompileData(**self.compile_data),
         )
 
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1432,7 +1432,7 @@ class Compile(BaseDocument):
     # In that case, substitute_compile_id will reference the actually compiled request.
     substitute_compile_id: Optional[uuid.UUID] = Field(field_type=uuid.UUID)
 
-    compile_data: Optional[str] = Field(field_type=str)
+    compile_data: Optional[dict] = Field(field_type=dict)
 
     @classmethod
     async def get_reports(
@@ -1567,7 +1567,7 @@ class Compile(BaseDocument):
             force_update=self.force_update,
             metadata=self.metadata,
             environment_variables=self.environment_variables,
-            compile_data=None if self.compile_data is None else json.loads(self.compile_data),
+            compile_data=self.compile_data,
         )
 
 

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -495,7 +495,7 @@ class CompilerService(ServerSlice):
         version = runner.version
 
         end = datetime.datetime.now()
-        compile_data_json: Optional[str] = None if compile_data is None else compile_data.json()
+        compile_data_json: Optional[dict] = None if compile_data is None else compile_data.dict()
         await compile.update_fields(completed=end, success=success, version=version, compile_data=compile_data_json)
         awaitables = [
             merge_candidate.update_fields(

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -434,11 +434,13 @@ async def test_compilerservice_compile_data(environment_factory: EnvironmentFact
         assert reports.code == 200
         assert len(reports.result["reports"]) == 1
         compile_id: str = reports.result["reports"][0]["id"]
+        compile_data_a = model.CompileData(**reports.result["reports"][0]["compile_data"])
 
         result = await client.get_compile_data(uuid.UUID(compile_id))
         assert result.code == 200
         assert "data" in result.result
         compile_data: model.CompileData = model.CompileData(**result.result["data"])
+        assert compile_data_a == compile_data
         return compile_data
 
     errors0: List[ast_export.Error] = (await get_compile_data("x = 0")).errors


### PR DESCRIPTION
# Description

Ensure proper api output for compile reports

closes #2317 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [X] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
