### PR TITLE
made pyproject.toml compatible with new irt build pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
-[tool.irt]
+[tool.irt.publish.python]
 public = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.irt]
+public = true


### PR DESCRIPTION
Part of inmanta/irt#439.
Will need to be cherry-picked to all iso<x> branches.

See inmanta/irt#447.