### PR TITLE
Downgrade importlib-metadata dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ psutil==5.7.3
 pyformance==0.4
 pydantic==1.7.3
 typing_inspect==0.6.0
-importlib_metadata==3.1.0
+importlib_metadata==2.1.0
 setuptools==50.3.2
 pip==20.3
 docstring-parser==0.7.3


### PR DESCRIPTION
# Description

The new pip dependency resolver is more strict, importlib-metadata has a conflict:
Tox requires importlib-metadata version <3, while requirements.txt has 3.1

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~Attached issue to pull request~
- [ ] ~Changelog entry~
- [ ] ~Type annotations are present~
- [ ] ~Code is clear and sufficiently documented~
- [ ] ~No (preventable) type errors (check using make mypy or make mypy-diff)~
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
