### PR TITLE
added support for null in dict in exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Ensure that a protected environment can't be decommissioned (#2376)
 - Don't load all code on agent start (#2343)
 - Allow empty body in else branch for if-else statement (#2375)
+- Fixed export failure with null in dict (#2437)
 
 # Release 2020.4 (2020-09-08)
 

--- a/src/inmanta/execute/proxy.py
+++ b/src/inmanta/execute/proxy.py
@@ -212,7 +212,8 @@ class SequenceProxy(DynamicProxy, JSONSerializable):
         return IteratorProxy(instance.__iter__())
 
     def json_serialization_step(self) -> List[PrimitiveTypes]:
-        return self._get_instance()
+        # Ensure proper unwrapping by using __getitem__
+        return [i for i in self]
 
 
 class DictProxy(DynamicProxy, Mapping, JSONSerializable):

--- a/src/inmanta/execute/proxy.py
+++ b/src/inmanta/execute/proxy.py
@@ -235,7 +235,8 @@ class DictProxy(DynamicProxy, Mapping, JSONSerializable):
         return IteratorProxy(instance.__iter__())
 
     def json_serialization_step(self) -> Dict[str, PrimitiveTypes]:
-        return self._get_instance()
+        # Ensure proper unwrapping by using __getitem__
+        return {k: v for k, v in self.items()}
 
 
 class CallProxy(DynamicProxy):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,10 +64,9 @@ from inmanta.server import SLICE_AGENT_MANAGER, SLICE_COMPILER
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.server.protocol import SliceStartupException
 from inmanta.server.services.compilerservice import CompilerService, CompileRun
-
-# Import the utils module differently when conftest is put into the inmanta_tests package
 from inmanta.types import JsonType
 
+# Import the utils module differently when conftest is put into the inmanta_tests packages
 if __file__ and os.path.dirname(__file__).split("/")[-1] == "inmanta_tests":
     from inmanta_tests import utils  # noqa: F401
 else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ import asyncio
 import concurrent
 import csv
 import datetime
+import json
 import logging
 import os
 import queue
@@ -65,6 +66,8 @@ from inmanta.server.protocol import SliceStartupException
 from inmanta.server.services.compilerservice import CompilerService, CompileRun
 
 # Import the utils module differently when conftest is put into the inmanta_tests package
+from inmanta.types import JsonType
+
 if __file__ and os.path.dirname(__file__).split("/")[-1] == "inmanta_tests":
     from inmanta_tests import utils  # noqa: F401
 else:
@@ -789,6 +792,10 @@ class SnippetCompilationTest(KeepOnFail):
 
     def do_export(self, include_status=False, do_raise=True):
         return self._do_export(deploy=False, include_status=include_status, do_raise=do_raise)
+
+    def get_exported_json(self) -> JsonType:
+        with open(os.path.join(self.project_dir, "dump.json")) as fh:
+            return json.load(fh)
 
     def _do_export(self, deploy=False, include_status=False, do_raise=True):
         """

--- a/tests/data/modules/exp/model/_init.cf
+++ b/tests/data/modules/exp/model/_init.cf
@@ -12,7 +12,7 @@ entity Test2 extends std::PurgeableResource:
 	string agent ="agenta"
 	string name = "ida"
 	dict mydict
-	string[] mylist
+	list mylist
 end
 
 implement Test2 using std::none

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -20,7 +20,7 @@ import os
 
 import pytest
 
-from inmanta import config, const
+from inmanta import config, const, protocol
 from inmanta.export import DependencyCycleException
 
 
@@ -242,7 +242,6 @@ a = exp::Test2(mydict={"a":"b"}, mylist=["a","b"])
     _version, json_value, status, model = snippetcompiler.do_export(include_status=True)
 
     assert len(json_value) == 1
-    print(_version, json_value, status, model)
 
 
 def test_export_null_in_collection(snippetcompiler):
@@ -256,7 +255,10 @@ a = exp::Test2(mydict={"a": null}, mylist=["a",null])
     _version, json_value, status, model = snippetcompiler.do_export(include_status=True)
 
     assert len(json_value) == 1
-    print(_version, json_value, status, model)
+    json_dict = snippetcompiler.get_exported_json()
+    resource = json_dict[0]
+    assert resource["mylist"] == ["a", None]
+    assert resource["mydict"] == {"a": None}
 
 
 def test_1934_cycle_in_dep_mgmr(snippetcompiler):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -245,6 +245,20 @@ a = exp::Test2(mydict={"a":"b"}, mylist=["a","b"])
     print(_version, json_value, status, model)
 
 
+def test_export_null_in_dict(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+import exp
+
+a = exp::Test2(mydict={"a": null}, mylist=["a","b"])
+"""
+    )
+    _version, json_value, status, model = snippetcompiler.do_export(include_status=True)
+
+    assert len(json_value) == 1
+    print(_version, json_value, status, model)
+
+
 def test_1934_cycle_in_dep_mgmr(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -20,7 +20,7 @@ import os
 
 import pytest
 
-from inmanta import config, const, protocol
+from inmanta import config, const
 from inmanta.export import DependencyCycleException
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -245,12 +245,12 @@ a = exp::Test2(mydict={"a":"b"}, mylist=["a","b"])
     print(_version, json_value, status, model)
 
 
-def test_export_null_in_dict(snippetcompiler):
+def test_export_null_in_collection(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 import exp
 
-a = exp::Test2(mydict={"a": null}, mylist=["a","b"])
+a = exp::Test2(mydict={"a": null}, mylist=["a",null])
 """
     )
     _version, json_value, status, model = snippetcompiler.do_export(include_status=True)


### PR DESCRIPTION
# Description

Added support for null in dict in exporter

fixes #2437

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
