### PR TITLE
Issue/ignore pre2020.4 source files

### DIFF
--- a/src/inmanta/loader.py
+++ b/src/inmanta/loader.py
@@ -201,6 +201,11 @@ class CodeLoader(object):
         configure_module_finder([mod_dir])
 
         for py in glob.iglob(os.path.join(mod_dir, "**", "*.py"), recursive=True):
+            # Files in the root of the modules directory are sources files formatted on disk
+            # using the pre inmanta 2020.4 format. These sources should be ignored.
+            if os.path.dirname(py) == mod_dir:
+                continue
+
             mod_name: str
             if mod_dir in py:
                 mod_name = PluginModuleLoader.convert_relative_path_to_module(os.path.relpath(py, start=mod_dir))

--- a/src/inmanta/loader.py
+++ b/src/inmanta/loader.py
@@ -202,8 +202,8 @@ class CodeLoader(object):
         configure_module_finder([mod_dir])
 
         for py in glob.iglob(os.path.join(mod_dir, "**", "*.py"), recursive=True):
-            # Files in the root of the modules directory are sources files formatted on disk
-            # using the pre inmanta 2020.4 format. These sources should be ignored.
+            # Files in the root of the modules directory are sources files formatted on disk using
+            # the pre inmanta 2020.4 format. These sources should be ignored. (See issue: #2162)
             if os.path.dirname(py) == mod_dir:
                 continue
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -320,6 +320,7 @@ install_mode: master
 def test_plugin_loading_old_format(tmpdir, capsys):
     """
         Ensure the code loader ignores code formatted in the old on disk format (pre Inmanta 2020.4).
+        (See issue: #2162)
     """
     # Create directory structure code dir
     code_dir = tmpdir


### PR DESCRIPTION
# Description

Ensure that sources in the code directory of an agent are ignored when they are formatted using the pre Inmanta 2020.4 on disk format.

Bugfix on #2162

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
