### PR TITLE
made compatible with latest setuptools

### DIFF
--- a/changelogs/unreleased/setuptools-compatibility-fix.yml
+++ b/changelogs/unreleased/setuptools-compatibility-fix.yml
@@ -1,0 +1,6 @@
+description: "Compatibility fix for setuptools 61.0"
+change-type: patch
+issue-repo: irt
+issue-nr: 1074
+destination-branches:
+  - master

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,6 @@ setup(
         "inmanta-core>=5.0.0.dev",
         "inmanta-ui>=2.0.0.dev",
     ],
+    # explicitly declare packages so setuptools does not attempt auto discovery
+    packages=[],
 )


### PR DESCRIPTION
# Description

setuptools-61.0.0 introduced auto discovery for packages if no `packages` or `py_modules` is explicitly specified. This is enabled by default (see pypa/setuptools#3197 and [CHANGES](https://github.com/pypa/setuptools/blob/v61.0.0/CHANGES.rst#v6100)). Since our product packages are just meta packages that don't have any source packages this results in random directories being marked as a package. This PR explicitly sets `packages=[]`.

part of inmanta/irt#1074

# Self Check:

- [ ] Attached issue to pull request
- [ ] Changelog entry
