### PR TITLE
Allow version bumps for the pyjwt dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,4 @@ updates:
       # Conflict with tox
     - dependency-name: "importlib-metadata"
       versions: [">=3"]
-      # Breaking change
-    - dependency-name: "pyjwt"
-      versions: [">=2"]
 


### PR DESCRIPTION
# Description

Remove version bumps for pyjwt

closes inmanta/inmanta-core#2683

# Self Check:

- [x] Attached issue to pull request
- [ ] ~~Changelog entry~~
