### PR TITLE
Remove outdated tox-venv dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,6 @@ sphinx-click==2.5.0
 rpdb==0.1.6
 inmanta-dev-dependencies==1.4.0
 tox==3.20.1
-tox-venv==0.4.0
 pytest-asyncio==0.14.0
 pytest-timeout==1.4.2
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = pep8,py36,mypy,docs
 skip_missing_interpreters=True
 requires = pip
+           virtualenv >= 20.2.2
 
 [testenv:py36]
 basepython=python3.6


### PR DESCRIPTION
# Description

- tox-venv has been deprecated (https://github.com/tox-dev/tox-venv), since virtualenv now creates venv style environments.
- virtualenv installs the latest pip by default

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~Attached issue to pull request~
- [ ] ~Changelog entry~
- [ ] ~Type annotations are present~
- [ ] ~Code is clear and sufficiently documented~
- [ ] ~No (preventable) type errors (check using make mypy or make mypy-diff)~
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
