### PR TITLE
attempt to correct the install_model documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Bug fixes
 - Fix broken links in the documentation (#2495)
+- Fixed documentation of `install_mode`
 - Ensure all running compilations are stopped when the server is stopped (#2508)
 - Cleanup old entries in the agentprocess and agentinstance database tables (#2499)
 - Ensure the compiler service takes into account the environment variables set on the system (#2413)

--- a/docs/model_developers/configurationmodel.rst
+++ b/docs/model_developers/configurationmodel.rst
@@ -35,11 +35,10 @@ modules. project.yml defines the following settings:
     * ``license`` License the module is released under
     * ``copyright`` Copyright holder name and date.
     * ``install_mode`` This key determines what version of a module should be selected when a module
-      is downloaded. This is used when the module version is not "pinned" in the ``requires`` list.
-      The available values are:
+      is downloaded. The available values are:
 
         * release (default): Only use a released version, that is compatible with the current
-          compiler.
+          compiler and the version constraints defined ``requires`` list.
         * prerelease: Similar to release, but also prerelease versions are allowed.
         * master: Use the master branch.
 

--- a/docs/model_developers/configurationmodel.rst
+++ b/docs/model_developers/configurationmodel.rst
@@ -38,7 +38,7 @@ modules. project.yml defines the following settings:
       is downloaded. The available values are:
 
         * release (default): Only use a released version, that is compatible with the current
-          compiler and the version constraints defined ``requires`` list.
+          compiler and the version constraints defined in the ``requires`` list.
         * prerelease: Similar to release, but also prerelease versions are allowed.
         * master: Use the master branch.
 

--- a/docs/reference/projectyml.rst
+++ b/docs/reference/projectyml.rst
@@ -28,7 +28,7 @@ Project.yml defines the following settings:
       is downloaded. The available values are:
 
         * release (default): Only use a released version, that is compatible with the current
-          compiler and the version constraints defined ``requires`` list.
+          compiler and the version constraints defined in the ``requires`` list.
           A version is released when there is a tag on a commit. This tag should be a
           valid version identifier (PEP440) and should not be a prerelease version. Inmanta selects
           the latest available version (version sort based on PEP440).

--- a/docs/reference/projectyml.rst
+++ b/docs/reference/projectyml.rst
@@ -25,11 +25,11 @@ Project.yml defines the following settings:
     * ``downloadpath`` This value determines the path where Inmanta should download modules from
       repositories. This path is not automatically included in in modulepath!
     * ``install_mode`` This key determines what version of a module should be selected when a module
-      is downloaded. This is used when the module version is not "pinned" in the ``requires`` list.
-      The available values are:
+      is downloaded. The available values are:
 
         * release (default): Only use a released version, that is compatible with the current
-          compiler. A version is released when there is a tag on a commit. This tag should be a
+          compiler and the version constraints defined ``requires`` list.
+          A version is released when there is a tag on a commit. This tag should be a
           valid version identifier (PEP440) and should not be a prerelease version. Inmanta selects
           the latest available version (version sort based on PEP440).
         * prerelease: Similar to release, but also prerelease versions are allowed.
@@ -38,9 +38,8 @@ Project.yml defines the following settings:
     * ``repo`` This key requires a list (a yaml list) of repositories where Inmanta can find
       modules. Inmanta creates the git repo url by formatting {} or {0} with the name of the repo. If no formatter is present it
       appends the name of the module. Inmanta tries to clone a module in the order in which it is defined in this value.
-    * ``requires`` Model files import other modules. These imports do not determine a version, this
-      is based on the install_model setting. Modules and projects can constrain a version in the
-      requires setting. Similar to the module, version constraints are defined using `PEP440 syntax
+    * ``requires``  This key can contain a list (a yaml list) of version constraints for modules used in this project.
+      Similar to the module, version constraints are defined using `PEP440 syntax
       <https://www.python.org/dev/peps/pep-0440/#version-specifiers>`_.
     * ``freeze_recursive`` This key determined if the freeze command will behave recursively or not. If freeze_recursive is set to false or not set, 
       the current version of all modules imported directly in the main.cf file will be set in project.yml. If it is set to true, 


### PR DESCRIPTION
# Description

We discovered that the documentation of install mode is not in line with the actual behavior, this should correct the documentation

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
