### PR TITLE
Fix 'compile_data_json_file' referenced before assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 - Fixed import loop when using `inmanta.execute.proxy` as entry point (#2341)
 - Clearing an environment with merged compile requests no longer fails (#2350)
+- Fix "compile_data_json_file" referenced before assignment (#2361)
 
 # Release 2020.4 (2020-09-08)
 

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -177,6 +177,7 @@ class CompileRun(object):
         now = datetime.datetime.now()
         await self.request.update_fields(started=now)
 
+        compile_data_json_file = NamedTemporaryFile()
         try:
             await self._start_stage("Init", "")
 
@@ -230,8 +231,6 @@ class CompileRun(object):
                     await self._run_compile_stage("Pulling updates", ["git", "pull"], project_dir)
                     LOGGER.info("Installing and updating modules")
                     await self._run_compile_stage("Updating modules", inmanta_path + ["modules", "update"], project_dir)
-
-            compile_data_json_file = NamedTemporaryFile()
 
             server_address = opt.server_address.get()
             server_port = opt.get_bind_port()

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -866,8 +866,8 @@ async def test_compileservice_cleanup_on_trigger(client_for_cleanup, environment
 async def test_issue_2361(environment_factory: EnvironmentFactory, server, client, tmpdir):
     env = await environment_factory.create_environment(main="")
 
-    # Change the branch to a non-existing branch as such that the clone stage of the compiler service
-    # returns success=False before the NamedTemporaryFile is created.
+    # Change the branch of the environment to a non-existing branch as such that the run method
+    # of the CompileRun returns after executing the clone stage.
     result = await client.environment_modify(id=env.id, name=env.id, branch="non-existing-branch")
     assert result.code == 200
 
@@ -887,4 +887,6 @@ async def test_issue_2361(environment_factory: EnvironmentFactory, server, clien
     cr = CompileRun(compile, project_work_dir)
 
     # This should not result in a "local variable referenced before assignment" exception
-    await cr.run()
+    success, compile_data = await cr.run()
+    assert not success
+    assert compile_data is None

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -860,3 +860,31 @@ async def test_compileservice_cleanup_on_trigger(client_for_cleanup, environment
     result = await client_for_cleanup.get_reports(environment_for_cleanup)
     assert result.code == 200
     assert len(result.result["reports"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_issue_2361(environment_factory: EnvironmentFactory, server, client, tmpdir):
+    env = await environment_factory.create_environment(main="")
+
+    # Change the branch to a non-existing branch as such that the clone stage of the compiler service
+    # returns success=False before the NamedTemporaryFile is created.
+    result = await client.environment_modify(id=env.id, name=env.id, branch="non-existing-branch")
+    assert result.code == 200
+
+    project_work_dir = os.path.join(tmpdir, "work")
+    ensure_directory_exist(project_work_dir)
+
+    compile = data.Compile(
+        remote_id=uuid.uuid4(),
+        environment=env.id,
+        do_export=True,
+        metadata={},
+        environment_variables={},
+        force_update=True,
+    )
+    await compile.insert()
+
+    cr = CompileRun(compile, project_work_dir)
+
+    # This should not result in a "local variable referenced before assignment" exception
+    await cr.run()


### PR DESCRIPTION
# Description

Fix issue where "compile_data_json_file" is referenced before assignment.

closes #2361 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
