### PR TITLE
Ensure that a protected environment can't be decommissioned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix version cli argument conflict (#2358)
 - Don't remove resource independent parameters on version deletion (#2370)
 - Enhance installation documentation (#2241, #2356, #2357)
+- Ensure that a protected environment can't be decommissioned (#2376)
 
 # Release 2020.4 (2020-09-08)
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -905,7 +905,7 @@ class Environment(BaseDocument):
             default=False,
             typ="bool",
             validator=convert_boolean,
-            doc="When set to true, this environment cannot be cleared or deleted.",
+            doc="When set to true, this environment cannot be cleared, deleted or decommissioned.",
         ),
     }
 

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -251,6 +251,12 @@ def decomission_environment(id: uuid.UUID, metadata: dict = None):
     """
     Decommision an environment. This is done by uploading an empty model to the server and let purge_on_delete handle
     removal.
+
+    :param id: The uuid of the environment.
+    :param metadata: Optional metadata associated with the decommissioning
+
+    :raises NotFound: The given environment doesn't exist.
+    :raises Forbidden: The given environment is protected.
     """
 
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -181,6 +181,12 @@ def environment_decommission(id: uuid.UUID, metadata: Optional[model.ModelMetada
     """
     Decommission an environment. This is done by uploading an empty model to the server and let purge_on_delete handle
     removal.
+
+    :param id: The uuid of the environment.
+    :param metadata: Optional metadata associated with the decommissioning
+
+    :raises NotFound: The given environment doesn't exist.
+    :raises Forbidden: The given environment is protected.
     """
 
 

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -369,6 +369,9 @@ class EnvironmentService(protocol.ServerSlice):
 
     @protocol.handle(methods_v2.environment_decommission, env="id")
     async def environment_decommission(self, env: data.Environment, metadata: Optional[model.ModelMetadata]) -> int:
+        is_protected_environment = await env.get(data.PROTECTED_ENVIRONMENT)
+        if is_protected_environment:
+            raise Forbidden(f"Environment {env.id} is protected. See environment setting: {data.PROTECTED_ENVIRONMENT}")
         version = await env.get_next_version()
         if metadata is None:
             metadata = model.ModelMetadata(message="Decommission of environment", type="api")

--- a/tests/server/test_env_settings.py
+++ b/tests/server/test_env_settings.py
@@ -254,15 +254,16 @@ async def test_decommission_protected_environment(server, client):
     async def assert_decomission_env(env_id: str, decommission_succeeds: bool) -> None:
         result = await client.list_versions(env_id)
         assert result.code == 200
-        assert len(result.result["versions"]) != 0
+        original_number_of_versions = len(result.result["versions"])
+        assert original_number_of_versions != 0
         # Execute clear operation
         result = await client.environment_decommission(env_id)
         assert result.code == 200 if decommission_succeeds else 403
         # Assert result
         result = await client.list_versions(env_id)
         assert result.code == 200
-        # Original and the empty for decommissioning
-        assert ("version_info" in result.result["versions"][0]) == decommission_succeeds
+        # Another version is added when decommissioning succeeds
+        assert (len(result.result["versions"]) > original_number_of_versions) == decommission_succeeds
 
     # Test default settings
     await push_version_to_environment()

--- a/tests/server/test_env_settings.py
+++ b/tests/server/test_env_settings.py
@@ -225,3 +225,56 @@ async def test_clear_protected_environment(server, client):
     result = await client.environment_settings_set(env_id, data.PROTECTED_ENVIRONMENT, False)
     assert result.code == 200
     await assert_clear_env(env_id, clear_succeeds=True)
+
+
+@pytest.mark.asyncio
+async def test_decommission_protected_environment(server, client):
+    result = await client.create_project("env-test")
+    assert result.code == 200
+    project_id = result.result["project"]["id"]
+
+    result = await client.create_environment(project_id=project_id, name="dev")
+    assert result.code == 200
+    env_id = result.result["environment"]["id"]
+
+    async def push_version_to_environment() -> None:
+        res = await client.reserve_version(env_id)
+        assert res.code == 200
+        version = res.result["data"]
+
+        result = await client.put_version(
+            tid=env_id,
+            version=version,
+            resources=[],
+            unknowns=[],
+            compiler_version=get_compiler_version(),
+        )
+        assert result.code == 200
+
+    async def assert_decomission_env(env_id: str, decommission_succeeds: bool) -> None:
+        result = await client.list_versions(env_id)
+        assert result.code == 200
+        assert len(result.result["versions"]) != 0
+        # Execute clear operation
+        result = await client.environment_decommission(env_id)
+        assert result.code == 200 if decommission_succeeds else 403
+        # Assert result
+        result = await client.list_versions(env_id)
+        assert result.code == 200
+        # Original and the empty for decommissioning
+        assert ("version_info" in result.result["versions"][0]) == decommission_succeeds
+
+    # Test default settings
+    await push_version_to_environment()
+    await assert_decomission_env(env_id, decommission_succeeds=True)
+
+    # Test environment is protected
+    await push_version_to_environment()
+    result = await client.environment_settings_set(env_id, data.PROTECTED_ENVIRONMENT, True)
+    assert result.code == 200
+    await assert_decomission_env(env_id, decommission_succeeds=False)
+
+    # Test environment is unprotected
+    result = await client.environment_settings_set(env_id, data.PROTECTED_ENVIRONMENT, False)
+    assert result.code == 200
+    await assert_decomission_env(env_id, decommission_succeeds=True)


### PR DESCRIPTION
# Description

closes #2376 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
