### PR TITLE
Issue/2538 error methods rollback

### DIFF
--- a/docs/platform_developers/define_api_endpoints.rst
+++ b/docs/platform_developers/define_api_endpoints.rst
@@ -56,7 +56,6 @@ An example is shown in the code snippet below.
     from inmanta.types import Apireturn
     from inmanta import data
     from inmanta.protocol import methods
-    from inmanta.protocol.exceptions import NotFound, ServerError
 
     @protocol.handle(methods.get_project, project_id="id")
     async def get_project(self, project_id: uuid.UUID) -> Apireturn:
@@ -65,16 +64,16 @@ An example is shown in the code snippet below.
             environments = await data.Environment.get_list(project=project_id)
 
             if project is None:
-                raise NotFound("The project with given id does not exist.")
+                return 404, {"message": "The project with given id does not exist."}
 
             project_dict = project.to_dict()
             project_dict["environments"] = [e.id for e in environments]
 
             return 200, {"project": project_dict}
         except ValueError:
-            raise NotFound("The project with given id does not exist.")
+            return 404, {"message": "The project with given id does not exist."}
 
-        raise ServerError()
+        return 500
 
 The first argument of the ``handle`` decorator defines that this is the handle function for the ``get_project`` API method.
 The second argument remaps the ``id`` argument of the API method to the ``project_id`` argument in the handle function.

--- a/src/inmanta/protocol/exceptions.py
+++ b/src/inmanta/protocol/exceptions.py
@@ -79,7 +79,7 @@ class UnauthorizedException(BaseHttpException):
 
 class BadRequest(BaseHttpException):
     """
-    This exception is raised for a mailformed request
+    This exception is raised for a malformed request
     """
 
     def __init__(self, message: Optional[str] = None, details: Optional[JsonType] = None) -> None:

--- a/src/inmanta/protocol/exceptions.py
+++ b/src/inmanta/protocol/exceptions.py
@@ -79,7 +79,7 @@ class UnauthorizedException(BaseHttpException):
 
 class BadRequest(BaseHttpException):
     """
-    This exception is raised for a malformed request
+    This exception is raised for a mailformed request
     """
 
     def __init__(self, message: Optional[str] = None, details: Optional[JsonType] = None) -> None:

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -659,7 +659,7 @@ class AgentManager(ServerSlice, SessionListener):
             query["environment"] = environment
             env = await data.Environment.get_by_id(environment)
             if env is None:
-                raise NotFound("The given environment id does not exist!")
+                return 404, {"message": "The given environment id does not exist!"}
         if not expired:
             query["expired"] = None
 
@@ -745,11 +745,11 @@ class AgentManager(ServerSlice, SessionListener):
     async def get_agent_process_report(self, agent_sid: uuid.UUID) -> Apireturn:
         ap = await data.AgentProcess.get_one(sid=agent_sid)
         if ap is None:
-            raise NotFound("The given AgentProcess id does not exist!")
+            return 404, {"message": "The given AgentProcess id does not exist!"}
         sid = ap.sid
         session_for_ap = self.sessions.get(sid, None)
         if session_for_ap is None:
-            raise NotFound("The given AgentProcess is not live!")
+            return 404, {"message": "The given AgentProcess is not live!"}
         client = session_for_ap.get_client()
         result = await client.get_status()
         return result.code, result.get_result()
@@ -768,7 +768,7 @@ class AgentManager(ServerSlice, SessionListener):
             res = await data.Resource.get_latest_version(env_id, resource_id)
 
             if res is None:
-                raise NotFound("The resource has no recent version.")
+                return 404, {"message": "The resource has no recent version."}
 
             rid: Id = Id.parse_id(res.resource_version_id)
             version: int = rid.version
@@ -798,7 +798,7 @@ class AgentManager(ServerSlice, SessionListener):
 
             return 503, {"message": "Agents queried for resource parameter."}
         else:
-            raise NotFound("resource_id parameter is required.")
+            return 404, {"message": "resource_id parameter is required."}
 
 
 class AutostartedAgentManager(ServerSlice):

--- a/src/inmanta/server/services/codeservice.py
+++ b/src/inmanta/server/services/codeservice.py
@@ -55,7 +55,7 @@ class CodeService(protocol.ServerSlice):
 
         hasherrors = any((k != hash_file(content[2].encode()) for k, content in sources.items()))
         if hasherrors:
-            raise BadRequest("Hashes in source map do not match to source_code")
+            return 400, {"message": "Hashes in source map do not match to source_code"}
 
         for file_hash in self.file_slice.stat_file_internal(sources.keys()):
             self.file_slice.upload_file_internal(file_hash, sources[file_hash][2].encode())

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -587,7 +587,7 @@ class CompilerService(ServerSlice):
         self, env: data.Environment, start: Optional[str] = None, end: Optional[str] = None, limit: Optional[int] = None
     ) -> Apireturn:
         if env is None:
-            raise NotFound("The given environment id does not exist!")
+            return 404, {"message": "The given environment id does not exist!"}
 
         if limit is None:
             limit = APILIMIT
@@ -620,7 +620,7 @@ class CompilerService(ServerSlice):
         report = await data.Compile.get_report(compile_id)
 
         if report is None:
-            raise NotFound("This report wasn't found")
+            return 404
 
         return 200, {"report": report}
 

--- a/src/inmanta/server/services/dryrunservice.py
+++ b/src/inmanta/server/services/dryrunservice.py
@@ -64,7 +64,7 @@ class DyrunService(protocol.ServerSlice):
     async def dryrun_request(self, env: data.Environment, version_id: int) -> Apireturn:
         model = await data.ConfigurationModel.get_version(environment=env.id, version=version_id)
         if model is None:
-            raise NotFound("The request version does not exist.")
+            return 404, {"message": "The request version does not exist."}
 
         # fetch all resource in this cm and create a list of distinct agents
         rvs = await data.Resource.get_list(model=version_id, environment=env.id)

--- a/src/inmanta/server/services/fileservice.py
+++ b/src/inmanta/server/services/fileservice.py
@@ -75,7 +75,7 @@ class FileService(protocol.ServerSlice):
         if os.path.exists(file_name):
             return 200
         else:
-            raise NotFound()
+            return 404
 
     @protocol.handle(methods.get_file, file_hash="id")
     async def get_file(self, file_hash: str) -> Apireturn:

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -29,7 +29,7 @@ from inmanta.data import APILIMIT, ENVIRONMENT_AGENT_TRIGGER_METHOD, PURGE_ON_DE
 from inmanta.data.model import ResourceIdStr, ResourceVersionIdStr
 from inmanta.protocol import methods, methods_v2
 from inmanta.protocol.common import attach_warnings
-from inmanta.protocol.exceptions import BadRequest, NotFound, ServerError
+from inmanta.protocol.exceptions import BadRequest, ServerError
 from inmanta.resources import Id
 from inmanta.server import (
     SLICE_AGENT_MANAGER,
@@ -129,11 +129,11 @@ class OrchestrationService(protocol.ServerSlice):
     ) -> Apireturn:
         version = await data.ConfigurationModel.get_version(env.id, version_id)
         if version is None:
-            raise NotFound("The given configuration model does not exist yet.")
+            return 404, {"message": "The given configuration model does not exist yet."}
 
         resources = await data.Resource.get_resources_for_version(env.id, version_id, no_obj=True)
         if resources is None:
-            raise NotFound("The given configuration model does not exist yet.")
+            return 404, {"message": "The given configuration model does not exist yet."}
 
         if limit is None:
             limit = APILIMIT
@@ -169,7 +169,7 @@ class OrchestrationService(protocol.ServerSlice):
     async def delete_version(self, env, version_id):
         version = await data.ConfigurationModel.get_version(env.id, version_id)
         if version is None:
-            raise NotFound("The given configuration model does not exist yet.")
+            return 404, {"message": "The given configuration model does not exist yet."}
 
         await version.delete_cascade()
         return 200
@@ -406,7 +406,7 @@ class OrchestrationService(protocol.ServerSlice):
     ) -> Apireturn:
         model = await data.ConfigurationModel.get_version(env.id, version_id)
         if model is None:
-            raise NotFound("The request version does not exist.")
+            return 404, {"message": "The request version does not exist."}
 
         await model.update_fields(released=True, result=const.VersionState.deploying)
 
@@ -483,7 +483,7 @@ class OrchestrationService(protocol.ServerSlice):
         # get latest version
         version_id = await data.ConfigurationModel.get_version_nr_latest_version(env.id)
         if version_id is None:
-            raise NotFound("No version available")
+            return 404, {"message": "No version available"}
 
         # filter agents
         allagents = await data.ConfigurationModel.get_agents(env.id, version_id)

--- a/src/inmanta/server/services/paramservice.py
+++ b/src/inmanta/server/services/paramservice.py
@@ -23,7 +23,6 @@ from inmanta import data
 from inmanta.const import ParameterSource
 from inmanta.protocol import methods
 from inmanta.protocol.common import attach_warnings
-from inmanta.protocol.exceptions import NotFound
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_DATABASE, SLICE_PARAM, SLICE_SERVER, SLICE_TRANSPORT
 from inmanta.server import config as opt
 from inmanta.server import protocol
@@ -111,7 +110,7 @@ class ParameterService(protocol.ServerSlice):
             if resource_id is not None:
                 out = await self.agentmanager.request_parameter(env.id, resource_id)
                 return out
-            raise NotFound()
+            return 404
 
         param = params[0]
 
@@ -244,7 +243,7 @@ class ParameterService(protocol.ServerSlice):
             params = await data.Parameter.get_list(environment=env.id, name=parameter_name, resource_id=resource_id)
 
         if len(params) == 0:
-            raise NotFound()
+            return 404
 
         param = params[0]
         await param.delete()

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -31,11 +31,7 @@ from inmanta.data import APILIMIT
 from inmanta.data.model import Resource, ResourceAction, ResourceType, ResourceVersionIdStr
 from inmanta.protocol import methods, methods_v2
 from inmanta.protocol.common import ReturnValue
-<<<<<<< HEAD
-from inmanta.protocol.exceptions import BadRequest, Conflict, NotFound
-=======
 from inmanta.protocol.exceptions import BadRequest
->>>>>>> parent of fa6eafe2... Use protocol.exceptions
 from inmanta.resources import Id
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_DATABASE, SLICE_RESOURCE, SLICE_TRANSPORT
 from inmanta.server import config as opt
@@ -234,11 +230,7 @@ class ResourceService(protocol.ServerSlice):
             return 409, {"message": "This agent is not currently the primary for the endpoint %s (sid: %s)" % (agent, sid)}
         if incremental_deploy:
             if version is not None:
-<<<<<<< HEAD
-                raise BadRequest("Cannot request increment for a specific version")
-=======
                 return 500, {"message": "Cannot request increment for a specific version"}
->>>>>>> parent of fa6eafe2... Use protocol.exceptions
             result = await self.get_resource_increment_for_agent(env, agent)
         else:
             result = await self.get_all_resources_for_agent(env, agent, version)
@@ -463,11 +455,7 @@ class ResourceService(protocol.ServerSlice):
                 if resource_action is None:
                     # new
                     if started is None:
-<<<<<<< HEAD
-                        raise BadRequest("A resource action can only be created with a start datetime.")
-=======
                         return 500, {"message": "A resource action can only be created with a start datetime."}
->>>>>>> parent of fa6eafe2... Use protocol.exceptions
 
                     version = Id.parse_id(resource_ids[0]).version
                     resource_action = data.ResourceAction(

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -31,7 +31,11 @@ from inmanta.data import APILIMIT
 from inmanta.data.model import Resource, ResourceAction, ResourceType, ResourceVersionIdStr
 from inmanta.protocol import methods, methods_v2
 from inmanta.protocol.common import ReturnValue
+<<<<<<< HEAD
 from inmanta.protocol.exceptions import BadRequest, Conflict, NotFound
+=======
+from inmanta.protocol.exceptions import BadRequest
+>>>>>>> parent of fa6eafe2... Use protocol.exceptions
 from inmanta.resources import Id
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_DATABASE, SLICE_RESOURCE, SLICE_TRANSPORT
 from inmanta.server import config as opt
@@ -194,7 +198,7 @@ class ResourceService(protocol.ServerSlice):
     ) -> Apireturn:
         resv = await data.Resource.get(env.id, resource_id)
         if resv is None:
-            raise NotFound("The resource with the given id does not exist in the given environment")
+            return 404, {"message": "The resource with the given id does not exist in the given environment"}
 
         if status is not None and status:
             return 200, {"status": resv.status}
@@ -227,10 +231,14 @@ class ResourceService(protocol.ServerSlice):
         self, env: data.Environment, agent: str, version: int, sid: uuid.UUID, incremental_deploy: bool
     ) -> Apireturn:
         if not self.agentmanager_service.is_primary(env, sid, agent):
-            raise Conflict("This agent is not currently the primary for the endpoint %s (sid: %s)" % (agent, sid))
+            return 409, {"message": "This agent is not currently the primary for the endpoint %s (sid: %s)" % (agent, sid)}
         if incremental_deploy:
             if version is not None:
+<<<<<<< HEAD
                 raise BadRequest("Cannot request increment for a specific version")
+=======
+                return 500, {"message": "Cannot request increment for a specific version"}
+>>>>>>> parent of fa6eafe2... Use protocol.exceptions
             result = await self.get_resource_increment_for_agent(env, agent)
         else:
             result = await self.get_all_resources_for_agent(env, agent, version)
@@ -241,12 +249,12 @@ class ResourceService(protocol.ServerSlice):
         if version is None:
             version = await data.ConfigurationModel.get_version_nr_latest_version(env.id)
             if version is None:
-                raise NotFound("No version available")
+                return 404, {"message": "No version available"}
 
         else:
             exists = await data.ConfigurationModel.version_exists(environment=env.id, version=version)
             if not exists:
-                raise NotFound("The given version does not exist")
+                return 404, {"message": "The given version does not exist"}
 
         deploy_model = []
 
@@ -284,7 +292,7 @@ class ResourceService(protocol.ServerSlice):
 
         version = await data.ConfigurationModel.get_version_nr_latest_version(env.id)
         if version is None:
-            raise NotFound("No version available")
+            return 404, {"message": "No version available"}
 
         increment = self._increment_cache.get(env.id, None)
         if increment is None:
@@ -455,7 +463,11 @@ class ResourceService(protocol.ServerSlice):
                 if resource_action is None:
                     # new
                     if started is None:
+<<<<<<< HEAD
                         raise BadRequest("A resource action can only be created with a start datetime.")
+=======
+                        return 500, {"message": "A resource action can only be created with a start datetime."}
+>>>>>>> parent of fa6eafe2... Use protocol.exceptions
 
                     version = Id.parse_id(resource_ids[0]).version
                     resource_action = data.ResourceAction(

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -34,7 +34,6 @@ from inmanta.ast import CompilerException
 from inmanta.config import Config
 from inmanta.const import AgentAction, AgentStatus, ParameterSource, ResourceState
 from inmanta.data import ENVIRONMENT_AGENT_TRIGGER_METHOD
-from inmanta.protocol.exceptions import Forbidden
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_AUTOSTARTED_AGENT_MANAGER, SLICE_PARAM, SLICE_SESSION_MANAGER
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.util import get_compiler_version
@@ -3447,8 +3446,8 @@ async def test_agentinstance_stops_deploying_when_stopped(
     assert agent_instance.is_stopped()
 
     # Agent cannot be unpaused after it is stopped
-    with pytest.raises(Forbidden):
-        agent_instance.unpause()
+    result, _ = agent_instance.unpause()
+    assert result == 403
     assert agent_instance._nq.finished()
     assert not agent_instance.is_enabled()
     assert agent_instance.is_stopped()

--- a/tests/server/test_incremental_deploy.py
+++ b/tests/server/test_incremental_deploy.py
@@ -311,10 +311,10 @@ async def test_deploy(server, agent: Agent, environment, caplog):
         assert len(payload["resources"]) == 0
 
         # Cannot request increment for specific version
-        with pytest.raises(BadRequest):
-            await resource_service.get_resources_for_agent(env, "agent1", version=version, incremental_deploy=True, sid=sid)
-        with pytest.raises(BadRequest):
-            await resource_service.get_resources_for_agent(env, "agent1", version=v2, incremental_deploy=True, sid=sid)
+        result, _ = await resource_service.get_resources_for_agent(env, "agent1", version=version, incremental_deploy=True, sid=sid)
+        assert result == 500
+        result, _ = await resource_service.get_resources_for_agent(env, "agent1", version=v2, incremental_deploy=True, sid=sid)
+        assert result == 500
 
     for record in caplog.records:
         assert record.levelname != "WARNING"

--- a/tests/server/test_incremental_deploy.py
+++ b/tests/server/test_incremental_deploy.py
@@ -30,7 +30,6 @@ import utils
 from inmanta import config, const, data
 from inmanta.agent.agent import Agent
 from inmanta.const import ResourceAction, ResourceState
-from inmanta.protocol.exceptions import BadRequest
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_ORCHESTRATION, SLICE_RESOURCE
 from inmanta.server.services.orchestrationservice import OrchestrationService
 from inmanta.server.services.resourceservice import ResourceService
@@ -311,7 +310,9 @@ async def test_deploy(server, agent: Agent, environment, caplog):
         assert len(payload["resources"]) == 0
 
         # Cannot request increment for specific version
-        result, _ = await resource_service.get_resources_for_agent(env, "agent1", version=version, incremental_deploy=True, sid=sid)
+        result, _ = await resource_service.get_resources_for_agent(
+            env, "agent1", version=version, incremental_deploy=True, sid=sid
+        )
         assert result == 500
         result, _ = await resource_service.get_resources_for_agent(env, "agent1", version=v2, incremental_deploy=True, sid=sid)
         assert result == 500

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -426,8 +426,8 @@ async def test_api(init_dataclasses_and_load_schema):
     report = await am.get_agent_process_report(agentid)
     assert (200, "X") == report
 
-    with pytest.raises(NotFound):
-        await am.get_agent_process_report(uuid4())
+    result, _ = await am.get_agent_process_report(uuid4())
+    assert result == 404
 
     code, all_agents = await am.list_agents(None)
     assert code == 200

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -385,6 +385,8 @@ async def test_api(init_dataclasses_and_load_schema):
 
     code, all_agents = await am.list_agent_processes(environment=env.id, expired=False)
     assert code == 200
+    agentid1 = all_agents["processes"][0]["sid"]
+    agentid2 = all_agents["processes"][1]["sid"]
 
     shouldbe = {
         "processes": [
@@ -422,7 +424,10 @@ async def test_api(init_dataclasses_and_load_schema):
 
     assert_equal_ish(shouldbe, all_agents)
 
-    report = await am.get_agent_process_report(agentid)
+    report = await am.get_agent_process_report(agentid1)
+    assert (200, "X") == report
+
+    report = await am.get_agent_process_report(agentid2)
     assert (200, "X") == report
 
     result, _ = await am.get_agent_process_report(uuid4())

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -30,7 +30,6 @@ from inmanta.agent import Agent, agent
 from inmanta.agent import config as agent_config
 from inmanta.const import AgentAction, AgentStatus
 from inmanta.protocol import Result
-from inmanta.protocol.exceptions import NotFound
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_AUTOSTARTED_AGENT_MANAGER
 from inmanta.server.agentmanager import AgentManager, SessionAction, SessionManager
 from inmanta.server.protocol import Session


### PR DESCRIPTION
# Description

Rollback changes that made `inmanta-lsm` fail.  (HttpError raising instead of ApiReponse return)

closes #2538 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] ~~Changelog entry~~
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
