### PR TITLE
Issue/2508 stop running compilations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug fixes
 - Fix broken links in the documentation (#2495)
+- Ensure all running compilations are stopped when the server is stopped (#2508)
 
 ## Upgrade notes
 - Ensure the database is backed up before executing an upgrade.

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -371,12 +371,6 @@ class CompilerService(ServerSlice):
         await self._recover()
         self.schedule(self._cleanup, opt.server_cleanup_compiler_reports_interval.get(), initial_delay=0)
 
-    async def prestop(self) -> None:
-        await super(CompilerService, self).prestop()
-
-    async def stop(self) -> None:
-        await super(CompilerService, self).stop()
-
     async def _cleanup(self) -> None:
         oldest_retained_date = datetime.datetime.now() - datetime.timedelta(seconds=opt.server_compiler_report_retention.get())
         LOGGER.info("Cleaning up compile reports that are older than %s", oldest_retained_date)

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -135,6 +135,7 @@ class Scheduler(object):
     def __init__(self, name: str) -> None:
         self.name = name
         self._scheduled: Dict[Callable, object] = {}
+        self._stopped = False
 
     def add_action(self, action: Union[Callable, Coroutine], interval: float, initial_delay: float = None) -> None:
         """
@@ -145,6 +146,10 @@ class Scheduler(object):
         :param initial_delay: Delay to the first execution, defaults to interval
         """
         assert inspect.iscoroutinefunction(action) or gen.is_coroutine_function(action)
+
+        if self._stopped:
+            LOGGER.warning("Scheduling action '%s', while scheduler is stopped", action.__name__)
+            return
 
         if initial_delay is None:
             initial_delay = interval
@@ -178,6 +183,7 @@ class Scheduler(object):
         """
         Stop the scheduler
         """
+        self._stopped = True
         try:
             # remove can still run during stop. That is why we loop until we get a keyerror == the dict is empty
             while True:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -72,6 +72,10 @@ async def test_scheduler_stop(caplog):
     assert len(i) == length
     no_error_in_logs(caplog)
 
+    caplog.clear()
+    sched.add_action(action, 0.05, 0)
+    assert "Scheduling action 'action', while scheduler is stopped" in caplog.messages
+
 
 @pytest.mark.asyncio
 async def test_scheduler_async_run_fail(caplog):


### PR DESCRIPTION
# Description

Ensure all running compilations are stopped when the server is stopped. The `CancelledError` should never be ignored.

closes #2508 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
