### PR TITLE
Installing with tox should use the latest pip version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist = pep8,py36,mypy,docs
 skip_missing_interpreters=True
+requires = pip
 
 [testenv:py36]
 basepython=python3.6


### PR DESCRIPTION
# Description

A transitive dependency (chardet) gets a conflicting version, when the requirements are installed with the default (old) pip version with tox (9.0.3).
Newer pip versions handle this conflict correctly

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~Attached issue to pull request~
- [ ] ~Changelog entry~
- [ ] ~Type annotations are present~
- [ ] ~Code is clear and sufficiently documented~
- [ ] ~No (preventable) type errors (check using make mypy or make mypy-diff)~
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
