### PR TITLE
Fixing option checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Bug fixes
 - Fix broken links in the documentation (#2495)
 - Ensure all running compilations are stopped when the server is stopped (#2508)
+- Fix `--server_address` option on `inmanta export` (#2514)
 
 ## Upgrade notes
 - Ensure the database is backed up before executing an upgrade.

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -454,7 +454,7 @@ def export(options: argparse.Namespace) -> None:
     if options.server is not None:
         Config.set("compiler_rest_transport", "host", options.server)
 
-    if options.server is not None:
+    if options.port is not None:
         Config.set("compiler_rest_transport", "port", options.port)
 
     if options.token is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,38 +23,10 @@ from typing import Dict
 
 import pytest
 
-from inmanta import config, data
+from inmanta import data
 from inmanta.const import Change, ResourceAction, ResourceState
 from inmanta.util import get_compiler_version
 from utils import get_resource, log_contains
-
-
-@pytest.mark.asyncio
-async def test_export(server, client, cli):
-    # create a new project
-    project_name = "test_project"
-    result = await client.create_project(project_name)
-    assert result.code == 200
-    project_id = result.result["project"]["id"]
-
-    # create a new environment
-    environment_name = "test_environment"
-    result = await client.create_environment(project_id, environment_name, ".", ".")
-    assert result.code == 200
-    environment_id = result.result["environment"]["id"]
-
-    result = await cli.run(
-        "export",
-        "-e",
-        environment_id,
-        "--server_address",
-        config.Config.get("server", "bind-address"),
-        "--server_port",
-        config.Config.get("server", "bind-port"),
-        "-f",
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "simple_project", "main.cf")
-    )
-    assert result.exit_code == 0, f"export exit code should be 0, but go {result.exit_code}: \nOutput: {result.output}"
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,10 +23,38 @@ from typing import Dict
 
 import pytest
 
-from inmanta import data
+from inmanta import config, data
 from inmanta.const import Change, ResourceAction, ResourceState
 from inmanta.util import get_compiler_version
 from utils import get_resource, log_contains
+
+
+@pytest.mark.asyncio
+async def test_export(server, client, cli):
+    # create a new project
+    project_name = "test_project"
+    result = await client.create_project(project_name)
+    assert result.code == 200
+    project_id = result.result["project"]["id"]
+
+    # create a new environment
+    environment_name = "test_environment"
+    result = await client.create_environment(project_id, environment_name, ".", ".")
+    assert result.code == 200
+    environment_id = result.result["environment"]["id"]
+
+    result = await cli.run(
+        "export",
+        "-e",
+        environment_id,
+        "--server_address",
+        config.Config.get("server", "bind-address"),
+        "--server_port",
+        config.Config.get("server", "bind-port"),
+        "-f",
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "simple_project", "main.cf")
+    )
+    assert result.exit_code == 0, f"export exit code should be 0, but go {result.exit_code}: \nOutput: {result.output}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

Fixes the bug that made `inmanta export` fail when `--server_address` was set.

closes #2514 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
