### PR TITLE
Handle failure in an event handler consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix broken links in the documentation (#2495)
 - Ensure all running compilations are stopped when the server is stopped (#2508)
 - Fix `--server_address` option on `inmanta export` (#2514)
+- Handle failure in an event handler consistently for local and non-local agents (#2509)
 
 ## Upgrade notes
 - Ensure the database is backed up before executing an upgrade.

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -207,6 +207,10 @@ class ResourceAction(object):
                     "Could not send events for %(resource_id)s", resource_id=str(self.resource.id), events=str(events_dict)
                 )
 
+        # Prevent that status set by execute() is overridden in process_events()
+        if success and ctx.status is not const.ResourceState.deployed:
+            success = False
+
         provider.close()
 
         return success, send_event

--- a/tests/agent_server/conftest.py
+++ b/tests/agent_server/conftest.py
@@ -183,6 +183,7 @@ def resource_container():
         """
         Set `ctx.set_status(const.ResourceState.failed)` in process_events().
         """
+
         fields = ("key", "value", "purged")
 
     @resource("test::BadPost", agent="agent", id_attribute="key")

--- a/tests/agent_server/conftest.py
+++ b/tests/agent_server/conftest.py
@@ -178,6 +178,14 @@ def resource_container():
 
         fields = ("key", "value", "purged")
 
+    @resource("test::BadEventsStatus", agent="agent", id_attribute="key")
+    class BadEventS(Resource):
+        """
+        A file on a filesystem
+        """
+
+        fields = ("key", "value", "purged")
+
     @resource("test::BadPost", agent="agent", id_attribute="key")
     class BadPostR(Resource):
         """
@@ -412,6 +420,21 @@ def resource_container():
 
         def process_events(self, ctx, resource, events):
             raise Exception()
+
+    @provider("test::BadEventsStatus", name="test_bad_events_status")
+    class BadEventStatus(ResourceHandler):
+        def check_resource(self, ctx, resource):
+            current = resource.clone()
+            return current
+
+        def do_changes(self, ctx, resource, changes):
+            pass
+
+        def can_process_events(self) -> bool:
+            return True
+
+        def process_events(self, ctx, resource, events):
+            ctx.set_status(const.ResourceState.failed)
 
     @provider("test::BadPost", name="test_bad_posts")
     class BadPost(Provider):

--- a/tests/agent_server/conftest.py
+++ b/tests/agent_server/conftest.py
@@ -181,9 +181,8 @@ def resource_container():
     @resource("test::BadEventsStatus", agent="agent", id_attribute="key")
     class BadEventS(Resource):
         """
-        A file on a filesystem
+        Set `ctx.set_status(const.ResourceState.failed)` in process_events().
         """
-
         fields = ("key", "value", "purged")
 
     @resource("test::BadPost", agent="agent", id_attribute="key")

--- a/tests/agent_server/test_send_events.py
+++ b/tests/agent_server/test_send_events.py
@@ -380,3 +380,81 @@ async def test_send_events_cross_agent_fail(resource_container, environment, ser
     r_to_s = {r["resource_version_id"]: r["status"] for r in result.result["resources"]}
     assert r_to_s[res_id_1] == "skipped"
     assert r_to_s[fail_r] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_set_deployment_status_in_process_events(
+    resource_container, environment, server, client, async_finalizer, clienthelper, agent_factory
+):
+    # Start agent1 and agent2
+    agents = [
+        agent_factory(
+            environment=environment,
+            hostname=f"agent{i}",
+            agent_map={f"agent{i}": "localhost"},
+            code_loader=False,
+            agent_names=[f"agent{i}"]
+        ) for i in range(1, 3)
+    ]
+    await asyncio.gather(*agents)
+
+    version = await clienthelper.get_version()
+    res_id_key1 = f"test::Resource[agent1,key=key1],v={version}"
+    res_id_key2 = f"test::Resource[agent2,key=key2],v={version}"
+    res_id_key3 = f"test::BadEventsStatus[agent1,key=key3],v={version}"
+    res_id_key4 = f"test::Resource[agent1,key=key4],v={version}"
+    resources = [
+        {
+            "key": "key1",
+            "value": "value1",
+            "id": res_id_key1,
+            "send_event": True,
+            "requires": [res_id_key3],
+            "purged": False,
+        },
+        {
+            "key": "key2",
+            "value": "value2",
+            "id": res_id_key2,
+            "send_event": True,
+            "purged": False,
+            "requires": [res_id_key3],
+        },
+        {
+            "key": "key3",
+            "value": "value3",
+            "id": res_id_key3,
+            "send_event": True,
+            "requires": [res_id_key4],
+            "purged": False,
+        },
+        {
+            "key": "key4",
+            "value": "value4",
+            "id": res_id_key4,
+            "send_event": True,
+            "requires": [],
+            "purged": False,
+        },
+    ]
+
+    await clienthelper.put_version_simple(resources, version)
+    result = await client.release_version(environment, version, True, const.AgentTriggerMethod.push_full_deploy)
+    assert result.code == 200
+
+    await resource_container.wait_for_done_with_waiters(
+        client, environment, version, wait_for_this_amount_of_resources_in_done=4, timeout=15
+    )
+
+    async def assert_deployment_status(res_id: str, expected_state: const.ResourceState) -> None:
+        result = await client.get_resource(tid=environment, id=res_id, logs=False, status=True)
+        assert result.code == 200
+        assert result.result["status"] == expected_state
+
+    await assert_deployment_status(res_id=res_id_key4, expected_state=const.ResourceState.deployed)
+    # Failed via ctx.set_status(const.ResourceState.failed) in process_events()
+    await assert_deployment_status(res_id=res_id_key3, expected_state=const.ResourceState.failed)
+    # Skipped due to failed cross-agent dependency
+    await assert_deployment_status(res_id=res_id_key2, expected_state=const.ResourceState.skipped)
+    # Skipped due to failed local dependency
+    await assert_deployment_status(res_id=res_id_key1, expected_state=const.ResourceState.skipped)

--- a/tests/agent_server/test_send_events.py
+++ b/tests/agent_server/test_send_events.py
@@ -393,8 +393,9 @@ async def test_set_deployment_status_in_process_events(
             hostname=f"agent{i}",
             agent_map={f"agent{i}": "localhost"},
             code_loader=False,
-            agent_names=[f"agent{i}"]
-        ) for i in range(1, 3)
+            agent_names=[f"agent{i}"],
+        )
+        for i in range(1, 3)
     ]
     await asyncio.gather(*agents)
 

--- a/tests/agent_server/test_send_events.py
+++ b/tests/agent_server/test_send_events.py
@@ -387,8 +387,8 @@ async def test_consistenly_handle_failure_in_process_events(
     resource_container, environment, server, client, async_finalizer, clienthelper, agent_factory
 ):
     """
-        Setting `ctx.set_status(const.ResourceState.failed)` in process events should result
-        in the same behavior for local and remote agents.
+    Setting `ctx.set_status(const.ResourceState.failed)` in process events should result
+    in the same behavior for local and remote agents.
     """
     # Start agent1 and agent2
     agents = [

--- a/tests/agent_server/test_send_events.py
+++ b/tests/agent_server/test_send_events.py
@@ -383,9 +383,13 @@ async def test_send_events_cross_agent_fail(resource_container, environment, ser
 
 
 @pytest.mark.asyncio
-async def test_set_deployment_status_in_process_events(
+async def test_consistenly_handle_failure_in_process_events(
     resource_container, environment, server, client, async_finalizer, clienthelper, agent_factory
 ):
+    """
+        Setting `ctx.set_status(const.ResourceState.failed)` in process events should result
+        in the same behavior for local and remote agents.
+    """
     # Start agent1 and agent2
     agents = [
         agent_factory(


### PR DESCRIPTION
# Description

Handle failure in an event handler consistently for local and non-local agents.

closes #2509 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
