### PR TITLE
Add ApiDocsFormat enum for Openapi docs endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Clearing an environment with merged compile requests no longer fails (#2350)
 - Fix "compile_data_json_file" referenced before assignment (#2361)
 - Fix server-autorecompile-wait config option (#2262)
+- Specify the supported values of the 'format' parameter of the OpenAPI endpoint explicitly (#2369)
 
 # Release 2020.4 (2020-09-08)
 

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -238,3 +238,8 @@ class ParameterSource(str, Enum):
     plugin = "plugin"
     user = "user"
     report = "report"
+
+
+class ApiDocsFormat(str, Enum):
+    openapi = "openapi"
+    swagger = "swagger"

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -241,5 +241,7 @@ class ParameterSource(str, Enum):
 
 
 class ApiDocsFormat(str, Enum):
+    # openapi: the api docs in json format, according to the OpenAPI v3 specification
+    # swagger: the api docs in html, using a Swagger-UI view
     openapi = "openapi"
     swagger = "swagger"

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -297,7 +297,7 @@ def reserve_version(tid: uuid.UUID) -> int:
 def get_api_docs(format: Optional[ApiDocsFormat] = ApiDocsFormat.swagger) -> ReturnValue[Union[OpenAPI, str]]:
     """
     Get the OpenAPI definition of the API
-    :param format: Use 'openapi' to get the schema in json format
+    :param format: Use 'openapi' to get the schema in json format, leave empty or use 'swagger' to get the Swagger-UI view
     """
 
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -19,7 +19,7 @@ import datetime
 import uuid
 from typing import Dict, List, Optional, Union
 
-from inmanta.const import AgentAction, ClientType
+from inmanta.const import AgentAction, ApiDocsFormat, ClientType
 from inmanta.data import model
 from inmanta.protocol.common import ReturnValue
 
@@ -294,7 +294,7 @@ def reserve_version(tid: uuid.UUID) -> int:
 
 
 @typedmethod(path="/docs", operation="GET", client_types=[ClientType.api], api_version=2)
-def get_api_docs(format: Optional[str] = None) -> ReturnValue[Union[OpenAPI, str]]:
+def get_api_docs(format: Optional[ApiDocsFormat] = ApiDocsFormat.swagger) -> ReturnValue[Union[OpenAPI, str]]:
     """
     Get the OpenAPI definition of the API
     :param format: Use 'openapi' to get the schema in json format

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
 import importlib_metadata
 
 from inmanta import data
+from inmanta.const import ApiDocsFormat
 from inmanta.data.model import ExtensionStatus, FeatureStatus, SliceStatus, StatusResponse
 from inmanta.protocol import exceptions, methods, methods_v2
 from inmanta.protocol.common import HTML_CONTENT_WITH_UTF8_CHARSET, ReturnValue, attach_warnings
@@ -212,13 +213,13 @@ angular.module('inmantaApi.config', []).constant('inmantaConfig', {
         return response
 
     @protocol.handle(methods_v2.get_api_docs)
-    async def get_api_docs(self, format: Optional[str]) -> ReturnValue[Union[OpenAPI, str]]:
+    async def get_api_docs(self, format: Optional[ApiDocsFormat] = ApiDocsFormat.swagger) -> ReturnValue[Union[OpenAPI, str]]:
         url_map = self._server._transport.get_global_url_map(self._server.get_slices().values())
         feature_manager = self.feature_manager
         openapi = OpenApiConverter(url_map, feature_manager)
         # Get rid of none values with custom json encoder
         openapi_json_str = openapi.generate_openapi_json()
-        if format == "openapi":
+        if format == ApiDocsFormat.openapi:
             openapi_dict = json.loads(openapi_json_str)
             return ReturnValue(response=openapi_dict)
 


### PR DESCRIPTION
# Description

closes #2369 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
