### PR TITLE
use Location instead of Range for Plugin.location

### DIFF
--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, FrozenSet, List, Optional
 
 import inmanta.ast.type as InmantaType
 from inmanta import const, protocol
-from inmanta.ast import CompilerException, LocatableString, Namespace, Range, RuntimeException, TypeNotFoundException
+from inmanta.ast import CompilerException, LocatableString, Location, Namespace, Range, RuntimeException, TypeNotFoundException
 from inmanta.ast.type import NamedType
 from inmanta.config import Config
 from inmanta.execute.proxy import DynamicProxy
@@ -196,7 +196,7 @@ class Plugin(NamedType, metaclass=PluginMeta):
         filename: Optional[str] = inspect.getsourcefile(self.__class__.__function__)
         assert filename is not None
         line: int = inspect.getsourcelines(self.__class__.__function__)[1] + 1
-        self.location: Range = Range(filename, line, 1, line, 2)
+        self.location = Location(filename, line)
 
     def normalize(self) -> None:
         self.resolver = self.namespace
@@ -289,7 +289,8 @@ class Plugin(NamedType, metaclass=PluginMeta):
         if arg_type == "dict":
             return InmantaType.TypedDict(allowed_element_type)
 
-        locatable_type: LocatableString = LocatableString(arg_type, self.location, 0, None)
+        plugin_line: Range = Range(self.location.file, self.location.lnr, 1, self.location.lnr + 1, 1)
+        locatable_type: LocatableString = LocatableString(arg_type, plugin_line, 0, None)
 
         # stack of transformations to be applied to the base InmantaType.Type
         # transformations will be applied right to left

--- a/tests/compiler/test_plugins.py
+++ b/tests/compiler/test_plugins.py
@@ -220,7 +220,7 @@ def test_1920_type_double_defined_plugin(snippetcompiler):
 import test_1920
         """,
         "Type test_1920::some_name is already defined"
-        f" (original at ({modpath}/plugins/__init__.py:5:1))"
+        f" (original at ({modpath}/plugins/__init__.py:5))"
         f" (duplicate at ({modpath}/model/_init.cf:1:16))",
     )
 


### PR DESCRIPTION
# Description

I couldn't find a simple way to cleanly and reliably determine the correct `Range` for a plugin definition. This PR sets `Plugin.location` to a `Location` instance instead of the current (inaccurate) `Range` instance. Related to #2482

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] ~~Changelog entry~~
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
