### PR TITLE
added support for environment markers as described in PEP 508

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release 2020.5 (?)
 
+## New features
+- Added support for environment markers as described in PEP 508 to module requirements parsing (#2359)
+
 ## Bug fixes
 - Fixed import loop when using `inmanta.execute.proxy` as entry point (#2341)
 - Clearing an environment with merged compile requests no longer fails (#2350)

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -175,6 +175,7 @@ class VirtualEnv(object):
 
             url = None
             version = None
+            marker = None
             try:
                 # this will fail is an url is supplied
                 parsed_req = list(pkg_resources.parse_requirements(req_spec))

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -185,16 +185,20 @@ class VirtualEnv(object):
                     elif hasattr(item, "unsafe_name"):
                         name = item.unsafe_name
                     version = item.specs
+                    marker = item.marker
                     if hasattr(item, "url"):
                         url = item.url
             except InvalidRequirement:
                 url = req_spec
 
             if name not in modules:
-                modules[name] = {"name": name, "version": []}
+                modules[name] = {"name": name, "version": [], "markers": []}
 
             if version is not None:
                 modules[name]["version"].extend(version)
+
+            if marker is not None:
+                modules[name]["markers"].append(marker)
 
             if url is not None:
                 modules[name]["url"] = url
@@ -202,13 +206,17 @@ class VirtualEnv(object):
         requirements_file = ""
         for module, info in modules.items():
             version_spec = ""
+            markers: str = ""
             if len(info["version"]) > 0:
                 version_spec = " " + (", ".join(["%s %s" % (a, b) for a, b in info["version"]]))
+
+            if len(info["markers"]) > 0:
+                markers = " ; " + (" and ".join(map(str, info["markers"])))
 
             if "url" in info:
                 module = info["url"]
 
-            requirements_file += module + version_spec + "\n"
+            requirements_file += module + version_spec + markers + "\n"
 
         return requirements_file
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -124,12 +124,15 @@ def test_gen_req_file(tmpdir):
         "lorem",
         # verify support for environment markers as described in PEP 508
         "lorem;python_version<'3.7'",
-        "lorem;platform_system == 'Linux'",
+        "lorem;platform_machine == 'x86_64' and platform_system == 'Linux'",
     ]
 
     req_lines = [x for x in e._gen_requirements_file(req).split("\n") if len(x) > 0]
     assert len(req_lines) == 3
-    assert 'lorem == 0.1.1, > 0.1 ; python_version < "3.7" and platform_system == "Linux"' in req_lines
+    assert (
+        'lorem == 0.1.1, > 0.1 ; python_version < "3.7" and platform_machine == "x86_64" and platform_system == "Linux"'
+        in req_lines
+    )
 
 
 def test_remove_requirements_present_in_parent_env(tmpdir):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -116,10 +116,20 @@ def test_req_parser(tmpdir):
 
 def test_gen_req_file(tmpdir):
     e = env.VirtualEnv(tmpdir)
-    req = ["lorem == 0.1.1", "lorem > 0.1", "dummy-yummy", "iplib@git+https://github.com/bartv/python3-iplib", "lorem"]
+    req = [
+        "lorem == 0.1.1",
+        "lorem > 0.1",
+        "dummy-yummy",
+        "iplib@git+https://github.com/bartv/python3-iplib",
+        "lorem",
+        # verify support for environment markers as described in PEP 508
+        "lorem;python_version<'3.7'",
+        "lorem;platform_system == 'Linux'",
+    ]
 
     req_lines = [x for x in e._gen_requirements_file(req).split("\n") if len(x) > 0]
     assert len(req_lines) == 3
+    assert 'lorem == 0.1.1, > 0.1 ; python_version < "3.7" and platform_system == "Linux"' in req_lines
 
 
 def test_remove_requirements_present_in_parent_env(tmpdir):


### PR DESCRIPTION
# Description

adds support for environment markers as described in PEP 508

closes #2359

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
