### PR TITLE
Revert "Bump cryptography from 3.2.1 to 3.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ click==7.1.2
 click-plugins==1.1.1
 colorlog==4.6.2
 cookiecutter==1.7.2
-cryptography==3.3
+cryptography==3.2.1
 execnet==1.7.1
 graphviz==0.15
 inmanta-sphinx==1.3.0


### PR DESCRIPTION
Reverts inmanta/inmanta#2566

I had a typo in the original comment to dependabot to ignore this, so it was merged again