### PR TITLE
added plugin call anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## New features
 - Add support to use a custom venv path in the Project class (#2466)
+- Added plugin call anchors to support ctrl-clicking a plugin call (#1954)
 
 ## Upgrade notes
 - Ensure the database is backed up before executing an upgrade.

--- a/src/inmanta/ast/statements/call.py
+++ b/src/inmanta/ast/statements/call.py
@@ -30,6 +30,7 @@ from inmanta.ast import (
     Location,
     Namespace,
     RuntimeException,
+    TypeReferenceAnchor,
     WrappingRuntimeException,
 )
 from inmanta.ast.statements import ExpressionStatement, ReferenceStatement
@@ -69,6 +70,7 @@ class FunctionCall(ReferenceStatement):
         self.wrapped_kwargs: List[WrappedKwargs] = wrapped_kwargs
         self.location: Location = location
         self.namespace: Namespace = namespace
+        self.anchors = [TypeReferenceAnchor(self.namespace, self.name)]
         self.kwargs: Dict[str, ExpressionStatement] = {}
         for loc_name, expr in kwargs:
             arg_name: str = str(loc_name)

--- a/tests/test_compiler_entrypoints.py
+++ b/tests/test_compiler_entrypoints.py
@@ -15,9 +15,13 @@
 
     Contact: code@inmanta.com
 """
+import os
 from collections import defaultdict
 
+import more_itertools
+
 from inmanta import compiler
+from inmanta.ast import Range
 
 
 def test_anchors_basic(snippetcompiler):
@@ -114,6 +118,33 @@ implement Test using a
     verify_anchor(11, 22, 26, 2)
     verify_anchor(15, 22, 23, 11)
     verify_anchor(15, 11, 15, 2)
+
+
+def test_anchors_plugin(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+import tests
+
+l = tests::length("Hello World!")
+        """
+    )
+    anchormap = compiler.anchormap()
+    location: Range
+    resolves_to: Range
+    location, resolves_to = more_itertools.one(
+        (location, resolves_to)
+        for location, resolves_to in anchormap
+        if location.file == os.path.join(snippetcompiler.project_dir, "main.cf")
+    )
+    assert location.lnr == 4
+    assert location.start_char == 5
+    assert location.end_lnr == 4
+    assert location.end_char == 18
+    assert resolves_to.file == os.path.join(snippetcompiler.modules_dir, "tests", "plugins", "__init__.py")
+    assert resolves_to.lnr == 13
+    assert resolves_to.start_char == 1
+    assert resolves_to.end_lnr == 13
+    assert resolves_to.end_char == 2
 
 
 def test_get_types_and_scopes(snippetcompiler):


### PR DESCRIPTION
# Description

added plugin call anchor to support ctrl-click on plugin calls

closes #1954

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
