### PR TITLE
Added centos_version field to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ files = [ "requirements.txt", "requirements.setup.txt",]
 centos_versions = [8]
 
 [tool.irt.build.rpm.enable_repo]
-el7 = [ "epel",]
 el8 = []
 
 [tool.irt.dependencies.npm.inmanta-dashboard]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ post_publish_hook_remote = "~/post_publish_hook.py"
 repo = "https://github.com/inmanta/inmanta-core"
 files = [ "requirements.txt", "requirements.setup.txt",]
 
+[tool.irt.build.rpm]
+centos_versions = [8]
+
 [tool.irt.build.rpm.enable_repo]
 el7 = [ "epel",]
 el8 = []


### PR DESCRIPTION
# Description

Mention in `pyproject.toml` file for which CentOS version an RPM should be build.

Part of inmanta/irt#918

# Self Check:

- [x] Attached issue to pull request
- [ ] ~~Changelog entry~~
