### PR TITLE
Issue/2342 test entrypoint import loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 - Fixed import loop when using `inmanta.execute.proxy` as entry point (#2341)
+- Fixed import loop when using `inmanta.resources` as entry point (#2342)
 - Clearing an environment with merged compile requests no longer fails (#2350)
 - Fixed compiler bug (#2378)
 - Fix "compile_data_json_file" referenced before assignment (#2361)

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -49,6 +49,8 @@ Resources
 .. autoclass:: inmanta.resources.ManagedResource
 .. autoclass:: inmanta.resources.IgnoreResourceException
 
+.. autoclass:: inmanta.execute.util.Unknown
+
 Handlers
 --------
 
@@ -74,6 +76,12 @@ Handlers
     :members:
     :inherited-members:
     :undoc-members:
+
+
+Export
+------
+
+.. autodecorator:: inmanta.export.dependency_manager
 
 
 Attributes

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1912,10 +1912,10 @@ class Resource(BaseDocument):
         query = "SELECT * FROM " + cls.table_name() + " WHERE environment=$1 AND attribute_hash IN " + hashes_as_str
         values = [cls._get_value(environment)] + [cls._get_value(h) for h in hashes]
         result = await cls._fetch_query(query, *values)
-        resources = []
+        resources_list = []
         for res in result:
-            resources.append(cls(from_postgres=True, **res))
-        return resources
+            resources_list.append(cls(from_postgres=True, **res))
+        return resources_list
 
     @classmethod
     async def get_resources(
@@ -2060,7 +2060,7 @@ class Resource(BaseDocument):
             (filter_statement, values) = cls._get_composed_filter(environment=environment, model=version)
 
         query = f"SELECT * FROM {Resource.table_name()} WHERE {filter_statement}"
-        resources = []
+        resources_list = []
         async with cls._connection_pool.acquire() as con:
             async with con.transaction():
                 async for record in con.cursor(query, *values):
@@ -2070,10 +2070,10 @@ class Resource(BaseDocument):
                         record["id"] = record["resource_version_id"]
                         parsed_id = resources.Id.parse_id(record["resource_version_id"])
                         record["resource_type"] = parsed_id.entity_type
-                        resources.append(record)
+                        resources_list.append(record)
                     else:
-                        resources.append(cls(from_postgres=True, **record))
-        return resources
+                        resources_list.append(cls(from_postgres=True, **record))
+        return resources_list
 
     @classmethod
     async def get_resources_for_version_raw(cls, environment, version, projection):

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -32,11 +32,10 @@ import asyncpg
 from asyncpg.protocol import Record
 
 import inmanta.db.versions
-from inmanta import const, util
+from inmanta import const, util, resources
 from inmanta.const import DONE_STATES, UNDEPLOYABLE_NAMES, AgentStatus, ResourceState
 from inmanta.data import model as m
 from inmanta.data import schema
-from inmanta.resources import Id
 from inmanta.server import config
 from inmanta.types import JsonType, PrimitiveTypes
 
@@ -2038,7 +2037,7 @@ class Resource(BaseDocument):
             async with con.transaction():
                 async for record in con.cursor(query, *values):
                     resource_id = record["resource_id"]
-                    parsed_id = Id.parse_id(resource_id)
+                    parsed_id = resources.Id.parse_id(resource_id)
                     result.append(
                         {
                             "resource_id": resource_id,
@@ -2069,7 +2068,7 @@ class Resource(BaseDocument):
                         record = dict(record)
                         record["attributes"] = json.loads(record["attributes"])
                         record["id"] = record["resource_version_id"]
-                        parsed_id = Id.parse_id(record["resource_version_id"])
+                        parsed_id = resources.Id.parse_id(record["resource_version_id"])
                         record["resource_type"] = parsed_id.entity_type
                         resources.append(record)
                     else:
@@ -2114,7 +2113,7 @@ class Resource(BaseDocument):
 
     @classmethod
     def new(cls, environment: uuid.UUID, resource_version_id: m.ResourceVersionIdStr, **kwargs: Any) -> "Resource":
-        vid = Id.parse_id(resource_version_id)
+        vid = resources.Id.parse_id(resource_version_id)
 
         attr = dict(
             environment=environment,

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -32,7 +32,7 @@ import asyncpg
 from asyncpg.protocol import Record
 
 import inmanta.db.versions
-from inmanta import const, util, resources
+from inmanta import const, resources, util
 from inmanta.const import DONE_STATES, UNDEPLOYABLE_NAMES, AgentStatus, ResourceState
 from inmanta.data import model as m
 from inmanta.data import schema

--- a/tests/test_import_entry_points.py
+++ b/tests/test_import_entry_points.py
@@ -54,11 +54,16 @@ def test_import_plugins(import_entry_point) -> None:
 
 def test_import_resources(import_entry_point) -> None:
     assert import_entry_point("inmanta.resources") == 0
+    assert import_entry_point("inmanta.execute.util") == 0
 
 
 def test_import_handlers(import_entry_point) -> None:
     assert import_entry_point("inmanta.agent.handler") == 0
     assert import_entry_point("inmanta.agent.io.local") == 0
+
+
+def test_import_export(import_entry_point) -> None:
+    assert import_entry_point("inmanta.export") == 0
 
 
 def test_import_attributes(import_entry_point) -> None:

--- a/tests/test_import_entry_points.py
+++ b/tests/test_import_entry_points.py
@@ -43,5 +43,36 @@ def import_entry_point() -> Iterator[Callable[[str], Optional[int]]]:
     yield do_import
 
 
+def test_import_exceptions(import_entry_point) -> None:
+    assert import_entry_point("inmanta.ast") == 0
+    assert import_entry_point("inmanta.parser") == 0
+
+
+def test_import_plugins(import_entry_point) -> None:
+    assert import_entry_point("inmanta.plugins") == 0
+
+
+def test_import_resources(import_entry_point) -> None:
+    assert import_entry_point("inmanta.resources") == 0
+
+
+def test_import_handlers(import_entry_point) -> None:
+    assert import_entry_point("inmanta.agent.handler") == 0
+    assert import_entry_point("inmanta.agent.io.local") == 0
+
+
+def test_import_attributes(import_entry_point) -> None:
+    assert import_entry_point("inmanta.ast.attribute") == 0
+
+
+def test_import_typing(import_entry_point) -> None:
+    assert import_entry_point("inmanta.ast.type") == 0
+
+
 def test_import_proxy(import_entry_point) -> None:
     assert import_entry_point("inmanta.execute.proxy") == 0
+
+
+def test_import_compile_data(import_entry_point) -> None:
+    assert import_entry_point("inmanta.data.model") == 0
+    assert import_entry_point("inmanta.ast.export") == 0


### PR DESCRIPTION
# Description

- Adds tests against import loops when using each of the modules documented in the inmanta Python API as entry point.
- Fixes import loop when using `inmanta.resources` as entry point.

closes #2342

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
