### PR TITLE
Use the current year for the copyright year

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os, pkg_resources
+import sys, os, pkg_resources, datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Inmanta'
-copyright = '2019 Inmanta NV'
+copyright = f'{datetime.datetime.now().year} Inmanta NV'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
# Description

This sets the year always to the current year because we forget to bump it.

Not sure if a changelog entry is required for this.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
