### PR TITLE
Fix for dependencies with extras used as constraints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,4 +44,9 @@ docstring-parser==0.7.3
 bumpversion==0.6.0
 sphinx-click==2.5.0
 rpdb==0.1.6
-inmanta-dev-dependencies[async,extension]==1.3.0
+inmanta-dev-dependencies==1.3.0
+tox==3.20.1
+tox-venv==0.4.0
+pytest-asyncio==0.14.0
+pytest-timeout==1.4.2
+


### PR DESCRIPTION
# Description

requirements.txt is used as a constraint file for some jobs in irt.
The issue is that it has a dependency, that has extras, and that's not allowed for constraints with the new pip resolver

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~Attached issue to pull request~
- [ ] ~Changelog entry~
- [ ] ~Type annotations are present~
- [ ] ~Code is clear and sufficiently documented~
- [ ] ~No (preventable) type errors (check using make mypy or make mypy-diff)~
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
