### PR TITLE
made attribute location a range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## New features
 - Add support to use a custom venv path in the Project class (#2466)
+- Added more specific location information for attributes (#2481)
 
 ## Upgrade notes
 - Ensure the database is backed up before executing an upgrade.

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -284,6 +284,7 @@ def p_entity_body(p: YaccProduction) -> None:
 def p_attribute_base_type(p: YaccProduction) -> None:
     """attr_base_type : ns_ref"""
     p[0] = TypeDeclaration(p[1])
+    attach_from_string(p, 1)
 
 
 def p_attribute_type_multi(p: YaccProduction) -> None:
@@ -309,32 +310,32 @@ def p_attribute_type(p: YaccProduction) -> None:
 def p_attr(p: YaccProduction) -> None:
     "attr : attr_type ID"
     p[0] = DefineAttribute(p[1], p[2], None)
-    attach_lnr(p, 2)
+    attach_from_string(p, 2)
 
 
 def p_attr_cte(p: YaccProduction) -> None:
     """attr : attr_type ID '=' constant
     | attr_type ID '=' constant_list"""
     p[0] = DefineAttribute(p[1], p[2], p[4])
-    attach_lnr(p, 2)
+    attach_from_string(p, 2)
 
 
 def p_attr_undef(p: YaccProduction) -> None:
     "attr : attr_type ID '=' UNDEF"
     p[0] = DefineAttribute(p[1], p[2], None, remove_default=True)
-    attach_lnr(p, 2)
+    attach_from_string(p, 2)
 
 
 def p_attr_dict(p: YaccProduction) -> None:
     "attr : DICT ID"
     p[0] = DefineAttribute(TypeDeclaration(p[1]), p[2], None)
-    attach_lnr(p, 1)
+    attach_from_string(p, 2)
 
 
 def p_attr_list_dict(p: YaccProduction) -> None:
     "attr : DICT ID '=' map_def"
     p[0] = DefineAttribute(TypeDeclaration(p[1]), p[2], p[4])
-    attach_lnr(p, 1)
+    attach_from_string(p, 2)
 
 
 def p_attr_list_dict_null_err(p: YaccProduction) -> None:
@@ -345,19 +346,19 @@ def p_attr_list_dict_null_err(p: YaccProduction) -> None:
 def p_attr_dict_nullable(p: YaccProduction) -> None:
     "attr : DICT '?' ID"
     p[0] = DefineAttribute(TypeDeclaration(p[1], nullable=True), p[3], None)
-    attach_lnr(p, 1)
+    attach_from_string(p, 3)
 
 
 def p_attr_list_dict_nullable(p: YaccProduction) -> None:
     "attr : DICT '?'  ID '=' map_def"
     p[0] = DefineAttribute(TypeDeclaration(p[1], nullable=True), p[3], p[5])
-    attach_lnr(p, 1)
+    attach_from_string(p, 3)
 
 
 def p_attr_list_dict_null(p: YaccProduction) -> None:
     "attr : DICT '?'  ID '=' NULL"
     p[0] = DefineAttribute(TypeDeclaration(p[1], nullable=True), p[3], make_none(p, 5))
-    attach_lnr(p, 1)
+    attach_from_string(p, 3)
 
 
 # IMPLEMENT

--- a/tests/compiler/test_conditional.py
+++ b/tests/compiler/test_conditional.py
@@ -53,7 +53,7 @@ if 0 == 1:
 end
         """,
         "The object __config__::Test (instantiated at {dir}/main.cf:6) is not complete: "
-        "attribute field ({dir}/main.cf:3) is not set",
+        "attribute field ({dir}/main.cf:3:12) is not set",
     )
 
 

--- a/tests/compiler/test_defaults.py
+++ b/tests/compiler/test_defaults.py
@@ -237,7 +237,7 @@ end
 
 Test(t=5)
         """,
-        "Invalid value 'str', expected Number (reported in number t = 'str' ({dir}/main.cf:3))",
+        "Invalid value 'str', expected Number (reported in number t = 'str' ({dir}/main.cf:3:12))",
     )
 
 
@@ -252,7 +252,7 @@ implement Test using std::none
 
 Test(t = ["str"])
         """,
-        "Invalid value '1', expected String (reported in string[]? t = List() ({dir}/main.cf:3))",
+        "Invalid value '1', expected String (reported in string[]? t = List() ({dir}/main.cf:3:15))",
     )
 
 
@@ -267,7 +267,7 @@ implement Test using std::none
 
 Test(t = 12)
         """,
-        "Invalid value '[1, 2]', expected Number (reported in number? t = List() ({dir}/main.cf:3))",
+        "Invalid value '[1, 2]', expected Number (reported in number? t = List() ({dir}/main.cf:3:13))",
     )
 
 
@@ -285,7 +285,7 @@ implement Test using std::none
 Test(t = 8)
         """,
         "Invalid value 12, does not match constraint `((self > 0) and (self < 10))`"
-        " (reported in digit t = 12 ({dir}/main.cf:5))",
+        " (reported in digit t = 12 ({dir}/main.cf:5:11))",
     )
 
 
@@ -296,7 +296,7 @@ entity Test:
     number t = "str"
 end
         """,
-        "Invalid value 'str', expected Number (reported in number t = 'str' ({dir}/main.cf:3))",
+        "Invalid value 'str', expected Number (reported in number t = 'str' ({dir}/main.cf:3:12))",
     )
 
 
@@ -319,5 +319,5 @@ entity Test:
 end
         """,
         "Invalid value 'nodatevalue', does not match constraint `(std::validate_type('datetime.date',self) == true)`"
-        " (reported in std::date d = 'nodatevalue' ({dir}/main.cf:3))",
+        " (reported in std::date d = 'nodatevalue' ({dir}/main.cf:3:15))",
     )

--- a/tests/compiler/test_define.py
+++ b/tests/compiler/test_define.py
@@ -35,6 +35,6 @@ end
     dir: str = snippetcompiler.project_dir
     with pytest.raises(
         DuplicateException,
-        match=re.escape(f"attribute already exists (original at ({dir}/main.cf:3)) (duplicate at ({dir}/main.cf:4))"),
+        match=re.escape(f"attribute already exists (original at ({dir}/main.cf:3:12)) (duplicate at ({dir}/main.cf:4:10))"),
     ):
         compiler.do_compile()

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -184,7 +184,7 @@ mm = nn
             """
 Reported 1 errors
 error 0:
-  The object __config__::A (instantiated at {dir}/main.cf:9) is not complete: attribute n ({dir}/main.cf:3) is not set
+  The object __config__::A (instantiated at {dir}/main.cf:9) is not complete: attribute n ({dir}/main.cf:3:12) is not set
 data trace:
 attribute n on __config__::A instance
 SUBTREE for __config__::A instance:

--- a/tests/compiler/test_execution.py
+++ b/tests/compiler/test_execution.py
@@ -429,7 +429,7 @@ implement Test1 using std::none
 t1 = Test1()
 """,
         "The object __config__::Test1 (instantiated at {dir}/main.cf:10) is not complete: "
-        "attribute a ({dir}/main.cf:5) is not set",
+        "attribute a ({dir}/main.cf:5:12) is not set",
     )
 
 

--- a/tests/compiler/test_list.py
+++ b/tests/compiler/test_list.py
@@ -428,7 +428,7 @@ def test_653_list_attribute_unset(snippetcompiler):
         implement Test using std::none
         """,
         "The object __config__::Test (instantiated at {dir}/main.cf:6) is not complete:"
-        " attribute bla ({dir}/main.cf:3) requires 1 values but only 0 are set",
+        " attribute bla ({dir}/main.cf:3:22) requires 1 values but only 0 are set",
     )
 
 

--- a/tests/compiler/test_null.py
+++ b/tests/compiler/test_null.py
@@ -131,7 +131,7 @@ def test_null_err(snippetcompiler):
         a = A()
 
     """,
-        "Invalid value 'null', expected String (reported in string a = null ({dir}/main.cf:3))",
+        "Invalid value 'null', expected String (reported in string a = null ({dir}/main.cf:3:20))",
     )
 
 
@@ -144,5 +144,5 @@ def test_null_on_list_err(snippetcompiler):
         implement A using std::none
         a = A()
     """,
-        "Invalid value 'null', expected string[] (reported in string[] a = null ({dir}/main.cf:3))",
+        "Invalid value 'null', expected string[] (reported in string[] a = null ({dir}/main.cf:3:22))",
     )

--- a/tests/compiler/test_typedef.py
+++ b/tests/compiler/test_typedef.py
@@ -76,7 +76,7 @@ end
 implement Test using std::none
         """,
         "Invalid value 'value', does not match constraint `(self in ['accepted','values'])`"
-        " (reported in mytype v = 'value' ({dir}/main.cf:5))",
+        " (reported in mytype v = 'value' ({dir}/main.cf:5:16))",
     )
 
 
@@ -92,7 +92,7 @@ end
 implement Test using std::none
         """,
         "Invalid value 'value', does not match constraint `/accepted_value/`"
-        " (reported in mytype v = 'value' ({dir}/main.cf:5))",
+        " (reported in mytype v = 'value' ({dir}/main.cf:5:16))",
     )
 
 
@@ -106,7 +106,7 @@ entity A:
 end
         """,
         "Invalid value [42, 42], does not match constraint `(std::unique(self) == true)`"
-        " (reported in mytype v = List() ({dir}/main.cf:5))",
+        " (reported in mytype v = List() ({dir}/main.cf:5:16))",
     )
 
 

--- a/tests/compiler/test_typing.py
+++ b/tests/compiler/test_typing.py
@@ -98,7 +98,7 @@ entity Test:
     int i = 0.0
 end
         """,
-        "Invalid value '0.0', expected int (reported in int i = 0.0 ({dir}/main.cf:3))",
+        "Invalid value '0.0', expected int (reported in int i = 0.0 ({dir}/main.cf:3:9))",
     )
 
 
@@ -281,7 +281,8 @@ entity Child extends Parent:
     number{child_modifier} n
 end
         """,
-        "Incompatible attributes (original at ({dir}/main.cf:7)) (duplicate at ({dir}/main.cf:3))",
+        "Incompatible attributes (original at ({dir}/main.cf:7:%d)) (duplicate at ({dir}/main.cf:3:%d))"
+        % (12 + len(child_modifier), 12 + len(parent_modifier)),
     )
 
 


### PR DESCRIPTION
# Description

This PR makes `Attribute` location a `Range` instead of a plain `Location`. This is related to #2481 though while working on this I realized the handling of plain `Location` instances can be improved on the vscode side as well. Now I'm not sure this PR should even be merged. The question is what we want the `Attribute`'s location to represent:
- just a line number, as it is now (don't merge this PR (or change it a bit, there's an inconsistency in the tokens used for the location of dicts and other attributes respectively))
- the range of the type declaration
- the range of the attribute name (current status of this PR)
- the combined range of the type declaration and the attribute name (without leading whitespace)

@wouterdb @arnaudsjs wdyt? I'm slightly in favor of leaving this as is (except for the dict-related changes mentioned above).

Some tests are failing because of these changes. I'll fix those once a decision has been reached.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [ ] Changelog entry
- [x] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
