### PR TITLE
backwards compatibility patch for agent plugin source loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## New features
 - Added merging of similar compile requests to the compile queue (#2137)
-- Export all handler's / resource's module's plugin source files so helper functions can be used from sibling modules (#2162)
+- Export all handler's / resource's module's plugin source files so helper functions can be used from sibling modules (#2162, #2312)
 - Added documentation on how a string is matched against a regex defined in a regex-based typedef (#2214)
 - Added API to query ResourceActions
 - Added support to query the resource action log of a resource via the CLI (#2253)
@@ -32,7 +32,7 @@
 - Don't add path params as query params to the url in the client (#2246)
 - Allow Optional as return type for typedmethods (#2277)
 - Made Dict- and SequenceProxy serializable to allow exporter to wrap dict and list attributes in other data structures (#2121)
-- Improved reporting of `PluginException` (#2304) 
+- Improved reporting of `PluginException` (#2304)
 
 # Release 2020.3 (2020-07-02)
 

--- a/src/inmanta/loader.py
+++ b/src/inmanta/loader.py
@@ -272,7 +272,7 @@ class CodeLoader(object):
                     pathlib.Path(os.path.join(normdir, "__init__.py")).touch()
                     touch_inits(os.path.dirname(normdir))
 
-                # esnure correct package structure
+                # ensure correct package structure
                 os.makedirs(module_dir, exist_ok=True)
                 touch_inits(os.path.dirname(module_dir))
                 source_file = os.path.join(module_dir, "__init__.py")

--- a/src/inmanta/loader.py
+++ b/src/inmanta/loader.py
@@ -252,10 +252,13 @@ class CodeLoader(object):
             if module_source.name not in self.__modules or module_source.hash_value != self.__modules[module_source.name][0]:
                 LOGGER.info("Deploying code (hv=%s, module=%s)", module_source.hash_value, module_source.name)
 
-                all_modules_dir: str = os.path.normpath(os.path.join(self.__code_dir, MODULE_DIR))
+                all_modules_dir: str = os.path.join(self.__code_dir, MODULE_DIR)
+                relative_module_path: str = PluginModuleLoader.convert_module_to_relative_path(module_source.name)
                 # Treat all modules as a package for simplicity: module is a dir with source in __init__.py
-                module_dir: str = os.path.join(
-                    all_modules_dir, PluginModuleLoader.convert_module_to_relative_path(module_source.name)
+                module_dir: str = os.path.join(all_modules_dir, relative_module_path)
+
+                package_dir: str = os.path.normpath(
+                    os.path.join(all_modules_dir, pathlib.PurePath(pathlib.PurePath(relative_module_path).parts[0]))
                 )
 
                 def touch_inits(directory: str) -> None:
@@ -264,7 +267,7 @@ class CodeLoader(object):
                         with pre-2020.4 inmanta clients because they don't necessarily upload the whole package.
                     """
                     normdir: str = os.path.normpath(directory)
-                    if normdir == all_modules_dir:
+                    if normdir == package_dir:
                         return
                     pathlib.Path(os.path.join(normdir, "__init__.py")).touch()
                     touch_inits(os.path.dirname(normdir))

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -175,6 +175,25 @@ def helper():
     assert "ModuleNotFoundError: No module named" not in caplog.text
 
 
+def test_2312_code_loader_missing_init(tmp_path) -> None:
+    cl = loader.CodeLoader(tmp_path)
+
+    code: str = (
+        """
+def test():
+    return 10
+        """
+    )
+    sha1sum = hashlib.new("sha1")
+    sha1sum.update(code.encode())
+    hv: str = sha1sum.hexdigest()
+    cl.deploy_version([ModuleSource("inmanta_plugins.my_module.my_sub_mod", code, hv)])
+
+    import inmanta_plugins.my_module.my_sub_mod as sm
+
+    assert sm.test() == 10
+
+
 def test_code_loader_import_error(tmp_path, caplog):
     """ Test loading code with an import error
     """


### PR DESCRIPTION
# Description

backwards compatibility patch for agent plugin source loading

closes #2312

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
