### PR TITLE
Handle JSON serialization errors in handler log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix `--server_address` option on `inmanta export` (#2514)
 - Handle failure in an event handler consistently for local and non-local agents (#2509)
 - Fix for cross agent dependencies responding to unavailable resources (#2501)
+- Handle JSON serialization errors in handler log messages (#1875)
 
 ## Upgrade notes
 - Ensure the database is backed up before executing an upgrade.

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -33,7 +33,7 @@ from inmanta.agent import io
 from inmanta.agent.cache import AgentCache
 from inmanta.const import ParameterSource, ResourceState
 from inmanta.data.model import AttributeStateChange
-from inmanta.protocol import Result
+from inmanta.protocol import Result, json_encode
 from inmanta.types import SimpleTypes
 from inmanta.util import hash_file
 
@@ -348,6 +348,10 @@ class HandlerContext(object):
             kwargs["traceback"] = traceback.format_exc()
         else:
             exc_info = False
+        try:
+            json_encode(kwargs)
+        except Exception as e:
+            raise Exception("Exception during serializing log message arguments:", e)
         log = data.LogLine.log(level, msg, **kwargs)
         self.logger.log(level, "resource %s: %s", self._resource.id.resource_version_str(), log._data["msg"], exc_info=exc_info)
         self._logs.append(log)
@@ -358,6 +362,8 @@ class HandlerContext(object):
 
         To pass exception information, use the keyword argument exc_info with
         a true value, e.g.
+
+        Keyword arguments should be JSON serializable.
 
         ``logger.debug("Houston, we have a %s", "thorny problem", exc_info=1)``
         """
@@ -370,6 +376,8 @@ class HandlerContext(object):
         To pass exception information, use the keyword argument exc_info with
         a true value, e.g.
 
+        Keyword arguments should be JSON serializable.
+
         ``logger.info("Houston, we have a %s", "interesting problem", exc_info=1)``
         """
         self.log_msg(logging.INFO, msg, args, kwargs)
@@ -380,6 +388,8 @@ class HandlerContext(object):
 
         To pass exception information, use the keyword argument exc_info with
         a true value, e.g.
+
+        Keyword arguments should be JSON serializable.
 
         ``logger.warning("Houston, we have a %s", "bit of a problem", exc_info=1)``
         """

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -351,7 +351,7 @@ class HandlerContext(object):
         try:
             json_encode(kwargs)
         except Exception as e:
-            raise Exception("Exception during serializing log message arguments:", e)
+            raise Exception("Exception during serializing log message arguments") from e
         log = data.LogLine.log(level, msg, **kwargs)
         self.logger.log(level, "resource %s: %s", self._resource.id.resource_version_str(), log._data["msg"], exc_info=exc_info)
         self._logs.append(log)

--- a/tests/agent_server/conftest.py
+++ b/tests/agent_server/conftest.py
@@ -194,6 +194,14 @@ def resource_container():
 
         fields = ("key", "value", "purged")
 
+    @resource("test::BadLogging", agent="agent", id_attribute="key")
+    class BadLoggingR(Resource):
+        """
+        Set `ctx.set_status(const.ResourceState.failed)` in process_events().
+        """
+
+        fields = ("key", "value", "purged")
+
     @provider("test::Resource", name="test_resource")
     class Provider(ResourceHandler):
         def check_resource(self, ctx, resource):
@@ -440,6 +448,15 @@ def resource_container():
     class BadPost(Provider):
         def post(self, ctx, resource) -> None:
             raise Exception()
+
+    class Empty:
+        pass
+
+    @provider("test::BadLogging", name="test_bad_logging")
+    class BadLogging(Provider):
+        def do_changes(self, ctx, resource, changes):
+            ctx.info("This is not JSON serializable: %(val)s", val=Empty())
+            super().do_changes(ctx, resource, changes)
 
     @resource("test::AgentConfig", agent="agent", id_attribute="agentname")
     class AgentConfig(PurgeableResource):

--- a/tests/agent_server/conftest.py
+++ b/tests/agent_server/conftest.py
@@ -197,7 +197,7 @@ def resource_container():
     @resource("test::BadLogging", agent="agent", id_attribute="key")
     class BadLoggingR(Resource):
         """
-        Set `ctx.set_status(const.ResourceState.failed)` in process_events().
+        Raises an exception when trying to log a message that's not serializable.
         """
 
         fields = ("key", "value", "purged")
@@ -453,10 +453,13 @@ def resource_container():
         pass
 
     @provider("test::BadLogging", name="test_bad_logging")
-    class BadLogging(Provider):
+    class BadLogging(ResourceHandler):
+        def check_resource(self, ctx, resource):
+            current = resource.clone()
+            return current
+
         def do_changes(self, ctx, resource, changes):
             ctx.info("This is not JSON serializable: %(val)s", val=Empty())
-            super().do_changes(ctx, resource, changes)
 
     @resource("test::AgentConfig", agent="agent", id_attribute="agentname")
     class AgentConfig(PurgeableResource):

--- a/tests/agent_server/test_resource_handler.py
+++ b/tests/agent_server/test_resource_handler.py
@@ -16,14 +16,17 @@
     Contact: code@inmanta.com
 """
 import base64
+import logging
 import typing
 from typing import TypeVar
 
 import pytest
 
+from inmanta import const
 from inmanta.agent.handler import ResourceHandler
 from inmanta.protocol import SessionClient, VersionMatch, common
 from test_protocol import make_random_file
+from utils import _wait_until_deployment_finishes, log_contains
 
 T = TypeVar("T")
 
@@ -73,3 +76,40 @@ def test_get_file_not_found():
     resource_handler = MockGetFileResourceHandler(client)
     result = resource_handler.get_file("hash")
     assert result is None
+
+
+@pytest.mark.asyncio(timeout=15)
+async def test_logging_error(resource_container, environment, client, agent, clienthelper, caplog):
+    """
+    When a log call uses an argument that is not JSON serializable, the corresponding resource should be marked as failed,
+    and the exception logged.
+    """
+    resource_container.Provider.reset()
+    version = await clienthelper.get_version()
+
+    res_id_1 = "test::BadLogging[agent1,key=key1],v=%d" % version
+    resources = [
+        {
+            "key": "key1",
+            "value": "value1",
+            "id": res_id_1,
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+    ]
+
+    await clienthelper.put_version_simple(resources, version)
+
+    result = await client.release_version(environment, version, True, const.AgentTriggerMethod.push_full_deploy)
+    assert result.code == 200
+
+    result = await client.get_version(environment, version)
+    assert result.code == 200
+
+    await _wait_until_deployment_finishes(client, environment, version)
+    result = await client.get_resource(tid=environment, id=res_id_1, logs=False, status=True)
+    assert result.code == 200
+    assert result.result["status"] == "failed"
+
+    log_contains(caplog, "inmanta.agent", logging.ERROR, "Exception during serializing log message arguments")


### PR DESCRIPTION
# Description

closes #1875 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
