### PR TITLE
Downgrade sphinx dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
   ignore:
     # ignore until this is resolved: https://github.com/ClearcodeHQ/pytest-postgresql/issues/338
     - dependency-name: "pytest-postgresql"
+    # Ignore until this is resolved: https://github.com/inmanta/inmanta/issues/2495
+    - dependency-name: "sphinx"

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ sphinx-argparse==0.2.5
 sphinx-autodoc-annotation==1.0-1
 sphinx-rtd-theme==0.5.0
 sphinx-tabs==1.3.0
-sphinx==3.3.0
+sphinx==3.2.1
 sphinxcontrib-serializinghtml==1.1.4
 sphinxcontrib-redoc==1.6.0
 texttable==1.6.3


### PR DESCRIPTION
# Description

Downgrade the sphinx dependency to version 3.2.1, because version 3.3.0 breaks the link check on the documentation (See: https://github.com/inmanta/inmanta/issues/2495).

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [ ] ~~Changelog entry~~
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
