### PR TITLE
Issue/2370 fix cleanup parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix server-autorecompile-wait config option (#2262)
 - Specify the supported values of the 'format' parameter of the OpenAPI endpoint explicitly (#2369)
 - Fix version cli argument conflict (#2358)
+- Don't remove resource independent parameters on version deletion (#2370)
 
 # Release 2020.4 (2020-09-08)
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2448,8 +2448,18 @@ class ConfigurationModel(BaseDocument):
 
                 # Delete facts when the resources in this version are the only
                 await con.execute(
-                    f"DELETE FROM {Parameter.table_name()} p WHERE environment=$1 AND NOT EXISTS "
-                    f"(SELECT * FROM {Resource.table_name()} r WHERE p.resource_id=r.resource_id)",
+                    f"""
+                    DELETE FROM {Parameter.table_name()} p
+                    WHERE(
+                        environment=$1 AND
+                        resource_id<>'' AND
+                        NOT EXISTS(
+                            SELECT 1
+                            FROM {Resource.table_name()} r
+                            WHERE p.resource_id=r.resource_id
+                        )
+                    )
+                    """,
                     self.environment,
                 )
 


### PR DESCRIPTION
# Description

Fix the bug where resource-independent parameters are deleted when a version of a configuration model is deleted.

closes #2370 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
