### PR TITLE
Protect server against large API results

### DIFF
--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -42,6 +42,7 @@ from inmanta.types import JsonType, PrimitiveTypes
 LOGGER = logging.getLogger(__name__)
 
 DBLIMIT = 100000
+APILIMIT = 1000
 
 
 # TODO: disconnect
@@ -1710,6 +1711,26 @@ class ResourceAction(BaseDocument):
                     WHERE environment=$1 AND resource_version_ids::varchar[] @> ARRAY[$2]::varchar[]
                  """
         values = [cls._get_value(environment), cls._get_value(resource_version_id)]
+        if action is not None:
+            query += " AND action=$3"
+            values.append(cls._get_value(action))
+        query += " ORDER BY started DESC"
+        if limit is not None and limit > 0:
+            query += " LIMIT $%d" % (len(values) + 1)
+            values.append(cls._get_value(limit))
+        async with cls._connection_pool.acquire() as con:
+            async with con.transaction():
+                return [cls(**dict(record), from_postgres=True) async for record in con.cursor(query, *values)]
+
+    @classmethod
+    async def get_logs_for_version(
+        cls, environment: uuid.UUID, version: int, action: Optional[str] = None, limit: int = 0
+    ) -> List["ResourceAction"]:
+        query = f"""SELECT *
+                        FROM {cls.table_name()}
+                        WHERE environment=$1 AND version=$2
+                     """
+        values = [cls._get_value(environment), cls._get_value(version)]
         if action is not None:
             query += " AND action=$3"
             values.append(cls._get_value(action))

--- a/src/inmanta/db/versions/v7.py
+++ b/src/inmanta/db/versions/v7.py
@@ -17,12 +17,12 @@
 """
 from asyncpg import Connection
 
-DISABLED = True
+DISABLED = False
 
 
 async def update(connection: Connection) -> None:
     await connection.execute(
         """
-
+CREATE INDEX resourceaction_environment_version_started_index ON resourceaction(environment,version,started DESC);
         """
     )

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -408,7 +408,9 @@ def get_resource(
     :param status: Only return the status of the resource
     :param log_action: The log action to include, leave empty/none for all actions. Valid actions are one of
                       the action strings in const.ResourceAction
-    :param log_limit: Limit the number of logs included in the response
+    :param log_limit: Limit the number of logs included in the response, up to a maximum of 1000.
+                      To retrieve more entries, use  /api/v2/resource_actions
+                      (:func:`~inmanta.protocol.methods_v2.get_resource_actions`)
     """
 
 
@@ -473,7 +475,7 @@ def list_versions(tid: uuid.UUID, start: int = None, limit: int = None):
 
     :param tid: The id of the environment
     :param start: Optional, parameter to control the amount of results that are returned. 0 is the latest version.
-    :param limit: Optional, parameter to control the amount of results returned.
+    :param limit: Optional, parameter to control the amount of results returned, up to a maximum of 1000.
     """
 
 
@@ -486,7 +488,10 @@ def get_version(tid: uuid.UUID, id: int, include_logs: bool = None, log_filter: 
     :param id: The id of the version to retrieve
     :param include_logs: If true, a log of all operations on all resources is included
     :param log_filter: Filter log to only include actions of the specified type
-    :param limit: The maximal number of actions to return per resource (starting from the latest)
+    :param limit: The maximal number of actions to return per resource (starting from the latest),
+                    up to a maximum of 1000.
+                    To retrieve more entries, use /api/v2/resource_actions
+                    (:func:`~inmanta.protocol.methods_v2.get_resource_actions`)
     """
 
 
@@ -835,7 +840,7 @@ def get_reports(tid: uuid.UUID, start: str = None, end: str = None, limit: int =
     :param tid: The id of the environment to get a report from
     :param start: Reports after start
     :param end: Reports before end
-    :param limit: Maximum number of results
+    :param limit: Maximum number of results, up to a maximum of 1000
     """
 
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -387,7 +387,7 @@ def get_resource_actions(
     :param attribute: Attribute name used for filtering
     :param attribute_value: Attribute value used for filtering. Attribute and attribute value should be supplied together.
     :param log_severity: Only include ResourceActions which have a log message with this severity.
-    :param limit: Limit the number of resource actions included in the response
+    :param limit: Limit the number of resource actions included in the response, up to 1000
     :param action_id: Start the query from this action_id.
             To be used in combination with either the first or last timestamp.
     :param first_timestamp: Limit the results to resource actions that started later

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -38,8 +38,9 @@ import pydantic
 
 import inmanta.data.model as model
 from inmanta import config, const, data, protocol, server
+from inmanta.data import APILIMIT
 from inmanta.protocol import encode_token, methods, methods_v2
-from inmanta.protocol.exceptions import NotFound
+from inmanta.protocol.exceptions import BadRequest, NotFound
 from inmanta.server import SLICE_COMPILER, SLICE_DATABASE, SLICE_TRANSPORT
 from inmanta.server import config as opt
 from inmanta.server.protocol import ServerSlice
@@ -569,6 +570,11 @@ class CompilerService(ServerSlice):
             return 500, {"message": "Limit, start and end can not be set together"}
         if env is None:
             return 404, {"message": "The given environment id does not exist!"}
+
+        if limit is None:
+            limit = APILIMIT
+        elif limit > APILIMIT:
+            raise BadRequest(f"limit parameter can not exceed {APILIMIT}, got {limit}.")
 
         start_time = None
         end_time = None

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -99,7 +99,7 @@ class OrchestrationService(protocol.ServerSlice):
         if (start is None and limit is not None) or (limit is None and start is not None):
             raise ServerError("Start and limit should always be set together.")
 
-        if start is None:
+        if start is None or limit is None:
             start = 0
             limit = data.APILIMIT
 
@@ -143,14 +143,14 @@ class OrchestrationService(protocol.ServerSlice):
                 f" To retrieve more entries, use /api/v2/resource_actions"
             )
 
-        resources_out = []
+        resources_out: List[JsonType] = []
         d = {"model": version, "resources": resources_out}
-        resource_action_lookup = {}
+        resource_action_lookup: Dict[ResourceVersionIdStr, List[data.ResourceAction]] = {}
 
         for res_dict in resources:
             resources_out.append(res_dict)
             if bool(include_logs):
-                actions = []
+                actions: List[data.ResourceAction] = []
                 res_dict["actions"] = actions
                 resource_action_lookup[res_dict["resource_version_id"]] = actions
 

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -583,10 +583,7 @@ class ResourceService(protocol.ServerSlice):
         if limit is None:
             limit = APILIMIT
         elif limit > APILIMIT:
-            raise BadRequest(
-                f"limit parameter can not exceed {APILIMIT}, got {limit}."
-                f" To retrieve more entries, use /api/v2/resource_actions"
-            )
+            raise BadRequest(f"limit parameter can not exceed {APILIMIT}, got {limit}.")
 
         resource_actions = await data.ResourceAction.query_resource_actions(
             env.id,

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -27,6 +27,7 @@ from tornado.httputil import url_concat
 
 from inmanta import const, data
 from inmanta.const import STATE_UPDATE, TERMINAL_STATES, TRANSIENT_STATES, VALID_STATES_ON_STATE_UPDATE
+from inmanta.data import APILIMIT
 from inmanta.data.model import Resource, ResourceAction, ResourceType, ResourceVersionIdStr
 from inmanta.protocol import methods, methods_v2
 from inmanta.protocol.common import ReturnValue
@@ -578,6 +579,15 @@ class ResourceService(protocol.ServerSlice):
                 f"The action_id parameter should be used in combination with either the first_timestamp or the last_timestamp "
                 f"Received action_id: {action_id}, first_timestamp: {first_timestamp}, last_timestamp: {last_timestamp}"
             )
+
+        if limit is None:
+            limit = APILIMIT
+        elif limit > APILIMIT:
+            raise BadRequest(
+                f"limit parameter can not exceed {APILIMIT}, got {limit}."
+                f" To retrieve more entries, use /api/v2/resource_actions"
+            )
+
         resource_actions = await data.ResourceAction.query_resource_actions(
             env.id,
             resource_type,

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -991,7 +991,7 @@ async def test_compileservice_api(client, environment):
     # Exceed max value for limit
     result = await client.get_reports(environment, limit=APILIMIT + 1)
     assert result.code == 400
-    assert result.result["message"] == f"Invalid request: limit parameter can not exceed 1000, got {APILIMIT+1}."
+    assert result.result["message"] == f"Invalid request: limit parameter can not exceed {APILIMIT}, got {APILIMIT+1}."
 
     result = await client.get_reports(environment, limit=APILIMIT)
     assert result.code == 200

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1771,6 +1771,7 @@ async def test_resource_action_get_logs(init_dataclasses_and_load_schema):
     assert action.action == const.ResourceAction.dryrun
     assert action.messages[0]["level"] == LogLevel.WARNING.name
     assert action.messages[0]["timestamp"] == times
+
     resource_actions = await data.ResourceAction.get_log(
         env.id, "std::File[agent1,path=/etc/motd],v=%1", const.ResourceAction.deploy.name, limit=2
     )
@@ -1782,6 +1783,15 @@ async def test_resource_action_get_logs(init_dataclasses_and_load_schema):
     # Get logs for non-existing resource_version_id
     resource_actions = await data.ResourceAction.get_log(env.id, "std::File[agent11,path=/etc/motd],v=%1")
     assert len(resource_actions) == 0
+
+    resource_actions = await data.ResourceAction.get_logs_for_version(env.id, version)
+    assert len(resource_actions) == 11
+    for i in range(len(resource_actions)):
+        action = resource_actions[i]
+        if i == 0:
+            assert action.action == const.ResourceAction.dryrun
+        else:
+            assert action.action == const.ResourceAction.deploy
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- optimized the get_version method to consume less resources
- added an upper limit of 1000 items per page on all API endpoints with paging

closes #2432

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Typing
(red is good)
```diff
+ src/inmanta/data/__init__.py:1861: error: "ResourceAction" gets multiple values for keyword argument "from_postgres"
- src/inmanta/server/services/resourceservice.py:588: error: Argument "limit" to "query_resource_actions" of "ResourceAction" has incompatible type "Optional[int]"; expected "int"
- src/inmanta/server/services/orchestrationservice.py:106: error: Argument 3 to "get_versions" of "ConfigurationModel" has incompatible type "Optional[int]"; expected "int"
- src/inmanta/server/services/orchestrationservice.py:112: error: Incompatible types in assignment (expression has type "int", target has type "List[ConfigurationModel]")
- src/inmanta/server/services/orchestrationservice.py:113: error: Incompatible types in assignment (expression has type "Optional[int]", target has type "List[ConfigurationModel]")
- src/inmanta/server/services/orchestrationservice.py:115: error: Incompatible types in assignment (expression has type "int", target has type "List[ConfigurationModel]")
- src/inmanta/server/services/orchestrationservice.py:139: error: Incompatible types in assignment (expression has type "List[<nothing>]", target has type "ConfigurationModel")
+ src/inmanta/server/services/orchestrationservice.py:151: error: Argument 1 to "append" of "list" has incompatible type "Resource"; expected "Dict[str, Any]"
- src/inmanta/server/services/orchestrationservice.py:143: error: Argument 4 to "get_log" of "ResourceAction" has incompatible type "Optional[int]"; expected "int"
- src/inmanta/server/services/orchestrationservice.py:148: error: Incompatible types in assignment (expression has type "List[UnknownParameter]", target has type "ConfigurationModel")
```

the error 

`src/inmanta/server/services/orchestrationservice.py:151: error: Argument 1 to "append" of "list" has incompatible type "Resource"; expected "Dict[str, Any]"`

is because this method can either return a dict or an object, so a bit hairy to handle, but not impossible iirc. 

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
