### PR TITLE
Split docs build and link check

### DIFF
--- a/docs/check_sphinx.py
+++ b/docs/check_sphinx.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 
 import pytest
-import pytest_dependency
 
 @pytest.fixture(scope="session")
 def build_docs(tmpdir_factory):
@@ -16,13 +15,11 @@ def build_docs(tmpdir_factory):
 
 
 @pytest.mark.build
-@pytest.mark.dependency()
 def test_build_docs(build_docs):
     _, _, _, build_proc = build_docs
     assert build_proc.check_returncode()
 
 
-@pytest.mark.dependency(depends=["test_build_docs"])
 def test_linkcheck(build_docs):
     docs_dir, doctrees, htmldir, _ = build_docs
     # Execute link check

--- a/docs/check_sphinx.py
+++ b/docs/check_sphinx.py
@@ -1,19 +1,30 @@
 import os
 import subprocess
-import pytest
 
-@pytest.fixture
-def build_docs(tmpdir):
+import pytest
+import pytest_dependency
+
+@pytest.fixture(scope="session")
+def build_docs(tmpdir_factory):
+    tmpdir = tmpdir_factory.mktemp("doctest")
     doctrees = tmpdir.join("doctrees")
     htmldir = tmpdir.join("html")
     docs_dir = os.path.dirname(os.path.abspath(__file__))
     # Ensure that all required files such as inmanta.pdf exist
-    subprocess.check_call(["make", "-C", docs_dir, "html", f"BUILDDIR={tmpdir}"])
-    return docs_dir, doctrees, htmldir
+    build_proc = subprocess.run(["make", "-C", docs_dir, "html", f"BUILDDIR={tmpdir}"], check=False)
+    return docs_dir, doctrees, htmldir, build_proc
 
 
+@pytest.mark.build
+@pytest.mark.dependency()
+def test_build_docs(build_docs):
+    _, _, _, build_proc = build_docs
+    assert build_proc.check_returncode()
+
+
+@pytest.mark.dependency(depends=["test_build_docs"])
 def test_linkcheck(build_docs):
-    docs_dir, doctrees, htmldir = build_docs
+    docs_dir, doctrees, htmldir, _ = build_docs
     # Execute link check
     subprocess.check_call(["sphinx-build", "-blinkcheck", "-d", str(doctrees), ".", str(htmldir)])
     # The link check for openapi.html is ignored in the conf.py file, since

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ more-itertools==8.6.0
 netifaces==0.10.9
 ply==3.11
 pytest-cover==3.0.0
+pytest-dependency==0.5.1
 pytest-instafail==0.4.2
 pytest-randomly==3.5.0
 pytest-sugar==0.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ more-itertools==8.6.0
 netifaces==0.10.9
 ply==3.11
 pytest-cover==3.0.0
-pytest-dependency==0.5.1
 pytest-instafail==0.4.2
 pytest-randomly==3.5.0
 pytest-sugar==0.9.4

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,13 @@ basepython=python3
 changedir=docs
 deps=pytest
     -rrequirements.txt
+commands=py.test -v check_sphinx.py -m build
+
+[testenv:docs-link-check]
+basepython=python3
+changedir=docs
+deps=pytest
+    -rrequirements.txt
 commands=py.test -v check_sphinx.py
 
 [testenv:mypy]


### PR DESCRIPTION
# Description

adds a seperate test that builds the docs and checks the returncode.
Using a mark only the build test can be called.
Replaced the original tox doc build test to call this.
Add an env to tox that performs both the build and linkcheck.

Should I add an entry to teh changelog?

Needed for https://github.com/inmanta/infra-tickets/issues/111
after this passed review, a nightly build needs to be configured to run the link-check

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~~Attached issue to pull request~~
- [ ] ~~Changelog entry~~
- [ ] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
