### PR TITLE
Revert pytest-postgresql to 2.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ tornado==6.0.4
 tox==3.20.0
 tox-venv==0.4.0
 asyncpg==0.21.0
-pytest-postgresql==2.5.1
+pytest-postgresql==2.5.0
 pytest-env==0.6.2
 jinja2==2.11.2
 pep8-naming==0.11.1


### PR DESCRIPTION
# Description

Pytest-postgresql sets the locale of the in the pg_ctl command to C.UTF-8 by default in version 2.5.1. (See: https://github.com/ClearcodeHQ/pytest-postgresql/commit/ff31a3f38bb92f7c92325db9f67941327849aa4f and https://github.com/ClearcodeHQ/pytest-postgresql/commit/7427378161a3d6dbb7953e258f9ef2732d8a0809). This breaks the tests on centos7, since centos7 doesn't support C.UTF-8 locale. 

Or should we open a ticket at pytest-postgresql for this?