### PR TITLE
Issue/2459 optional relations null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added plugin call anchors to support ctrl-clicking a plugin call (#1954)
 - Added rpdb signal handler (#2170)
 - Added support to build RPMs for a python version different from Python3.6 (#1857)
+- Added support for assigning `null` to relations with lower arity 0 (#2459)
 
 ## Bug fixes
 - Fix broken links in the documentation (#2495)

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -342,7 +342,9 @@ Instances of an entity are created with a constructor statement
 A constructor can assign values to any of the properties (attributes or relations) of the entity. It can also leave the properties unassigned.
 For attributes with default values, the constructor is the only place where the defaults can be overridden.
 
-Values can be assigned to the remaining properties as if they are variables. To relations with a higher arity, multiple values can be assigned
+Values can be assigned to the remaining properties as if they are variables. To relations with a higher arity, multiple values can be assigned.
+Additionally, `null` can be assigned to relations with a lower arity of 0 to indicate explicitly that the model will not assign
+any values to the relation attribute.
 
 .. code-block:: inmanta
 

--- a/tests/compiler/test_relations.py
+++ b/tests/compiler/test_relations.py
@@ -15,11 +15,12 @@
 
     Contact: code@inmanta.com
 """
-import pytest
-from typing import Optional, Union, Tuple
+from typing import Optional, Tuple, Union
 
-import inmanta.compiler as compiler
+import pytest
+
 import inmanta.ast.type as ast_type
+import inmanta.compiler as compiler
 from inmanta.ast import CompilerException, DuplicateException, Namespace, NotFoundException, RuntimeException, TypingException
 from inmanta.execute.runtime import Instance, ResultVariable
 
@@ -608,7 +609,8 @@ implement A using std::none
 
 a = A()
 a.other = null
-        """ % ("" if multi else "1")
+        """
+        % ("" if multi else "1")
     )
     root_ns: Namespace
     (_, root_ns) = compiler.do_compile()
@@ -622,7 +624,7 @@ a.other = null
     if multi:
         assert other_var.value == []
     else:
-        assert other_var.value == None
+        assert other_var.value is None
 
 
 def test_optional_variable_relation(snippetcompiler):
@@ -657,7 +659,7 @@ a.ns = null
         (("a.others = null", "a.others = null"), True),
         (("a.others = [A(), A()]", "a.others = null"), False),
         (("a.others = null", "a.others = [A(), A()]"), False),
-    ]
+    ],
 )
 def test_relation_null_multiple_assignments(snippetcompiler, statements: Tuple[str, str], valid: bool) -> None:
     snippetcompiler.setup_for_snippet(

--- a/tests/compiler/test_relations.py
+++ b/tests/compiler/test_relations.py
@@ -625,6 +625,29 @@ a.other = null
         assert other_var.value == None
 
 
+def test_optional_variable_relation(snippetcompiler):
+    """
+    Make sure DeprecatedOptionVariables do not allow `null`.
+    """
+    snippetcompiler.setup_for_error(
+        """
+entity A:
+    number[] ns
+end
+
+implement A using std::none
+
+
+a = A()
+a.ns = null
+        """,
+        "Could not set attribute `ns` on instance `__config__::A (instantiated at {dir}/main.cf:9)`"
+        " (reported in a.ns = null ({dir}/main.cf:10))"
+        "\ncaused by:"
+        "\n  Invalid value 'null', expected number[] (reported in a.ns = null ({dir}/main.cf:10))",
+    )
+
+
 @pytest.mark.parametrize(
     "statements,valid",
     [


### PR DESCRIPTION
# Description

Allow explicitly assinging `null` to relations with lower arity bound of 0.

closes #2459

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
