### PR TITLE
Revert "Bump cryptography from 3.2.1 to 3.3 (#2560)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ click==7.1.2
 click-plugins==1.1.1
 colorlog==4.6.2
 cookiecutter==1.7.2
-cryptography==3.3
+cryptography==3.2.1
 execnet==1.7.1
 graphviz==0.15
 inmanta-sphinx==1.3.0


### PR DESCRIPTION
This reverts commit 54fd354856bc3de1cdddc8d9aa1f2335d9614ef5.

# Description

The new cryptography version breaks the rpm build. Until #2518 is resolved, we should use the previous version.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~Attached issue to pull request~
- [ ] ~Changelog entry~
- [ ] ~Type annotations are present~
- [ ] ~Code is clear and sufficiently documented~
- [ ] ~No (preventable) type errors (check using make mypy or make mypy-diff)~
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
