### PR TITLE
Fix Python3.8 deprecation warning

### DIFF
--- a/src/inmanta/execute/proxy.py
+++ b/src/inmanta/execute/proxy.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 
-from collections import Mapping
+from collections.abc import Mapping
 from copy import copy
 from typing import Dict, List, Optional, Tuple, Union
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py38,mypy
+envlist = pep8,py36,mypy
 skip_missing_interpreters=True
 
 [testenv:py36]

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps=
 extras=
     dataflow_graphic
 install_command=pip install -c requirements.txt {opts} {packages}
-commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv tests/ --postgresql-exec /usr/lib/postgresql/10/bin/pg_ctl
+commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv tests/
 # The HOME environment variable is required for Git to discover the user.email and
 # user.name config options (required by test case: tests/test_app.py::test_init_project)
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py36,mypy
+envlist = pep8,py38,mypy
 skip_missing_interpreters=True
 
 [testenv:py36]
@@ -29,7 +29,7 @@ deps=
 extras=
     dataflow_graphic
 install_command=pip install -c requirements.txt {opts} {packages}
-commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv tests/
+commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv tests/ --postgresql-exec /usr/lib/postgresql/10/bin/pg_ctl
 # The HOME environment variable is required for Git to discover the user.email and
 # user.name config options (required by test case: tests/test_app.py::test_init_project)
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME


### PR DESCRIPTION
# Description

Running the test suite multiple times with python 3.8 hasn't uncovered any issues (apart from a deprecation warning that this fix is for).
The tests pass on Ubuntu, Centos8, Fedora31, as well as on the Jenkins test executors.

closes #2219 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [ ] ~Changelog entry~
- [ ] ~Type annotations are present~
- [x] Code is clear and sufficiently documented
- [ ] ~No (preventable) type errors (check using make mypy or make mypy-diff)~
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
