### PR TITLE
added highlights

### DIFF
--- a/changelogs/unreleased/75-upgrade-notes-00-modules-v2.yml
+++ b/changelogs/unreleased/75-upgrade-notes-00-modules-v2.yml
@@ -1,0 +1,18 @@
+description: Modules v2 changelog notes.
+
+sections:
+  feature: >-
+    Introduced the [v2 module format](https://docs.inmanta.com/community/latest/model_developers/modules.html#understanding-modules).
+    V2 modules offer better integration with the Python ecosystem with regards to
+    [distribution](https://docs.inmanta.com/community/latest/model_developers/modules.html#installing-modules),
+    dependency resolution and plugin loading. For more information on v2 modules, see how to
+    [add a v2 module source](https://docs.inmanta.com/community/latest/model_developers/developer_getting_started.html#v2-module-source),
+    [use a v2 module in your project](https://docs.inmanta.com/community/latest/model_developers/developer_getting_started.html#setting-up-a-module),
+    and [install v2 modules](https://docs.inmanta.com/community/latest/model_developers/modules.html#installing-modules).
+  upgrade-note: >-
+    Compiling a project no longer installs modules on the fly. Run `inmanta project install` to install modules. For more details see
+    [setting up a project](https://docs.inmanta.com/community/latest/model_developers/developer_getting_started.html#setting-up-a-project).
+
+change-type: patch
+destination-branches:
+  - master

--- a/changelogs/unreleased/75-upgrade-notes-10-module-install.yml
+++ b/changelogs/unreleased/75-upgrade-notes-10-module-install.yml
@@ -1,0 +1,8 @@
+description: Deprecation note for module install command
+
+sections:
+  deprecation-note: "`inmanta module install` no longer installs all modules for a project. This has moved to `inmanta project install`."
+
+change-type: patch
+destination-branches:
+  - master

--- a/changelogs/unreleased/75-upgrade-notes-10-python-environment.yml
+++ b/changelogs/unreleased/75-upgrade-notes-10-python-environment.yml
@@ -1,0 +1,8 @@
+description: Python environment changelog notes.
+
+sections:
+  upgrade-note: The compiler venv (`.env`) is no longer used. The compiler uses the active venv.
+
+change-type: patch
+destination-branches:
+  - master

--- a/changelogs/unreleased/75-upgrade-notes-20-pg13.yml
+++ b/changelogs/unreleased/75-upgrade-notes-20-pg13.yml
@@ -1,0 +1,9 @@
+description: PostgreSQL 13 upgrade note
+
+# Another change entry already exists with a feature note
+sections:
+  upgrade-note: The supported PostgreSQL version is now 13
+
+change-type: patch
+destination-branches:
+  - master

--- a/changelogs/unreleased/75-upgrade-notes-20-python-39.yml
+++ b/changelogs/unreleased/75-upgrade-notes-20-python-39.yml
@@ -1,0 +1,9 @@
+description: Added support for Python 3.9
+
+sections:
+  feature: "{{description}}"
+  upgrade-note: The supported Python version is now 3.9
+
+change-type: patch
+destination-branches:
+  - master

--- a/changelogs/unreleased/75-upgrade-notes-20-rhel8.yml
+++ b/changelogs/unreleased/75-upgrade-notes-20-rhel8.yml
@@ -1,0 +1,8 @@
+description: Dropped support for RHEL 7
+
+sections:
+  upgrade-note: This release requires RHEL 8
+
+change-type: patch
+destination-branches:
+  - master

--- a/changelogs/unreleased/75-upgrade-notes-handler-deploy.yml
+++ b/changelogs/unreleased/75-upgrade-notes-handler-deploy.yml
@@ -1,0 +1,10 @@
+description: Added deploy method to handlers for increased flexibility in responding to events
+issue-repo: inmanta-core
+issue-nr: 2940
+
+sections:
+  feature: "{{description}}"
+
+change-type: patch
+destination-branches:
+  - master

--- a/changelogs/unreleased/75-upgrade-notes-r-strings.yml
+++ b/changelogs/unreleased/75-upgrade-notes-r-strings.yml
@@ -1,0 +1,8 @@
+description: Added raw strings (r-strings) to the inmanta language
+
+sections:
+  feature: "{{description}} (https://docs.inmanta.com/community/latest/language.html#literals-values)"
+
+change-type: patch
+destination-branches:
+  - master

--- a/changelogs/unreleased/75-upgrade-notes-std.yml
+++ b/changelogs/unreleased/75-upgrade-notes-std.yml
@@ -1,0 +1,9 @@
+description: Added support for Jinja 3 to std module.
+
+sections:
+  feature: "{{description}}"
+  upgrade-note: Jinja templates are required to be compatible with [Jinja 3](https://jinja.palletsprojects.com/en/3.0.x/changes/#version-3-0-0).
+
+change-type: patch
+destination-branches:
+  - master

--- a/changelogs/unreleased/75-upgrade-notes-terraform.yml
+++ b/changelogs/unreleased/75-upgrade-notes-terraform.yml
@@ -1,0 +1,10 @@
+description: >-
+  Added terraform module. Allows to use native terraform providers without having to use terraform directly by using the
+  included model generator.
+
+sections:
+  feature: "{{description}} (https://docs.inmanta.com/community/latest/reference/modules/terraform.html)"
+
+change-type: patch
+destination-branches:
+  - master

--- a/changelogs/unreleased/75-upgrade-notes-vscode.yml
+++ b/changelogs/unreleased/75-upgrade-notes-vscode.yml
@@ -1,0 +1,9 @@
+description: Vscode changelog note
+
+sections:
+  feature: VSCode extension interacts with the Python extension to allow venv selection.
+  upgrade-note: An update of the VSCode extension is required for compatibility with this release.
+
+change-type: patch
+destination-branches:
+  - master

--- a/changelogs/unreleased/75-upgrade-notes-web-console-cache.yml
+++ b/changelogs/unreleased/75-upgrade-notes-web-console-cache.yml
@@ -1,0 +1,10 @@
+description: Added frontend browser cache changelog note.
+
+change-type: patch
+destination-branches:
+  - master
+
+sections:
+  upgrade-note: >-
+    Clear your browser cache after upgrading to remove the old redirection rule. If the cache is not cleared the ‘/’ route
+    will keep redirecting to ‘/dashboard’.

--- a/changelogs/unreleased/75-upgrade-notes-web-console.yml
+++ b/changelogs/unreleased/75-upgrade-notes-web-console.yml
@@ -1,0 +1,10 @@
+description: Extended web console functionality and made it the default front-end.
+
+sections:
+  feature: "{{description}}"
+  deprecation-note: >-
+    The inmanta dashboard is now deprecated in favor of the web console. It will be removed in a future major release.
+
+change-type: patch
+destination-branches:
+  - master


### PR DESCRIPTION
# Description

I decided to just take over all highlight change entries from the iso product. I believe all are relevant.

closes #75

# Self Check:

- [ ] Attached issue to pull request
- [ ] Changelog entry

# Full changelog

## Inmanta: unreleased changes (2022-01-28)

### New features

- Added the web console as the default front-end, replacing the dashboard (Issue #65)
- Introduced the [v2 module format](https://docs.inmanta.com/community/latest/model_developers/modules.html#understanding-modules). V2 modules offer better integration with the Python ecosystem with regards to [distribution](https://docs.inmanta.com/community/latest/model_developers/modules.html#installing-modules), dependency resolution and plugin loading. For more information on v2 modules, see how to [add a v2 module source](https://docs.inmanta.com/community/latest/model_developers/developer_getting_started.html#v2-module-source), [use a v2 module in your project](https://docs.inmanta.com/community/latest/model_developers/developer_getting_started.html#setting-up-a-module), and [install v2 modules](https://docs.inmanta.com/community/latest/model_developers/modules.html#installing-modules).
- Added support for Python 3.9
- Added deploy method to handlers for increased flexibility in responding to events (Issue inmanta/inmanta-core#2940)
- Added raw strings (r-strings) to the inmanta language (https://docs.inmanta.com/community/latest/language.html#literals-values)
- Added support for Jinja 3 to std module.
- Added terraform module. Allows to use native terraform providers without having to use terraform directly by using the included model generator. (https://docs.inmanta.com/community/latest/reference/modules/terraform.html)
- VSCode extension interacts with the Python extension to allow venv selection.
- Extended web console functionality and made it the default front-end.

### Upgrade notes

- Compiling a project no longer installs modules on the fly. Run `inmanta project install` to install modules. For more details see [setting up a project](https://docs.inmanta.com/community/latest/model_developers/developer_getting_started.html#setting-up-a-project).
- The compiler venv (`.env`) is no longer used. The compiler uses the active venv.
- The supported PostgreSQL version is now 13
- The supported Python version is now 3.9
- This release requires RHEL 8
- Jinja templates are required to be compatible with [Jinja 3](https://jinja.palletsprojects.com/en/3.0.x/changes/#version-3-0-0).
- An update of the VSCode extension is required for compatibility with this release.
- Clear your browser cache after upgrading to remove the old redirection rule. If the cache is not cleared the ‘/’ route will keep redirecting to ‘/dashboard’.
- The compiler and agent venv's with a Python version older than the Python version of the Inmanta server will be moved to an `.rpmsave` directory at installation time. (Issue inmanta/inmanta-service-orchestrator#234)

### Deprecation notes

- `inmanta module install` no longer installs all modules for a project. This has moved to `inmanta project install`.
- The inmanta dashboard is now deprecated in favor of the web console. It will be removed in a future major release.

