### PR TITLE
fixed docs config inheritance

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,8 +4,11 @@ import os
 import sys
 
 # import all names from core conf
-sys.path.append(os.path.dirname(__file__))
-from conf_core import *
+core_conf_file: str = os.path.abspath(os.path.join(os.path.dirname(__file__), "conf_core.py"))
+with open(core_conf_file, "r") as f:
+    code = compile(f.read(), core_conf_file, "exec")
+    # share this file's globals namespace (both for reading and for writing)
+    exec(code, globals())
 
 # override exclude patterns: don't exclude anything for product docs
 exclude_patterns = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,13 @@
 import os
 import sys
 
-# import all names from core conf
+# import all names from core conf:
+#   sphinx injects a global named `tags` into the conf.py namespace. Therefore, simply importing all names from the core config
+#   file (`from conf_core import *`) does not suffice because core_conf.py then lacks access to this global. Instead we follow a
+#   similar approach to sphinx itself (although a bit simpler because we're just proxying): exec the core config file with a
+#   shared globals namespace, both so conf_core.py can access the tags global and so all names from conf_core.py get get bound
+#   to this module's namespace.
+#   (sphinx implementation for reference: https://github.com/sphinx-doc/sphinx/blob/799385f5558a888d1a143bf703d06b66d6717fe4/sphinx/config.py#L329)
 core_conf_file: str = os.path.abspath(os.path.join(os.path.dirname(__file__), "conf_core.py"))
 with open(core_conf_file, "r") as f:
     code = compile(f.read(), core_conf_file, "exec")


### PR DESCRIPTION
# Description

Sphinx injects a global named `tags` into the `conf.py` namespace. Therefore, simply importing all names from the core config file does not suffice because `core_conf.py` then lacks access to this global. Instead I propose we follow a similar approach to sphinx itself (although a bit simpler because we're just proxying): exec the core config file with a shared globals namespace.

part of inmanta/inmanta-core#3721

# Self Check:

- [x] Attached issue to pull request
- [x] ~~Changelog entry~~
