### PR TITLE
Issue/2500 agent api paging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added more specific location information for attributes (#2481)
 - Added plugin call anchors to support ctrl-clicking a plugin call (#1954)
 - Added rpdb signal handler (#2170)
+- Added pagination support on api calls for agent and agentproc (#2500)
 
 ## Bug fixes
 - Fix broken links in the documentation (#2495)

--- a/docs/platform_developers/define_api_endpoints.rst
+++ b/docs/platform_developers/define_api_endpoints.rst
@@ -56,6 +56,7 @@ An example is shown in the code snippet below.
     from inmanta.types import Apireturn
     from inmanta import data
     from inmanta.protocol import methods
+    from inmanta.protocol.exceptions import NotFound, ServerError
 
     @protocol.handle(methods.get_project, project_id="id")
     async def get_project(self, project_id: uuid.UUID) -> Apireturn:
@@ -64,16 +65,16 @@ An example is shown in the code snippet below.
             environments = await data.Environment.get_list(project=project_id)
 
             if project is None:
-                return 404, {"message": "The project with given id does not exist."}
+                raise NotFound("The project with given id does not exist.")
 
             project_dict = project.to_dict()
             project_dict["environments"] = [e.id for e in environments]
 
             return 200, {"project": project_dict}
         except ValueError:
-            return 404, {"message": "The project with given id does not exist."}
+            raise NotFound("The project with given id does not exist.")
 
-        return 500
+        raise ServerError()
 
 The first argument of the ``handle`` decorator defines that this is the handle function for the ``get_project`` API method.
 The second argument remaps the ``id`` argument of the API method to the ``project_id`` argument in the handle function.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ netifaces==0.10.9
 ply==3.11
 pytest-cover==3.0.0
 pytest-instafail==0.4.2
-pytest-randomly==3.4.1
+pytest-randomly==3.5.0
 pytest-sugar==0.9.4
 pytest-xdist==2.1.0
 python-dateutil==2.8.1

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -904,7 +904,9 @@ class AgentInstance(object):
                 self.logger.warning(
                     "Cannot retrieve fact for %s because resource is undeployable or code could not be loaded", resource["id"]
                 )
-                raise ServerError(f"Cannot retrieve fact for {resource['id']} because resource is undeployable or code could not be loaded")
+                raise ServerError(
+                    f"Cannot retrieve fact for {resource['id']} because resource is undeployable or code could not be loaded"
+                )
 
             started = datetime.datetime.now()
             provider = None

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -41,6 +41,7 @@ from inmanta.const import ParameterSource, ResourceState
 from inmanta.data.model import AttributeStateChange, Event, ResourceIdStr, ResourceVersionIdStr
 from inmanta.loader import CodeLoader, ModuleSource
 from inmanta.protocol import SessionEndpoint, methods, methods_v2
+from inmanta.protocol.exceptions import Forbidden, NotFound, ServerError
 from inmanta.resources import Id, Resource
 from inmanta.types import Apireturn, JsonType
 from inmanta.util import add_future
@@ -645,7 +646,7 @@ class AgentInstance(object):
 
     def unpause(self) -> Apireturn:
         if self._stopped:
-            return 403, "Cannot unpause stopped agent instance"
+            raise Forbidden("Cannot unpause stopped agent instance")
 
         if self.is_enabled():
             return 200, "already running"
@@ -903,7 +904,7 @@ class AgentInstance(object):
                 self.logger.warning(
                     "Cannot retrieve fact for %s because resource is undeployable or code could not be loaded", resource["id"]
                 )
-                return 500
+                raise ServerError(f"Cannot retrieve fact for {resource['id']} because resource is undeployable or code could not be loaded")
 
             started = datetime.datetime.now()
             provider = None
@@ -950,7 +951,7 @@ class AgentInstance(object):
 
             except Exception:
                 self.logger.exception("Unable to find a handler for %s", resource["id"])
-                return 500
+                raise ServerError(f"Unable to find a handler for {resource['id']}")
             finally:
                 if provider is not None:
                     provider.close()
@@ -1192,14 +1193,14 @@ class Agent(SessionEndpoint):
     def unpause(self, name: str) -> Apireturn:
         instance = self._instances.get(name)
         if not instance:
-            return 404, "No such agent"
+            raise NotFound("No such agent")
 
         return instance.unpause()
 
     def pause(self, name: str) -> Apireturn:
         instance = self._instances.get(name)
         if not instance:
-            return 404, "No such agent"
+            raise NotFound("No such agent")
 
         return instance.pause()
 
@@ -1289,7 +1290,7 @@ class Agent(SessionEndpoint):
             return 200
 
         if not instance.is_enabled():
-            return 500, "Agent is not _enabled"
+            raise ServerError("Agent is not _enabled")
 
         LOGGER.info("Agent %s got a trigger to update in environment %s", agent, env)
         self.add_background_task(

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -487,7 +487,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
     @classmethod
     async def get_list_paged(
         cls: Type[TBaseDocument],
-        order_by_column: str = None,
+        order_by_column: str,
         order: str = "ASC",
         limit: Optional[int] = None,
         start: Optional[Any] = None,
@@ -510,7 +510,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
         """
         query = cls._convert_field_names_to_db_column_names(query)
         (filter_statement, values) = cls._get_composed_filter(**query)
-        filter_statements = filter_statement.split(" AND ")
+        filter_statements = filter_statement.split(" AND ") if filter_statement != "" else []
         if start is not None:
             filter_statements.append(f"{order_by_column} > $" + str(len(values) + 1))
             values.append(cls._get_value(start))
@@ -520,8 +520,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
         sql_query = "SELECT * FROM " + cls.table_name()
         if len(filter_statements) > 0:
             sql_query += " WHERE " + " AND ".join(filter_statements)
-        if order_by_column is not None:
-            sql_query += " ORDER BY " + str(order_by_column) + " " + str(order)
+        sql_query += " ORDER BY " + str(order_by_column) + " " + str(order)
         if limit is not None and limit > 0:
             sql_query += " LIMIT " + str(limit)
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1118,8 +1118,8 @@ class AgentProcess(BaseDocument):
         environment_id: Optional[uuid.UUID] = None,
         expired: bool = True,
         limit: Optional[int] = DBLIMIT,
-        start: Optional[datetime.datetime] = None,
-        end: Optional[datetime.datetime] = None,
+        start: Optional[uuid.UUID] = None,
+        end: Optional[uuid.UUID] = None,
     ) -> List["AgentProcess"]:
         query = "SELECT * FROM " + cls.table_name()
         conditions_in_where_clause = []
@@ -1130,14 +1130,14 @@ class AgentProcess(BaseDocument):
             conditions_in_where_clause.append("environment=$1")
             values.append(cls._get_value(environment_id))
         if start:
-            conditions_in_where_clause.append("last_seen > $" + str(len(values) + 1))
+            conditions_in_where_clause.append("sid > $" + str(len(values) + 1))
             values.append(cls._get_value(start))
         if end:
-            conditions_in_where_clause.append("last_seen < $" + str(len(values) + 1))
+            conditions_in_where_clause.append("sid < $" + str(len(values) + 1))
             values.append(cls._get_value(end))
         if len(conditions_in_where_clause) > 0:
             query += " WHERE " + " AND ".join(conditions_in_where_clause)
-        query += f" ORDER BY last_seen ASC NULLS LAST"
+        query += f" ORDER BY sid ASC NULLS LAST"
         if limit:
             query += " LIMIT $" + str(len(values) + 1)
             values.append(cls._get_value(limit))

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -510,15 +510,16 @@ class BaseDocument(object, metaclass=DocumentMeta):
         """
         query = cls._convert_field_names_to_db_column_names(query)
         (filter_statement, values) = cls._get_composed_filter(**query)
+        filter_statements = filter_statement.split(" AND ")
         if start is not None:
-            filter_statement += f" AND {order_by_column} > $" + str(len(values) + 1)
+            filter_statements.append(f"{order_by_column} > $" + str(len(values) + 1))
             values.append(cls._get_value(start))
         if end is not None:
-            filter_statement += f" AND {order_by_column} < $" + str(len(values) + 1)
+            filter_statements.append(f"{order_by_column} < $" + str(len(values) + 1))
             values.append(cls._get_value(end))
         sql_query = "SELECT * FROM " + cls.table_name()
-        if filter_statement:
-            sql_query += " WHERE " + filter_statement
+        if len(filter_statements) > 0:
+            sql_query += " WHERE " + " AND ".join(filter_statements)
         if order_by_column is not None:
             sql_query += " ORDER BY " + str(order_by_column) + " " + str(order)
         if limit is not None and limit > 0:

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -33,7 +33,6 @@ from asyncpg.protocol import Record
 
 import inmanta.db.versions
 from inmanta import const, resources, util
-from inmanta.config import Option
 from inmanta.const import DONE_STATES, UNDEPLOYABLE_NAMES, AgentStatus, ResourceState
 from inmanta.data import model as m
 from inmanta.data import schema
@@ -515,8 +514,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
             sql_query += " ORDER BY " + str(order_by_column) + " " + str(order)
         if limit is not None and limit > 0:
             sql_query += " LIMIT " + str(limit)
-        print(query)
-        print(sql_query)
+
         result = await cls.select_query(sql_query, values, no_obj=no_obj, connection=connection)
         return result
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -476,14 +476,14 @@ class BaseDocument(object, metaclass=DocumentMeta):
         if filter_statement:
             sql_query += " WHERE " + filter_statement
         if order_by_column is not None:
-            sql_query += " ORDER BY $" + str(len(values) + 1) + " $" + str(len(values) + 2)
-            values.extend([str(order_by_column), str(order)])
+            sql_query += " ORDER BY $" + str(len(values) + 1) + str(order)
+            values.append(str(order_by_column))
         if limit is not None and limit > 0:
             sql_query += " LIMIT $" + str(len(values) + 1)
-            values.append(str(limit))
+            values.append(int(limit))
         if offset is not None and offset > 0:
             sql_query += " OFFSET $" + str(len(values) + 1)
-            values.append(str(offset))
+            values.append(int(offset))
         result = await cls.select_query(sql_query, values, no_obj=no_obj, connection=connection)
         return result
 
@@ -526,11 +526,11 @@ class BaseDocument(object, metaclass=DocumentMeta):
         if len(filter_statements) > 0:
             sql_query += " WHERE " + " AND ".join(filter_statements)
         if order_by_column is not None:
-            sql_query += " ORDER BY $" + str(len(values) + 1) + " $" + str(len(values) + 2)
-            values.extend([str(order_by_column), str(order)])
+            sql_query += " ORDER BY $" + str(len(values) + 1) + str(order)
+            values.append(str(order_by_column))
         if limit is not None and limit > 0:
             sql_query += " LIMIT $" + str(len(values) + 1)
-            values.append(str(limit))
+            values.append(int(limit))
 
         result = await cls.select_query(sql_query, values, no_obj=no_obj, connection=connection)
         return result

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -476,11 +476,14 @@ class BaseDocument(object, metaclass=DocumentMeta):
         if filter_statement:
             sql_query += " WHERE " + filter_statement
         if order_by_column is not None:
-            sql_query += " ORDER BY " + str(order_by_column) + " " + str(order)
+            sql_query += " ORDER BY $" + str(len(values) + 1) + " $" + str(len(values) + 2)
+            values.extend([str(order_by_column), str(order)])
         if limit is not None and limit > 0:
-            sql_query += " LIMIT " + str(limit)
+            sql_query += " LIMIT $" + str(len(values) + 1)
+            values.append(str(limit))
         if offset is not None and offset > 0:
-            sql_query += " OFFSET " + str(offset)
+            sql_query += " OFFSET $" + str(len(values) + 1)
+            values.append(str(offset))
         result = await cls.select_query(sql_query, values, no_obj=no_obj, connection=connection)
         return result
 
@@ -523,11 +526,11 @@ class BaseDocument(object, metaclass=DocumentMeta):
         if len(filter_statements) > 0:
             sql_query += " WHERE " + " AND ".join(filter_statements)
         if order_by_column is not None:
-            sql_query += " ORDER BY " + str(len(values) + 1) + " " + str(len(values) + 1)
-            values.extend([order_by_column, order])
+            sql_query += " ORDER BY $" + str(len(values) + 1) + " $" + str(len(values) + 2)
+            values.extend([str(order_by_column), str(order)])
         if limit is not None and limit > 0:
-            sql_query += " LIMIT " + str(len(values) + 1)
-            values.append(limit)
+            sql_query += " LIMIT $" + str(len(values) + 1)
+            values.append(str(limit))
 
         result = await cls.select_query(sql_query, values, no_obj=no_obj, connection=connection)
         return result

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -474,7 +474,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
             possible = ["ASC", "DESC", "NULLS", "FIRST", "LAST"]
             if o not in possible:
                 raise RuntimeError("The following order can not be applied: {order}, {o} should be one of {possible}")
-        
+
         query = cls._convert_field_names_to_db_column_names(query)
         (filter_statement, values) = cls._get_composed_filter(**query)
         sql_query = "SELECT * FROM " + cls.table_name()
@@ -522,7 +522,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
             possible = ["ASC", "DESC", "NULLS", "FIRST", "LAST"]
             if o not in possible:
                 raise RuntimeError("The following order can not be applied: {order}, {o} should be one of {possible}")
-        
+
         query = cls._convert_field_names_to_db_column_names(query)
         (filter_statement, values) = cls._get_composed_filter(**query)
         filter_statements = filter_statement.split(" AND ") if filter_statement != "" else []

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -473,7 +473,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
         for o in order.split(" "):
             possible = ["ASC", "DESC", "NULLS", "FIRST", "LAST"]
             if o not in possible:
-                raise RuntimeError("The following order can not be applied: {order}, {o} should be one of {possible}")
+                raise RuntimeError(f"The following order can not be applied: {order}, {o} should be one of {possible}")
 
         query = cls._convert_field_names_to_db_column_names(query)
         (filter_statement, values) = cls._get_composed_filter(**query)

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -470,6 +470,11 @@ class BaseDocument(object, metaclass=DocumentMeta):
         """
         Get a list of documents matching the filter args
         """
+        for o in order.split(" "):
+            possible = ["ASC", "DESC", "NULLS", "FIRST", "LAST"]
+            if o not in possible:
+                raise RuntimeError("The following order can not be applied: {order}, {o} should be one of {possible}")
+        
         query = cls._convert_field_names_to_db_column_names(query)
         (filter_statement, values) = cls._get_composed_filter(**query)
         sql_query = "SELECT * FROM " + cls.table_name()
@@ -513,6 +518,11 @@ class BaseDocument(object, metaclass=DocumentMeta):
         :param connection: An optional connection
         :param **query: Any additional filter to apply
         """
+        for o in order.split(" "):
+            possible = ["ASC", "DESC", "NULLS", "FIRST", "LAST"]
+            if o not in possible:
+                raise RuntimeError("The following order can not be applied: {order}, {o} should be one of {possible}")
+        
         query = cls._convert_field_names_to_db_column_names(query)
         (filter_statement, values) = cls._get_composed_filter(**query)
         filter_statements = filter_statement.split(" AND ") if filter_statement != "" else []

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1529,32 +1529,6 @@ class Compile(BaseDocument):
     compile_data: Optional[dict] = Field(field_type=dict)
 
     @classmethod
-    async def get_reports(
-        cls,
-        environment_id: uuid.UUID,
-        limit: Optional[int] = None,
-        start: Optional[datetime.datetime] = None,
-        end: Optional[datetime.datetime] = None,
-    ) -> List[JsonType]:
-        query = "SELECT * FROM " + cls.table_name()
-        conditions_in_where_clause = ["environment=$1"]
-        values = [cls._get_value(environment_id)]
-        if start:
-            conditions_in_where_clause.append("started > $" + str(len(values) + 1))
-            values.append(cls._get_value(start))
-        if end:
-            conditions_in_where_clause.append("started < $" + str(len(values) + 1))
-            values.append(cls._get_value(end))
-        if len(conditions_in_where_clause) > 0:
-            query += " WHERE " + " AND ".join(conditions_in_where_clause)
-        query += " ORDER BY started DESC"
-        if limit:
-            query += " LIMIT $" + str(len(values) + 1)
-            values.append(cls._get_value(limit))
-
-        return [m.to_dict() for m in await cls.select_query(query, values)]
-
-    @classmethod
     # TODO: Use join
     async def get_report(cls, compile_id: uuid.UUID) -> "Compile":
         """

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -497,14 +497,23 @@ class BaseDocument(object, metaclass=DocumentMeta):
         **query: Any,
     ) -> List[TBaseDocument]:
         """
-        Get a list of documents matching the filter args
+        Get a list of documents matching the filter args, with paging support
+
+        :param order_by_column: The name of the column in the database the sorting should be based on
+        :param order: The order to apply to the sorting
+        :param limit: If specified, the maximum number of entries to return
+        :param start: A value conforming the sorting column type, all returned rows will have greater value in the sorted column
+        :param end: A value conforming the sorting column type, all returned rows will have lower value in the sorted column
+        :param no_obj: Whether not to cast the query result into a matching object
+        :param connection: An optional connection
+        :param **query: Any additonnal filter to apply
         """
         query = cls._convert_field_names_to_db_column_names(query)
         (filter_statement, values) = cls._get_composed_filter(**query)
-        if start:
+        if start is not None:
             filter_statement += f" AND {order_by_column} > $" + str(len(values) + 1)
             values.append(cls._get_value(start))
-        if end:
+        if end is not None:
             filter_statement += f" AND {order_by_column} < $" + str(len(values) + 1)
             values.append(cls._get_value(end))
         sql_query = "SELECT * FROM " + cls.table_name()

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -521,7 +521,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
         for o in order.split(" "):
             possible = ["ASC", "DESC", "NULLS", "FIRST", "LAST"]
             if o not in possible:
-                raise RuntimeError("The following order can not be applied: {order}, {o} should be one of {possible}")
+                raise RuntimeError(f"The following order can not be applied: {order}, {o} should be one of {possible}")
 
         query = cls._convert_field_names_to_db_column_names(query)
         (filter_statement, values) = cls._get_composed_filter(**query)

--- a/src/inmanta/protocol/exceptions.py
+++ b/src/inmanta/protocol/exceptions.py
@@ -79,7 +79,7 @@ class UnauthorizedException(BaseHttpException):
 
 class BadRequest(BaseHttpException):
     """
-    This exception is raised for a mailformed request
+    This exception is raised for a malformed request
     """
 
     def __init__(self, message: Optional[str] = None, details: Optional[JsonType] = None) -> None:

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -857,12 +857,17 @@ def get_report(id: uuid.UUID):
 
 
 @method(path="/agentproc", operation="GET", client_types=[const.ClientType.api])
-def list_agent_processes(environment: uuid.UUID = None, expired: bool = True):
+def list_agent_processes(
+    environment: uuid.UUID = None, expired: bool = True, start: str = None, end: str = None, limit: int = None
+):
     """
     Return a list of all nodes and the agents for these nodes
 
     :param environment: An optional environment. If set, only the agents that belong to this environment are returned
     :param all: Optional, also show expired.
+    :param start: Reports after start
+    :param end: Reports before end
+    :param limit: Maximum number of results, up to a maximum of 1000
     :return: A list of nodes
     """
 

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -869,7 +869,6 @@ def list_agent_processes(
     :param end: Agent processes before end (sorted by sid in ASC)
     :param limit: Maximum number of results, up to a maximum of 1000
 
-    :raises BadRequest: Limit, start and end can not be set together
     :raises BadRequest: limit parameter can not exceed 1000
     :raises NotFound: The given environment id does not exist!
 
@@ -909,7 +908,6 @@ def list_agents(tid: uuid.UUID, start: str = None, end: str = None, limit: int =
     :param end: Agent before end (sorted by name in ASC)
     :param limit: Maximum number of results, up to a maximum of 1000
 
-    :raises BadRequest: Limit, start and end can not be set together
     :raises BadRequest: limit parameter can not exceed 1000
     :raises NotFound: The given environment id does not exist!
     """

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -858,15 +858,15 @@ def get_report(id: uuid.UUID):
 
 @method(path="/agentproc", operation="GET", client_types=[const.ClientType.api])
 def list_agent_processes(
-    environment: uuid.UUID = None, expired: bool = True, start: str = None, end: str = None, limit: int = None
+    environment: uuid.UUID = None, expired: bool = True, start: uuid.UUID = None, end: uuid.UUID = None, limit: int = None
 ):
     """
     Return a list of all nodes and the agents for these nodes
 
     :param environment: An optional environment. If set, only the agents that belong to this environment are returned
     :param all: Optional, also show expired.
-    :param start: Reports after start
-    :param end: Reports before end
+    :param start: Agent processes after start (sorted by sid in ASC)
+    :param end: Agent processes before end (sorted by sid in ASC)
     :param limit: Maximum number of results, up to a maximum of 1000
     :return: A list of nodes
     """

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -895,11 +895,14 @@ def trigger_agent(tid: uuid.UUID, id: str):
 
 
 @method(path="/agent", operation="GET", api=True, timeout=5, arg_options=ENV_OPTS, client_types=[const.ClientType.api])
-def list_agents(tid: uuid.UUID):
+def list_agents(tid: uuid.UUID, start: str = None, end: str = None, limit: int = None):
     """
     List all agent for an environment
 
     :param tid: The environment the agents are defined in
+    :param start: Agent after start (sorted by name in ASC)
+    :param end: Agent before end (sorted by name in ASC)
+    :param limit: Maximum number of results, up to a maximum of 1000
     """
 
 

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -33,7 +33,7 @@ async def convert_environment(env: uuid.UUID, metadata: dict) -> data.Environmen
     metadata[const.INMANTA_URN + "env"] = str(env)
     env = await data.Environment.get_by_id(env)
     if env is None:
-        raise exceptions.NotFound("the given environment id does not exist!")
+        raise exceptions.NotFound("The given environment id does not exist!")
     return env
 
 
@@ -864,10 +864,15 @@ def list_agent_processes(
     Return a list of all nodes and the agents for these nodes
 
     :param environment: An optional environment. If set, only the agents that belong to this environment are returned
-    :param all: Optional, also show expired.
+    :param expired: Optional, also show expired.
     :param start: Agent processes after start (sorted by sid in ASC)
     :param end: Agent processes before end (sorted by sid in ASC)
     :param limit: Maximum number of results, up to a maximum of 1000
+
+    :raises BadRequest: Limit, start and end can not be set together
+    :raises BadRequest: limit parameter can not exceed 1000
+    :raises NotFound: The given environment id does not exist!
+
     :return: A list of nodes
     """
 
@@ -903,6 +908,10 @@ def list_agents(tid: uuid.UUID, start: str = None, end: str = None, limit: int =
     :param start: Agent after start (sorted by name in ASC)
     :param end: Agent before end (sorted by name in ASC)
     :param limit: Maximum number of results, up to a maximum of 1000
+
+    :raises BadRequest: Limit, start and end can not be set together
+    :raises BadRequest: limit parameter can not exceed 1000
+    :raises NotFound: The given environment id does not exist!
     """
 
 

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -849,7 +849,7 @@ def get_report(id: uuid.UUID):
     """
     Get a compile report from the server
 
-    :param compile_id: The id of the compile and its reports to fetch.
+    :param id: The id of the compile and its reports to fetch.
     """
 
 
@@ -864,7 +864,7 @@ def list_agent_processes(
     Return a list of all nodes and the agents for these nodes
 
     :param environment: An optional environment. If set, only the agents that belong to this environment are returned
-    :param expired: Optional, also show expired.
+    :param expired: Optional, also show expired processes, otherwise only living processes are shown.
     :param start: Agent processes after start (sorted by sid in ASC)
     :param end: Agent processes before end (sorted by sid in ASC)
     :param limit: Maximum number of results, up to a maximum of 1000
@@ -882,7 +882,7 @@ def get_agent_process(id: uuid.UUID):
     """
     Return a detailed report for a node
 
-    :param agent_sid: The session id of the agent
+    :param id: The session id of the agent
     :return: The requested node
     """
 

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -643,9 +643,9 @@ class AgentManager(ServerSlice, SessionListener):
         self,
         environment: Optional[UUID],
         expired: bool,
-        start: Optional[str] = None,
-        end: Optional[str] = None,
-        limit: Optional[int] = None,
+        start: Optional[UUID] = None,
+        end: Optional[UUID] = None,
+        limit: Optional[UUID] = None,
     ) -> Apireturn:
         argscount = len([x for x in [start, end, limit] if x is not None])
         if argscount == 3:
@@ -660,14 +660,7 @@ class AgentManager(ServerSlice, SessionListener):
         elif limit > APILIMIT:
             raise BadRequest(f"limit parameter can not exceed {APILIMIT}, got {limit}.")
 
-        start_time = None
-        end_time = None
-        if start is not None:
-            start_time = dateutil.parser.parse(start)
-        if end is not None:
-            end_time = dateutil.parser.parse(end)
-
-        aps = await data.AgentProcess.get_agent_processes(environment, expired, limit, start_time, end_time)
+        aps = await data.AgentProcess.get_agent_processes(environment, expired, limit, start, end)
 
         processes = []
         for p in aps:

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -687,7 +687,7 @@ class AgentManager(ServerSlice, SessionListener):
             raise BadRequest(f"limit parameter can not exceed {APILIMIT}, got {limit}.")
         
         tid = env.id
-        ags = await data.Agent.get_agents(tid, start, end, limit)
+        ags = await data.Agent.get_agents(tid, limit, start, end)
 
         return 200, {"agents": [a.to_dict() for a in ags], "servertime": datetime.now().isoformat(timespec="microseconds")}
 

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -663,8 +663,7 @@ class AgentManager(ServerSlice, SessionListener):
             raise BadRequest(f"limit parameter can not exceed {APILIMIT}, got {limit}.")
 
         aps = await data.AgentProcess.get_list_paged(
-            order_by_column="sid",
-            order="ASC NULLS LAST",
+            page_by_column="sid",
             limit=limit,
             start=start,
             end=end,
@@ -707,6 +706,7 @@ class AgentManager(ServerSlice, SessionListener):
             raise BadRequest(f"limit parameter can not exceed {APILIMIT}, got {limit}.")
 
         ags = await data.Agent.get_list_paged(
+            page_by_column="name",
             order_by_column="name",
             order="ASC NULLS LAST",
             limit=limit,

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -30,7 +30,6 @@ from uuid import UUID
 import asyncpg
 
 from inmanta import const, data
-from inmanta.ast.constraint.expression import Not
 from inmanta.config import Config
 from inmanta.const import AgentAction, AgentStatus
 from inmanta.data import APILIMIT

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -649,8 +649,8 @@ class AgentManager(ServerSlice, SessionListener):
 
         :param environment: Optional, the environment the agent should come from.
         :param expired: If True, expired agents will also be shown, they are hidden otherwise.
-        :param start: The sid all of the selected agent process should be greater than (non included in output), defaults to None
-        :param end: The sid all of the selected agent process should be smaller than (non included in output), defaults to None
+        :param start: The sid all of the selected agent process should be greater than this, defaults to None
+        :param end: The sid all of the selected agent process should be smaller than this, defaults to None
         :param limit: Whether to limit the number of returned entries, defaults to None
         :raises BadRequest: Limit, start and end can not be set together
         :raises NotFound: The given environment id does not exist!
@@ -707,8 +707,8 @@ class AgentManager(ServerSlice, SessionListener):
         """List all agents whose name is after start and before end
 
         :param env: The environment the agents should come from
-        :param start: The name all of the selected agent should be greater than (non included in output), defaults to None
-        :param end: The name all of the selected agent should be smaller than (non included in output), defaults to None
+        :param start: The name all of the selected agent should be greater than this, defaults to None
+        :param end: The name all of the selected agent should be smaller than this, defaults to None
         :param limit: Whether to limit the number of returned entries, defaults to None
         :raises BadRequest: Limit, start and end can not be set together
         :raises BadRequest: Limit parameter can not exceed 1000

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -645,6 +645,17 @@ class AgentManager(ServerSlice, SessionListener):
         end: Optional[UUID] = None,
         limit: Optional[int] = None,
     ) -> Apireturn:
+        """List all agent processes whose sid is after start and before end
+
+        :param environment: Optional, the environment the agent should come from.
+        :param expired: If True, expired agents will also be shown, they are hidden otherwise.
+        :param start: The sid all of the selected agent process should be greater than (non included in output), defaults to None
+        :param end: The sid all of the selected agent process should be smaller than (non included in output), defaults to None
+        :param limit: Whether to limit the number of returned entries, defaults to None
+        :raises BadRequest: Limit, start and end can not be set together
+        :raises NotFound: The given environment id does not exist!
+        :raises BadRequest: Limit parameter can not exceed 1000
+        """
         query: Dict[str, Any] = {}
         argscount = len([x for x in [start, end, limit] if x is not None])
         if argscount == 3:
@@ -660,7 +671,7 @@ class AgentManager(ServerSlice, SessionListener):
         if limit is None:
             limit = APILIMIT
         elif limit > APILIMIT:
-            raise BadRequest(f"limit parameter can not exceed {APILIMIT}, got {limit}.")
+            raise BadRequest(f"Limit parameter can not exceed {APILIMIT}, got {limit}.")
 
         aps = await data.AgentProcess.get_list_paged(
             page_by_column="sid",
@@ -693,6 +704,15 @@ class AgentManager(ServerSlice, SessionListener):
         end: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> Apireturn:
+        """List all agents whose name is after start and before end
+
+        :param env: The environment the agents should come from
+        :param start: The name all of the selected agent should be greater than (non included in output), defaults to None
+        :param end: The name all of the selected agent should be smaller than (non included in output), defaults to None
+        :param limit: Whether to limit the number of returned entries, defaults to None
+        :raises BadRequest: Limit, start and end can not be set together
+        :raises BadRequest: Limit parameter can not exceed 1000
+        """
         query = {}
         argscount = len([x for x in [start, end, limit] if x is not None])
         if argscount == 3:
@@ -703,7 +723,7 @@ class AgentManager(ServerSlice, SessionListener):
         if limit is None:
             limit = APILIMIT
         elif limit > APILIMIT:
-            raise BadRequest(f"limit parameter can not exceed {APILIMIT}, got {limit}.")
+            raise BadRequest(f"Limit parameter can not exceed {APILIMIT}, got {limit}.")
 
         ags = await data.Agent.get_list_paged(
             page_by_column="name",

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -657,9 +657,6 @@ class AgentManager(ServerSlice, SessionListener):
         :raises BadRequest: Limit parameter can not exceed 1000
         """
         query: Dict[str, Any] = {}
-        argscount = len([x for x in [start, end, limit] if x is not None])
-        if argscount == 3:
-            raise BadRequest("Limit, start and end can not be set together")
         if environment is not None:
             query["environment"] = environment
             env = await data.Environment.get_by_id(environment)
@@ -714,9 +711,6 @@ class AgentManager(ServerSlice, SessionListener):
         :raises BadRequest: Limit parameter can not exceed 1000
         """
         query = {}
-        argscount = len([x for x in [start, end, limit] if x is not None])
-        if argscount == 3:
-            raise BadRequest("Limit, start and end can not be set together")
         if env is not None:
             query["environment"] = env.id
 

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -28,8 +28,6 @@ from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
 from uuid import UUID
 
 import asyncpg
-import dateutil
-import dateutil.parser
 
 from inmanta import const, data
 from inmanta.config import Config
@@ -665,12 +663,7 @@ class AgentManager(ServerSlice, SessionListener):
             raise BadRequest(f"limit parameter can not exceed {APILIMIT}, got {limit}.")
 
         aps = await data.AgentProcess.get_list_paged(
-            order_by_column="sid",
-            order="ASC NULLS LAST",
-            limit=limit,
-            start=start,
-            end=end,
-            **query
+            order_by_column="sid", order="ASC NULLS LAST", limit=limit, start=start, end=end, **query
         )
 
         processes = []
@@ -687,7 +680,9 @@ class AgentManager(ServerSlice, SessionListener):
         return 200, {"processes": processes}
 
     @protocol.handle(methods.list_agents, env="tid")
-    async def list_agents(self, env: Optional[data.Environment], start: str = None, end: str = None, limit: int = None) -> Apireturn:
+    async def list_agents(
+        self, env: Optional[data.Environment], start: str = None, end: str = None, limit: int = None
+    ) -> Apireturn:
         query = {}
         argscount = len([x for x in [start, end, limit] if x is not None])
         if argscount == 3:
@@ -699,14 +694,9 @@ class AgentManager(ServerSlice, SessionListener):
             limit = APILIMIT
         elif limit > APILIMIT:
             raise BadRequest(f"limit parameter can not exceed {APILIMIT}, got {limit}.")
-        
+
         ags = await data.Agent.get_list_paged(
-            order_by_column="name",
-            order="ASC NULLS LAST",
-            limit=limit,
-            start=start,
-            end=end,
-            **query
+            order_by_column="name", order="ASC NULLS LAST", limit=limit, start=start, end=end, **query
         )
 
         return 200, {"agents": [a.to_dict() for a in ags], "servertime": datetime.now().isoformat(timespec="microseconds")}

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -681,7 +681,11 @@ class AgentManager(ServerSlice, SessionListener):
 
     @protocol.handle(methods.list_agents, env="tid")
     async def list_agents(
-        self, env: Optional[data.Environment], start: str = None, end: str = None, limit: int = None
+        self,
+        env: Optional[data.Environment],
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+        limit: Optional[int] = None,
     ) -> Apireturn:
         query = {}
         argscount = len([x for x in [start, end, limit] if x is not None])

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -24,7 +24,7 @@ import uuid
 from asyncio import queues, subprocess
 from datetime import datetime
 from enum import Enum
-from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 from uuid import UUID
 
 import asyncpg
@@ -643,9 +643,9 @@ class AgentManager(ServerSlice, SessionListener):
         expired: Optional[bool] = None,
         start: Optional[UUID] = None,
         end: Optional[UUID] = None,
-        limit: Optional[UUID] = None,
+        limit: Optional[int] = None,
     ) -> Apireturn:
-        query = {}
+        query: Dict[str, Any] = {}
         argscount = len([x for x in [start, end, limit] if x is not None])
         if argscount == 3:
             return 500, {"message": "Limit, start and end can not be set together"}
@@ -663,7 +663,7 @@ class AgentManager(ServerSlice, SessionListener):
             raise BadRequest(f"limit parameter can not exceed {APILIMIT}, got {limit}.")
 
         aps = await data.AgentProcess.get_list_paged(
-            order_by_column="sid", order="ASC NULLS LAST", limit=limit, start=start, end=end, **query
+            order_by_column="sid", order="ASC NULLS LAST", limit=limit, start=start, end=end, no_obj=False, connection=None, **query
         )
 
         processes = []
@@ -700,7 +700,7 @@ class AgentManager(ServerSlice, SessionListener):
             raise BadRequest(f"limit parameter can not exceed {APILIMIT}, got {limit}.")
 
         ags = await data.Agent.get_list_paged(
-            order_by_column="name", order="ASC NULLS LAST", limit=limit, start=start, end=end, **query
+            order_by_column="name", order="ASC NULLS LAST", limit=limit, start=start, end=end, no_obj=False, connection=None, **query
         )
 
         return 200, {"agents": [a.to_dict() for a in ags], "servertime": datetime.now().isoformat(timespec="microseconds")}

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -639,8 +639,8 @@ class AgentManager(ServerSlice, SessionListener):
     @protocol.handle(methods.list_agent_processes)
     async def list_agent_processes(
         self,
-        environment: Optional[UUID] = None,
-        expired: Optional[bool] = None,
+        environment: Optional[UUID],
+        expired: bool,
         start: Optional[UUID] = None,
         end: Optional[UUID] = None,
         limit: Optional[int] = None,
@@ -654,7 +654,7 @@ class AgentManager(ServerSlice, SessionListener):
             env = await data.Environment.get_by_id(environment)
             if env is None:
                 raise NotFound("The given environment id does not exist!")
-        if expired is None or not expired:
+        if not expired:
             query["expired"] = None
 
         if limit is None:

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -663,7 +663,14 @@ class AgentManager(ServerSlice, SessionListener):
             raise BadRequest(f"limit parameter can not exceed {APILIMIT}, got {limit}.")
 
         aps = await data.AgentProcess.get_list_paged(
-            order_by_column="sid", order="ASC NULLS LAST", limit=limit, start=start, end=end, no_obj=False, connection=None, **query
+            order_by_column="sid",
+            order="ASC NULLS LAST",
+            limit=limit,
+            start=start,
+            end=end,
+            no_obj=False,
+            connection=None,
+            **query,
         )
 
         processes = []
@@ -700,7 +707,14 @@ class AgentManager(ServerSlice, SessionListener):
             raise BadRequest(f"limit parameter can not exceed {APILIMIT}, got {limit}.")
 
         ags = await data.Agent.get_list_paged(
-            order_by_column="name", order="ASC NULLS LAST", limit=limit, start=start, end=end, no_obj=False, connection=None, **query
+            order_by_column="name",
+            order="ASC NULLS LAST",
+            limit=limit,
+            start=start,
+            end=end,
+            no_obj=False,
+            connection=None,
+            **query,
         )
 
         return 200, {"agents": [a.to_dict() for a in ags], "servertime": datetime.now().isoformat(timespec="microseconds")}

--- a/src/inmanta/server/services/codeservice.py
+++ b/src/inmanta/server/services/codeservice.py
@@ -55,7 +55,7 @@ class CodeService(protocol.ServerSlice):
 
         hasherrors = any((k != hash_file(content[2].encode()) for k, content in sources.items()))
         if hasherrors:
-            return 400, {"message": "Hashes in source map do not match to source_code"}
+            raise BadRequest("Hashes in source map do not match to source_code")
 
         for file_hash in self.file_slice.stat_file_internal(sources.keys()):
             self.file_slice.upload_file_internal(file_hash, sources[file_hash][2].encode())

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -588,9 +588,9 @@ class CompilerService(ServerSlice):
     ) -> Apireturn:
         argscount = len([x for x in [start, end, limit] if x is not None])
         if argscount == 3:
-            return 500, {"message": "Limit, start and end can not be set together"}
+            raise BadRequest("Limit, start and end can not be set together")
         if env is None:
-            return 404, {"message": "The given environment id does not exist!"}
+            raise NotFound("The given environment id does not exist!")
 
         if limit is None:
             limit = APILIMIT
@@ -623,7 +623,7 @@ class CompilerService(ServerSlice):
         report = await data.Compile.get_report(compile_id)
 
         if report is None:
-            return 404
+            raise NotFound("This report wasn't found")
 
         return 200, {"report": report}
 

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -605,6 +605,7 @@ class CompilerService(ServerSlice):
             end_time = dateutil.parser.parse(end)
 
         models = await data.Compile.get_list_paged(
+            page_by_column="started",
             order_by_column="started",
             order="DESC",
             limit=limit,

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -603,7 +603,15 @@ class CompilerService(ServerSlice):
             start_time = dateutil.parser.parse(start)
         if end is not None:
             end_time = dateutil.parser.parse(end)
-        models = await data.Compile.get_reports(env.id, limit, start_time, end_time)
+
+        models = await data.Compile.get_list_paged(
+            order_by_column="started",
+            order="DESC",
+            limit=limit,
+            start=start_time,
+            end=end_time,
+            environment=env.id,
+        )
 
         return 200, {"reports": models}
 

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -610,6 +610,8 @@ class CompilerService(ServerSlice):
             limit=limit,
             start=start_time,
             end=end_time,
+            no_obj=False,
+            connection=None,
             environment=env.id,
         )
 

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -586,9 +586,6 @@ class CompilerService(ServerSlice):
     async def get_reports(
         self, env: data.Environment, start: Optional[str] = None, end: Optional[str] = None, limit: Optional[int] = None
     ) -> Apireturn:
-        argscount = len([x for x in [start, end, limit] if x is not None])
-        if argscount == 3:
-            raise BadRequest("Limit, start and end can not be set together")
         if env is None:
             raise NotFound("The given environment id does not exist!")
 

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -613,7 +613,7 @@ class CompilerService(ServerSlice):
             environment=env.id,
         )
 
-        return 200, {"reports": models}
+        return 200, {"reports": [m.to_dict() for m in models]}
 
     @protocol.handle(methods.get_report, compile_id="id")
     async def get_report(self, compile_id: uuid.UUID) -> Apireturn:

--- a/src/inmanta/server/services/dryrunservice.py
+++ b/src/inmanta/server/services/dryrunservice.py
@@ -64,7 +64,7 @@ class DyrunService(protocol.ServerSlice):
     async def dryrun_request(self, env: data.Environment, version_id: int) -> Apireturn:
         model = await data.ConfigurationModel.get_version(environment=env.id, version=version_id)
         if model is None:
-            return 404, {"message": "The request version does not exist."}
+            raise NotFound("The request version does not exist.")
 
         # fetch all resource in this cm and create a list of distinct agents
         rvs = await data.Resource.get_list(model=version_id, environment=env.id)

--- a/src/inmanta/server/services/fileservice.py
+++ b/src/inmanta/server/services/fileservice.py
@@ -75,7 +75,7 @@ class FileService(protocol.ServerSlice):
         if os.path.exists(file_name):
             return 200
         else:
-            return 404
+            raise NotFound()
 
     @protocol.handle(methods.get_file, file_hash="id")
     async def get_file(self, file_hash: str) -> Apireturn:

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -29,7 +29,7 @@ from inmanta.data import APILIMIT, ENVIRONMENT_AGENT_TRIGGER_METHOD, PURGE_ON_DE
 from inmanta.data.model import ResourceIdStr, ResourceVersionIdStr
 from inmanta.protocol import methods, methods_v2
 from inmanta.protocol.common import attach_warnings
-from inmanta.protocol.exceptions import BadRequest, ServerError
+from inmanta.protocol.exceptions import BadRequest, NotFound, ServerError
 from inmanta.resources import Id
 from inmanta.server import (
     SLICE_AGENT_MANAGER,
@@ -129,11 +129,11 @@ class OrchestrationService(protocol.ServerSlice):
     ) -> Apireturn:
         version = await data.ConfigurationModel.get_version(env.id, version_id)
         if version is None:
-            return 404, {"message": "The given configuration model does not exist yet."}
+            raise NotFound("The given configuration model does not exist yet.")
 
         resources = await data.Resource.get_resources_for_version(env.id, version_id, no_obj=True)
         if resources is None:
-            return 404, {"message": "The given configuration model does not exist yet."}
+            raise NotFound("The given configuration model does not exist yet.")
 
         if limit is None:
             limit = APILIMIT
@@ -169,7 +169,7 @@ class OrchestrationService(protocol.ServerSlice):
     async def delete_version(self, env, version_id):
         version = await data.ConfigurationModel.get_version(env.id, version_id)
         if version is None:
-            return 404, {"message": "The given configuration model does not exist yet."}
+            raise NotFound("The given configuration model does not exist yet.")
 
         await version.delete_cascade()
         return 200
@@ -406,7 +406,7 @@ class OrchestrationService(protocol.ServerSlice):
     ) -> Apireturn:
         model = await data.ConfigurationModel.get_version(env.id, version_id)
         if model is None:
-            return 404, {"message": "The request version does not exist."}
+            raise NotFound("The request version does not exist.")
 
         await model.update_fields(released=True, result=const.VersionState.deploying)
 
@@ -483,7 +483,7 @@ class OrchestrationService(protocol.ServerSlice):
         # get latest version
         version_id = await data.ConfigurationModel.get_version_nr_latest_version(env.id)
         if version_id is None:
-            return 404, {"message": "No version available"}
+            raise NotFound("No version available")
 
         # filter agents
         allagents = await data.ConfigurationModel.get_agents(env.id, version_id)

--- a/src/inmanta/server/services/paramservice.py
+++ b/src/inmanta/server/services/paramservice.py
@@ -23,6 +23,7 @@ from inmanta import data
 from inmanta.const import ParameterSource
 from inmanta.protocol import methods
 from inmanta.protocol.common import attach_warnings
+from inmanta.protocol.exceptions import NotFound
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_DATABASE, SLICE_PARAM, SLICE_SERVER, SLICE_TRANSPORT
 from inmanta.server import config as opt
 from inmanta.server import protocol
@@ -110,7 +111,7 @@ class ParameterService(protocol.ServerSlice):
             if resource_id is not None:
                 out = await self.agentmanager.request_parameter(env.id, resource_id)
                 return out
-            return 404
+            raise NotFound()
 
         param = params[0]
 
@@ -243,7 +244,7 @@ class ParameterService(protocol.ServerSlice):
             params = await data.Parameter.get_list(environment=env.id, name=parameter_name, resource_id=resource_id)
 
         if len(params) == 0:
-            return 404
+            raise NotFound()
 
         param = params[0]
         await param.delete()

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -31,7 +31,7 @@ from inmanta.data import APILIMIT
 from inmanta.data.model import Resource, ResourceAction, ResourceType, ResourceVersionIdStr
 from inmanta.protocol import methods, methods_v2
 from inmanta.protocol.common import ReturnValue
-from inmanta.protocol.exceptions import BadRequest, Conflict, Forbidden, NotFound, ServerError
+from inmanta.protocol.exceptions import BadRequest, Conflict, Forbidden, NotFound
 from inmanta.resources import Id
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_DATABASE, SLICE_RESOURCE, SLICE_TRANSPORT
 from inmanta.server import config as opt

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -31,7 +31,7 @@ from inmanta.data import APILIMIT
 from inmanta.data.model import Resource, ResourceAction, ResourceType, ResourceVersionIdStr
 from inmanta.protocol import methods, methods_v2
 from inmanta.protocol.common import ReturnValue
-from inmanta.protocol.exceptions import BadRequest, Conflict, Forbidden, NotFound
+from inmanta.protocol.exceptions import BadRequest, Conflict, NotFound
 from inmanta.resources import Id
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_DATABASE, SLICE_RESOURCE, SLICE_TRANSPORT
 from inmanta.server import config as opt

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -230,7 +230,7 @@ class ResourceService(protocol.ServerSlice):
             raise Conflict("This agent is not currently the primary for the endpoint %s (sid: %s)" % (agent, sid))
         if incremental_deploy:
             if version is not None:
-                raise Forbidden("Cannot request increment for a specific version")
+                raise BadRequest("Cannot request increment for a specific version")
             result = await self.get_resource_increment_for_agent(env, agent)
         else:
             result = await self.get_all_resources_for_agent(env, agent, version)
@@ -455,7 +455,7 @@ class ResourceService(protocol.ServerSlice):
                 if resource_action is None:
                     # new
                     if started is None:
-                        raise Forbidden("A resource action can only be created with a start datetime.")
+                        raise BadRequest("A resource action can only be created with a start datetime.")
 
                     version = Id.parse_id(resource_ids[0]).version
                     resource_action = data.ResourceAction(

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -31,7 +31,7 @@ from inmanta.data import APILIMIT
 from inmanta.data.model import Resource, ResourceAction, ResourceType, ResourceVersionIdStr
 from inmanta.protocol import methods, methods_v2
 from inmanta.protocol.common import ReturnValue
-from inmanta.protocol.exceptions import BadRequest
+from inmanta.protocol.exceptions import BadRequest, Conflict, Forbidden, NotFound, ServerError
 from inmanta.resources import Id
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_DATABASE, SLICE_RESOURCE, SLICE_TRANSPORT
 from inmanta.server import config as opt
@@ -194,7 +194,7 @@ class ResourceService(protocol.ServerSlice):
     ) -> Apireturn:
         resv = await data.Resource.get(env.id, resource_id)
         if resv is None:
-            return 404, {"message": "The resource with the given id does not exist in the given environment"}
+            raise NotFound("The resource with the given id does not exist in the given environment")
 
         if status is not None and status:
             return 200, {"status": resv.status}
@@ -227,10 +227,10 @@ class ResourceService(protocol.ServerSlice):
         self, env: data.Environment, agent: str, version: int, sid: uuid.UUID, incremental_deploy: bool
     ) -> Apireturn:
         if not self.agentmanager_service.is_primary(env, sid, agent):
-            return 409, {"message": "This agent is not currently the primary for the endpoint %s (sid: %s)" % (agent, sid)}
+            raise Conflict("This agent is not currently the primary for the endpoint %s (sid: %s)" % (agent, sid))
         if incremental_deploy:
             if version is not None:
-                return 500, {"message": "Cannot request increment for a specific version"}
+                raise Forbidden("Cannot request increment for a specific version")
             result = await self.get_resource_increment_for_agent(env, agent)
         else:
             result = await self.get_all_resources_for_agent(env, agent, version)
@@ -241,12 +241,12 @@ class ResourceService(protocol.ServerSlice):
         if version is None:
             version = await data.ConfigurationModel.get_version_nr_latest_version(env.id)
             if version is None:
-                return 404, {"message": "No version available"}
+                raise NotFound("No version available")
 
         else:
             exists = await data.ConfigurationModel.version_exists(environment=env.id, version=version)
             if not exists:
-                return 404, {"message": "The given version does not exist"}
+                raise NotFound("The given version does not exist")
 
         deploy_model = []
 
@@ -284,7 +284,7 @@ class ResourceService(protocol.ServerSlice):
 
         version = await data.ConfigurationModel.get_version_nr_latest_version(env.id)
         if version is None:
-            return 404, {"message": "No version available"}
+            raise NotFound("No version available")
 
         increment = self._increment_cache.get(env.id, None)
         if increment is None:
@@ -455,7 +455,7 @@ class ResourceService(protocol.ServerSlice):
                 if resource_action is None:
                     # new
                     if started is None:
-                        return 500, {"message": "A resource action can only be created with a start datetime."}
+                        raise Forbidden("A resource action can only be created with a start datetime.")
 
                     version = Id.parse_id(resource_ids[0]).version
                     resource_action = data.ResourceAction(

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -34,6 +34,7 @@ from inmanta.ast import CompilerException
 from inmanta.config import Config
 from inmanta.const import AgentAction, AgentStatus, ParameterSource, ResourceState
 from inmanta.data import ENVIRONMENT_AGENT_TRIGGER_METHOD
+from inmanta.protocol.exceptions import Forbidden
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_AUTOSTARTED_AGENT_MANAGER, SLICE_PARAM, SLICE_SESSION_MANAGER
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.util import get_compiler_version
@@ -3446,8 +3447,8 @@ async def test_agentinstance_stops_deploying_when_stopped(
     assert agent_instance.is_stopped()
 
     # Agent cannot be unpaused after it is stopped
-    return_code, _ = agent_instance.unpause()
-    assert return_code == 403
+    with pytest.raises(Forbidden):
+        agent_instance.unpause()
     assert agent_instance._nq.finished()
     assert not agent_instance.is_enabled()
     assert agent_instance.is_stopped()

--- a/tests/server/test_incremental_deploy.py
+++ b/tests/server/test_incremental_deploy.py
@@ -30,6 +30,7 @@ import utils
 from inmanta import config, const, data
 from inmanta.agent.agent import Agent
 from inmanta.const import ResourceAction, ResourceState
+from inmanta.protocol.exceptions import Forbidden
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_ORCHESTRATION, SLICE_RESOURCE
 from inmanta.server.services.orchestrationservice import OrchestrationService
 from inmanta.server.services.resourceservice import ResourceService
@@ -310,12 +311,10 @@ async def test_deploy(server, agent: Agent, environment, caplog):
         assert len(payload["resources"]) == 0
 
         # Cannot request increment for specific version
-        result, _ = await resource_service.get_resources_for_agent(
-            env, "agent1", version=version, incremental_deploy=True, sid=sid
-        )
-        assert result == 500
-        result, _ = await resource_service.get_resources_for_agent(env, "agent1", version=v2, incremental_deploy=True, sid=sid)
-        assert result == 500
+        with pytest.raises(Forbidden):
+            await resource_service.get_resources_for_agent(env, "agent1", version=version, incremental_deploy=True, sid=sid)
+        with pytest.raises(Forbidden):
+            await resource_service.get_resources_for_agent(env, "agent1", version=v2, incremental_deploy=True, sid=sid)
 
     for record in caplog.records:
         assert record.levelname != "WARNING"

--- a/tests/server/test_incremental_deploy.py
+++ b/tests/server/test_incremental_deploy.py
@@ -30,7 +30,7 @@ import utils
 from inmanta import config, const, data
 from inmanta.agent.agent import Agent
 from inmanta.const import ResourceAction, ResourceState
-from inmanta.protocol.exceptions import Forbidden
+from inmanta.protocol.exceptions import BadRequest
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_ORCHESTRATION, SLICE_RESOURCE
 from inmanta.server.services.orchestrationservice import OrchestrationService
 from inmanta.server.services.resourceservice import ResourceService
@@ -311,9 +311,9 @@ async def test_deploy(server, agent: Agent, environment, caplog):
         assert len(payload["resources"]) == 0
 
         # Cannot request increment for specific version
-        with pytest.raises(Forbidden):
+        with pytest.raises(BadRequest):
             await resource_service.get_resources_for_agent(env, "agent1", version=version, incremental_deploy=True, sid=sid)
-        with pytest.raises(Forbidden):
+        with pytest.raises(BadRequest):
             await resource_service.get_resources_for_agent(env, "agent1", version=v2, incremental_deploy=True, sid=sid)
 
     for record in caplog.records:

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -30,6 +30,7 @@ from inmanta.agent import Agent, agent
 from inmanta.agent import config as agent_config
 from inmanta.const import AgentAction, AgentStatus
 from inmanta.protocol import Result
+from inmanta.protocol.exceptions import NotFound
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_AUTOSTARTED_AGENT_MANAGER
 from inmanta.server.agentmanager import AgentManager, SessionAction, SessionManager
 from inmanta.server.protocol import Session
@@ -384,8 +385,8 @@ async def test_api(init_dataclasses_and_load_schema):
     report = await am.get_agent_process_report(agentid)
     assert (200, "X") == report
 
-    report = await am.get_agent_process_report(uuid4())
-    assert 404 == report[0]
+    with pytest.raises(NotFound):
+        await am.get_agent_process_report(uuid4())
 
     code, all_agents = await am.list_agents(None)
     assert code == 200

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -411,13 +411,13 @@ async def test_api(init_dataclasses_and_load_schema):
     assert_equal_ish(shouldbe, all_agents, sortby=["environment", "name"])
 
     start = "agent2"
-    code, all_agents = await am.list_agents(environment=None, start=start)
+    code, all_agents = await am.list_agents(env=None, start=start)
     assert code == 200
     for a in all_agents["agents"]:
         assert a["name"] > start, f"List of agent should not contain a name (={a['name']}) before or equal to start (={start})"
 
     end = "agent2"
-    code, all_agents = await am.list_agents(environment=None, end=end)
+    code, all_agents = await am.list_agents(env=None, end=end)
     assert code == 200
     for a in all_agents["agents"]:
         assert a["name"] < end, f"List of agent should not contain a name (={a['name']}) after or equal to end (={end})"

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -363,11 +363,13 @@ async def test_api(init_dataclasses_and_load_schema):
     }
 
     assert_equal_ish(shouldbe, all_agents_processes, sortby=["hostname", "name"])
-    agentid = all_agents_processes["processes"][0]["sid"]
+    # There is 5 agent processes, we take the 3rd one and will select the two before, and two after it.
+    agentid = sorted(all_agents_processes["processes"], key=lambda p: p["sid"])[2]["sid"]
 
     start = agentid
     code, all_agents_processes = await am.list_agent_processes(environment=None, expired=True, start=start)
     assert code == 200
+    assert len(all_agents_processes["processes"]) == 2
     for agent_process in all_agents_processes["processes"]:
         assert (
             agent_process["sid"] > start
@@ -376,6 +378,7 @@ async def test_api(init_dataclasses_and_load_schema):
     end = agentid
     code, all_agents_processes = await am.list_agent_processes(environment=None, expired=True, end=end)
     assert code == 200
+    assert len(all_agents_processes["processes"]) == 2
     for agent_process in all_agents_processes["processes"]:
         assert (
             agent_process["sid"] < end
@@ -459,12 +462,14 @@ async def test_api(init_dataclasses_and_load_schema):
     start = "agent2"
     code, all_agents = await am.list_agents(env=None, start=start)
     assert code == 200
+    assert len(all_agents["agents"]) == 3
     for a in all_agents["agents"]:
         assert a["name"] > start, f"List of agent should not contain a name (={a['name']}) before or equal to start (={start})"
 
     end = "agent2"
     code, all_agents = await am.list_agents(env=None, end=end)
     assert code == 200
+    assert len(all_agents["agents"]) == 3
     for a in all_agents["agents"]:
         assert a["name"] < end, f"List of agent should not contain a name (={a['name']}) after or equal to end (={end})"
 

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -55,6 +55,9 @@ async def empty_future(*args, **kwargs):
 
 
 async def api_call_future(*args, **kwargs) -> Result:
+    """
+    Mock implementation of Client methods
+    """
     return Result(200, "X")
 
 
@@ -266,7 +269,7 @@ async def test_api(init_dataclasses_and_load_schema):
     await futures.proccess()
     assert len(am.sessions) == 4
 
-    code, all_agents = await am.list_agent_processes(None, None)
+    code, all_agents = await am.list_agent_processes(environment=None, expired=None)
     assert code == 200
 
     shouldbe = {
@@ -322,17 +325,22 @@ async def test_api(init_dataclasses_and_load_schema):
     code, all_agents_processes = await am.list_agent_processes(environment=None, expired=None, start=start)
     assert code == 200
     for agent_process in all_agents_processes["processes"]:
+        assert agent_process["expired"] is None
+        
+    code, all_agents_processes = await am.list_agent_processes(environment=None, expired=True, start=start)
+    assert code == 200
+    for agent_process in all_agents_processes["processes"]:
         assert (
             agent_process["sid"] > start
-        ), f"List of agent processes should not contain a name (={agent_process['sid']}) before or equal to start (={start})"
+        ), f"List of agent processes should not contain a sid (={agent_process['sid']}) before or equal to start (={start})"
 
     end = agentid
-    code, all_agents_processes = await am.list_agent_processes(None, None, end=end)
+    code, all_agents_processes = await am.list_agent_processes(environment=None, expired=True, end=end)
     assert code == 200
     for agent_process in all_agents_processes["processes"]:
         assert (
             agent_process["sid"] < end
-        ), f"List of agent processes should not contain a name (={agent_process['sid']}) after or equal to end (={end})"
+        ), f"List of agent processes should not contain a sid (={agent_process['sid']}) after or equal to end (={end})"
 
     code, all_agents = await am.list_agent_processes(env.id, None)
     assert code == 200
@@ -402,13 +410,13 @@ async def test_api(init_dataclasses_and_load_schema):
     assert_equal_ish(shouldbe, all_agents, sortby=["environment", "name"])
 
     start = "agent2"
-    code, all_agents = await am.list_agents(None, start=start)
+    code, all_agents = await am.list_agents(environment=None, start=start)
     assert code == 200
     for a in all_agents["agents"]:
         assert a["name"] > start, f"List of agent should not contain a name (={a['name']}) before or equal to start (={start})"
 
     end = "agent2"
-    code, all_agents = await am.list_agents(None, end=end)
+    code, all_agents = await am.list_agents(environment=None, end=end)
     assert code == 200
     for a in all_agents["agents"]:
         assert a["name"] < end, f"List of agent should not contain a name (={a['name']}) after or equal to end (={end})"

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -313,6 +313,23 @@ async def test_api(init_dataclasses_and_load_schema):
     assert_equal_ish(shouldbe, all_agents, sortby=["hostname", "name"])
     agentid = all_agents["processes"][0]["sid"]
 
+    start = agentid
+    code, all_agents_processes = await am.list_agent_processes(None, None, start=start)
+    print(all_agents_processes)
+    assert code == 200
+    for agent_process in all_agents_processes["processes"]:
+        assert (
+            agent_process["sid"] > start
+        ), f"List of agent processes should not contain a name (={agent_process['sid']}) before or equal to start (={start})"
+
+    end = agentid
+    code, all_agents_processes = await am.list_agent_processes(None, None, end=end)
+    assert code == 200
+    for agent_process in all_agents_processes["processes"]:
+        assert (
+            agent_process["sid"] < end
+        ), f"List of agent processes should not contain a name (={agent_process['sid']}) after or equal to end (={end})"
+
     code, all_agents = await am.list_agent_processes(env.id, None)
     assert code == 200
 
@@ -383,6 +400,22 @@ async def test_api(init_dataclasses_and_load_schema):
         ]
     }
     assert_equal_ish(shouldbe, all_agents, sortby=["environment", "name"])
+
+    start = "agent2"
+    code, all_agents = await am.list_agents(None, start=start)
+    assert code == 200
+    for agent in all_agents["agents"]:
+        assert (
+            agent["name"] > start
+        ), f"List of agent should not contain a name (={agent['name']}) before or equal to start (={start})"
+
+    end = "agent2"
+    code, all_agents = await am.list_agents(None, end=end)
+    assert code == 200
+    for agent in all_agents["agents"]:
+        assert (
+            agent["name"] < end
+        ), f"List of agent should not contain a name (={agent['name']}) after or equal to end (={end})"
 
     code, all_agents = await am.list_agents(env2)
     assert code == 200

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -326,7 +326,7 @@ async def test_api(init_dataclasses_and_load_schema):
     assert code == 200
     for agent_process in all_agents_processes["processes"]:
         assert agent_process["expired"] is None
-        
+
     code, all_agents_processes = await am.list_agent_processes(environment=None, expired=True, start=start)
     assert code == 200
     for agent_process in all_agents_processes["processes"]:

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -269,7 +269,7 @@ async def test_api(init_dataclasses_and_load_schema):
     await futures.proccess()
     assert len(am.sessions) == 4
 
-    code, all_agents = await am.list_agent_processes(environment=None, expired=None)
+    code, all_agents = await am.list_agent_processes(environment=None, expired=False)
     assert code == 200
 
     shouldbe = {
@@ -322,7 +322,7 @@ async def test_api(init_dataclasses_and_load_schema):
     agentid = all_agents["processes"][0]["sid"]
 
     start = agentid
-    code, all_agents_processes = await am.list_agent_processes(environment=None, expired=None, start=start)
+    code, all_agents_processes = await am.list_agent_processes(environment=None, expired=False, start=start)
     assert code == 200
     for agent_process in all_agents_processes["processes"]:
         assert agent_process["expired"] is None
@@ -342,7 +342,7 @@ async def test_api(init_dataclasses_and_load_schema):
             agent_process["sid"] < end
         ), f"List of agent processes should not contain a sid (={agent_process['sid']}) after or equal to end (={end})"
 
-    code, all_agents = await am.list_agent_processes(env.id, None)
+    code, all_agents = await am.list_agent_processes(environment=env.id, expired=False)
     assert code == 200
 
     shouldbe = {
@@ -374,7 +374,7 @@ async def test_api(init_dataclasses_and_load_schema):
 
     assert_equal_ish(shouldbe, all_agents, sortby=["hostname", "name"])
 
-    code, all_agents = await am.list_agent_processes(env2.id, None)
+    code, all_agents = await am.list_agent_processes(environment=env2.id, expired=False)
     assert code == 200
 
     shouldbe = {"processes": []}

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -315,7 +315,6 @@ async def test_api(init_dataclasses_and_load_schema):
 
     start = agentid
     code, all_agents_processes = await am.list_agent_processes(None, None, start=start)
-    print(all_agents_processes)
     assert code == 200
     for agent_process in all_agents_processes["processes"]:
         assert (

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -373,11 +373,6 @@ async def test_api(init_dataclasses_and_load_schema):
 
     assert_equal_ish(shouldbe, all_agents)
 
-    async def dummy_status():
-        return Result(200, "X")
-
-    ts1.get_client().get_status.side_effect = dummy_status
-
     report = await am.get_agent_process_report(agentid)
     assert (200, "X") == report
 

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -54,6 +54,10 @@ async def empty_future(*args, **kwargs):
     pass
 
 
+async def api_call_future(*args, **kwargs) -> Result:
+    return Result(200, "X")
+
+
 class MockSession(object):
     """
     An environment that segments agents connected to the server
@@ -66,6 +70,7 @@ class MockSession(object):
         self.nodename = nodename
         self.client = Mock()
         self.client.set_state.side_effect = empty_future
+        self.client.get_status = api_call_future
 
     def get_id(self):
         return self._sid
@@ -372,6 +377,7 @@ async def test_api(init_dataclasses_and_load_schema):
         return Result(200, "X")
 
     ts1.get_client().get_status.side_effect = dummy_status
+
     report = await am.get_agent_process_report(agentid)
     assert (200, "X") == report
 

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -319,7 +319,7 @@ async def test_api(init_dataclasses_and_load_schema):
     agentid = all_agents["processes"][0]["sid"]
 
     start = agentid
-    code, all_agents_processes = await am.list_agent_processes(None, None, start=start)
+    code, all_agents_processes = await am.list_agent_processes(environment=None, expired=None, start=start)
     assert code == 200
     for agent_process in all_agents_processes["processes"]:
         assert (

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -404,18 +404,14 @@ async def test_api(init_dataclasses_and_load_schema):
     start = "agent2"
     code, all_agents = await am.list_agents(None, start=start)
     assert code == 200
-    for agent in all_agents["agents"]:
-        assert (
-            agent["name"] > start
-        ), f"List of agent should not contain a name (={agent['name']}) before or equal to start (={start})"
+    for a in all_agents["agents"]:
+        assert a["name"] > start, f"List of agent should not contain a name (={a['name']}) before or equal to start (={start})"
 
     end = "agent2"
     code, all_agents = await am.list_agents(None, end=end)
     assert code == 200
-    for agent in all_agents["agents"]:
-        assert (
-            agent["name"] < end
-        ), f"List of agent should not contain a name (={agent['name']}) after or equal to end (={end})"
+    for a in all_agents["agents"]:
+        assert a["name"] < end, f"List of agent should not contain a name (={a['name']}) after or equal to end (={end})"
 
     code, all_agents = await am.list_agents(env2)
     assert code == 200

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -414,7 +414,9 @@ async def test_agent_process(init_dataclasses_and_load_schema):
     assert len(live_procs) == 1
     assert live_procs[0].sid == agent_proc.sid
 
-    live_by_env_procs = await data.AgentProcess.get_list(environment=env.id, expired=None, order_by_column="last_seen", order="ASC NULLS LAST")
+    live_by_env_procs = await data.AgentProcess.get_list(
+        environment=env.id, expired=None, order_by_column="last_seen", order="ASC NULLS LAST"
+    )
     assert len(live_by_env_procs) == 1
     assert live_by_env_procs[0].sid == agent_proc.sid
 
@@ -423,7 +425,9 @@ async def test_agent_process(init_dataclasses_and_load_schema):
     live_procs = await data.AgentProcess.get_live()
     assert len(live_procs) == 0
 
-    live_by_env_procs = await data.AgentProcess.get_list(environment=env.id, expired=None, order_by_column="last_seen", order="ASC NULLS LAST")
+    live_by_env_procs = await data.AgentProcess.get_list(
+        environment=env.id, expired=None, order_by_column="last_seen", order="ASC NULLS LAST"
+    )
     assert len(live_by_env_procs) == 0
 
     await agent_proc.delete_cascade()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -403,7 +403,7 @@ async def test_agent_process(init_dataclasses_and_load_schema):
     agi2 = data.AgentInstance(process=agent_proc.sid, name="agi2", tid=env.id)
     await agi2.insert()
 
-    agent_procs = await data.AgentProcess.get_by_env(env=env.id)
+    agent_procs = await data.AgentProcess.get_list(environment=env.id, order_by_column="last_seen", order="ASC NULLS LAST")
     assert len(agent_procs) == 1
     assert agent_procs[0].sid == agent_proc.sid
 
@@ -414,7 +414,7 @@ async def test_agent_process(init_dataclasses_and_load_schema):
     assert len(live_procs) == 1
     assert live_procs[0].sid == agent_proc.sid
 
-    live_by_env_procs = await data.AgentProcess.get_live_by_env(env=env.id)
+    live_by_env_procs = await data.AgentProcess.get_list(environment=env.id, expired=None, order_by_column="last_seen", order="ASC NULLS LAST")
     assert len(live_by_env_procs) == 1
     assert live_by_env_procs[0].sid == agent_proc.sid
 
@@ -423,7 +423,7 @@ async def test_agent_process(init_dataclasses_and_load_schema):
     live_procs = await data.AgentProcess.get_live()
     assert len(live_procs) == 0
 
-    live_by_env_procs = await data.AgentProcess.get_live_by_env(env=env.id)
+    live_by_env_procs = await data.AgentProcess.get_list(environment=env.id, expired=None, order_by_column="last_seen", order="ASC NULLS LAST")
     assert len(live_by_env_procs) == 0
 
     await agent_proc.delete_cascade()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -81,7 +81,7 @@ def assert_equal_ish(minimal, actual, sortby=[]):
     elif minimal is UNKWN:
         return
     else:
-        assert minimal == actual
+        assert minimal == actual, f"Minimal value expected is '{minimal}' but got '{actual}'"
 
 
 def assert_graph(graph, expected):


### PR DESCRIPTION
# Description

Implemented `get_list_paged` as an alternative to `get_list`.  While `get_list` uses `offset` and `limit` to select a section of output, `get_list_paged` relies on a combination of `start`, `end` (applied on the column we are basing the sorting on) and `limit`.  This method is now used by the following routes: 
 - `GET /agent`
 - `GET /agentproc`
 - `GET /compilereport` (this already did pagination, but the method used is now common to the others)

closes #2500 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
