### PR TITLE
fixed #2378 Compiler Scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 - Fixed import loop when using `inmanta.execute.proxy` as entry point (#2341)
 - Clearing an environment with merged compile requests no longer fails (#2350)
+- Fixed compiler bug (#2378)
 
 # Release 2020.4 (2020-09-08)
 

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -606,7 +606,9 @@ class Waiter(object):
     Waiters represent an executable unit, that can be executed the result variables they depend on have their values.
     """
 
-    __slots__ = ("waitcount", "queue", "done")
+    __slots__ = ("waitcount", "queue", "done", "requires")
+
+    requires: Dict[object, ResultVariable]
 
     def __init__(self, queue: QueueScheduler):
         self.waitcount = 1
@@ -639,7 +641,7 @@ class ExecutionUnit(Waiter):
      @param provides: Whether to register this XU as provider to the result variable
     """
 
-    __slots__ = ("result", "requires", "expression", "resolver", "queue_scheduler", "owner")
+    __slots__ = ("result", "expression", "resolver", "queue_scheduler", "owner")
 
     def __init__(
         self,
@@ -686,7 +688,7 @@ class HangUnit(Waiter):
     Wait for a dict of requirements, call the resume method on the resumer, with a map of the resulting values
     """
 
-    __slots__ = ("resolver", "requires", "resumer", "target")
+    __slots__ = ("resolver", "resumer", "target")
 
     def __init__(
         self,
@@ -720,7 +722,7 @@ class RawUnit(Waiter):
     but with a map of ResultVariables instead of their values
     """
 
-    __slots__ = ("resolver", "requires", "resumer")
+    __slots__ = ("resolver", "resumer")
 
     def __init__(
         self,

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -413,9 +413,6 @@ class ListVariable(BaseListVariable):
         self.myself = instance
         super().__init__(queue)
 
-    def freeze(self) -> None:
-        super().freeze()
-
     def set_value(self, value: ListValue, location: Location, recur: bool = True) -> None:
         try:
             if not self._set_value(value, location, recur):

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -413,6 +413,9 @@ class ListVariable(BaseListVariable):
         self.myself = instance
         super().__init__(queue)
 
+    def freeze(self) -> None:
+        super().freeze()
+
     def set_value(self, value: ListValue, location: Location, recur: bool = True) -> None:
         try:
             if not self._set_value(value, location, recur):

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -404,7 +404,7 @@ class Scheduler(object):
 
         now = time.time()
         LOGGER.info(
-            "Total compilation time %f)",
+            "Total compilation time %f",
             now - start,
         )
 

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -230,7 +230,7 @@ class Scheduler(object):
 
         return rangetorange
 
-    def find_wait_cycle(self, allwaiters: List[Waiter]) -> bool:
+    def find_wait_cycle(self, allwaiters: Set[Waiter]) -> bool:
         """
         Preconditions: no progress is made anymore
 

--- a/tests/compiler/test_execution.py
+++ b/tests/compiler/test_execution.py
@@ -437,7 +437,7 @@ def test_issue_2378_scheduler(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity A:
-    string name 
+    string name
 end
 
 A.b [0:] -- B

--- a/tests/compiler/test_execution.py
+++ b/tests/compiler/test_execution.py
@@ -431,3 +431,35 @@ t1 = Test1()
         "The object __config__::Test1 (instantiated at {dir}/main.cf:10) is not complete: "
         "attribute a ({dir}/main.cf:5) is not set",
     )
+
+
+def test_issue_2378_scheduler(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+entity A:
+    string name 
+end
+
+A.b [0:] -- B
+
+entity B:
+    string name
+end
+
+
+b = B(name="b")
+
+a3 = A(name="a3")
+
+a1 = A(name="a1")
+a2 = A(name="a2")
+
+implement A using std::none
+implement B using std::none
+
+a3.b = std::key_sort(a1.b, "name")
+a1.b = a2.b
+a2.b += b
+"""
+    )
+    compiler.do_compile()


### PR DESCRIPTION
# Description

When a plugin takes a higher multiplicity relation (a) as input, that gets its content from another higher multiplicity relation (b), the compiler gets stuck. The plugin waits for the relation a. The ListVariable for the relation a has progress potential (something that doesn't support gradual execution needs the value) and one promise (from the assignment from list b). List b has no progress potential (all things that listen to it support gradual execution) and no promisses .
Compiler will not freeze a because it has a promisse, and will not freeze b because is has no progress potential.

closes #2378

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
