### PR TITLE
Bumping pytest-postgresql version to 2.5.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,5 @@ updates:
     # Allow both direct and indirect updates for all packages
     - dependency-type: "all"
   ignore:
-    # ignore until this is resolved: https://github.com/ClearcodeHQ/pytest-postgresql/issues/338
-    - dependency-name: "pytest-postgresql"
     # Ignore until this is resolved: https://github.com/inmanta/inmanta/issues/2495
     - dependency-name: "sphinx"

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ tornado==6.1
 tox==3.20.1
 tox-venv==0.4.0
 asyncpg==0.21.0
-pytest-postgresql==2.5.0
+pytest-postgresql==2.5.2
 pytest-env==0.6.2
 jinja2==2.11.2
 pep8-naming==0.11.1


### PR DESCRIPTION
# Description

Bumping pytest-postgresql version to 2.5.2.

closes #2494 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] ~~Changelog entry~~
- [x] ~~Type annotations are present~~
- [x] ~~Code is clear and sufficiently documented~~
- [x] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] ~~Correct, in line with design~~
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
