### PR TITLE
explicitly added files to bumpversion file

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,10 +1,11 @@
 [bumpversion]
 current_version = 2020.7
 parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}
 	{major}.{minor}
 
 [bumpversion:part:minor]
 first_value = 1
 
+[bumpversion:file:setup.py]


### PR DESCRIPTION
# Description

Explicitly added files to bumpversion file. This will need to be cherry-picked to `iso4`.

part of inmanta/irt#393

# Self Check:

- [ ] Attached issue to pull request
- [ ] Changelog entry
