### PR TITLE
Make python version of RPM venv configurable

### DIFF
--- a/inmanta.spec
+++ b/inmanta.spec
@@ -249,6 +249,7 @@ exit
 %changelog
 * Tue Jan 11 2022 Arnaud Schoonjans <arnaud.schoonjans@inmanta.com> - 2021.2.2
 - Make python_version of RPM venv configurable
+
 * Mon Jan 18 2021 Arnaud Schoonjans <arnaud.schoonjans@inmanta.com> - 2016.3
 - Initial commit
 

--- a/inmanta.spec
+++ b/inmanta.spec
@@ -247,6 +247,8 @@ getent passwd inmanta >/dev/null || \
 exit
 
 %changelog
+* Tue Jan 11 2022 Arnaud Schoonjans <arnaud.schoonjans@inmanta.com> - 2021.2.2
+- Make python_version of RPM venv configurable
 * Mon Jan 18 2021 Arnaud Schoonjans <arnaud.schoonjans@inmanta.com> - 2016.3
 - Initial commit
 

--- a/inmanta.spec
+++ b/inmanta.spec
@@ -6,8 +6,9 @@
 # * buildid_egg: Build_tag inmanta pypi package
 # * inmanta_dashboard_version: Fully qualified version inmanta-dashboard NPM packge (version number + build_tag)
 # * inmanta_core_version: Fully qualified version inmanta-core pypi packge (version number + build_tag)
+# * python_version: Create an RPM containing a venv for this python version. Only pass
+#                   the version number. For example: "3.6", "3.9", etc.
 
-%define python_version 3.9
 %define undotted_python_version %(v=%{python_version}; echo "${v//\./}")
 %define venv %{buildroot}/opt/inmanta
 %define _p3 %{venv}/bin/python%{python_version}

--- a/inmanta.spec
+++ b/inmanta.spec
@@ -7,7 +7,7 @@
 # * inmanta_dashboard_version: Fully qualified version inmanta-dashboard NPM packge (version number + build_tag)
 # * inmanta_core_version: Fully qualified version inmanta-core pypi packge (version number + build_tag)
 
-%define python_version 3.6
+%define python_version 3.9
 %define undotted_python_version %(v=%{python_version}; echo "${v//\./}")
 %define venv %{buildroot}/opt/inmanta
 %define _p3 %{venv}/bin/python%{python_version}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,6 @@ files = [ "requirements.txt", "requirements.setup.txt",]
 centos_versions = [8]
 python_version = "python3.9"
 
-[tool.irt.build.python]
-python_versions = ["python3.9"]
-
 [tool.irt.build.rpm.enable_repo]
 el8 = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,10 @@ post_publish_hook_remote = "~/post_publish_hook.py"
 repo = "https://github.com/inmanta/inmanta-core"
 files = [ "requirements.txt", "requirements.setup.txt",]
 
+[tool.irt.build.rpm]
+centos_versions = [8]
+
 [tool.irt.build.rpm.enable_repo]
-el7 = [ "epel",]
 el8 = []
 
 [tool.irt.dependencies.npm.inmanta-dashboard]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ files = [ "requirements.txt", "requirements.setup.txt",]
 
 [tool.irt.build.rpm]
 centos_versions = [8]
+python_version = "python3.9"
+
+[tool.irt.build.python]
+python_versions = ["python3.9"]
 
 [tool.irt.build.rpm.enable_repo]
 el8 = []


### PR DESCRIPTION
# Description

This PR updates the RPM build config to make the python version of the RPM venv configurable. 

Part of inmanta/irt#917

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
