### PR TITLE
fixed too restrictive typing (and coercing) of AttributeStateChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Handle failure in an event handler consistently for local and non-local agents (#2509)
 - Fix for cross agent dependencies responding to unavailable resources (#2501)
 - Handle JSON serialization errors in handler log messages (#1875)
+- Fixed too restrictive typing (and coercing) of AttributeStateChange (#2540)
 
 ## Upgrade notes
 - Ensure the database is backed up before executing an upgrade.

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -265,7 +265,7 @@ class HandlerContext(object):
     def change(self) -> const.Change:
         return self._change
 
-    def add_change(self, name: str, desired: typing.Any, current: typing.Any = None) -> None:
+    def add_change(self, name: str, desired: object, current: object = None) -> None:
         """
         Report a change of a field. This field is added to the set of updated fields
 

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -130,8 +130,8 @@ class AttributeStateChange(BaseModel):
     Changes in the attribute
     """
 
-    current: Optional[Union[SimpleTypes, List[SimpleTypes], Dict[str, SimpleTypes]]] = None
-    desired: Optional[Union[SimpleTypes, List[SimpleTypes], Dict[str, SimpleTypes]]] = None
+    current: Optional[Any] = None
+    desired: Optional[Any] = None
 
 
 class Event(BaseModel):

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -63,6 +63,12 @@ def test_context_changes():
     assert len(ctx.changes) == 1
     assert isinstance(ctx.changes["value"], AttributeStateChange)
 
+    # use dict with empty string
+    ctx.update_changes({"value": dict(current="", desired="value")})
+    assert len(ctx.changes) == 1
+    assert ctx.changes["value"].current == ""
+    assert ctx.changes["value"].desired == "value"
+
     # use tuple
     ctx.update_changes({"value": ("a", "b")})
     assert len(ctx.changes) == 1


### PR DESCRIPTION
# Description

fixed too restrictive typing (and coercing) of AttributeStateChange

closes #2540

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
