### PR TITLE
Container with empty env file

### DIFF
--- a/changelogs/unreleased/fix-container-env-loading.yml
+++ b/changelogs/unreleased/fix-container-env-loading.yml
@@ -1,0 +1,4 @@
+---
+description: Fix container environment loading issue when using empty env file and ssh
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/docker/resources/load-inmanta-env
+++ b/docker/resources/load-inmanta-env
@@ -1,8 +1,7 @@
 # Loading the content of the server env file if it is there
 if [ -f /etc/inmanta/env ]
 then
-  export $(cat /etc/inmanta/env | xargs)
-  export FOUND_INMANTA_ENV_FILE=true
+  export $(cat /etc/inmanta/env | xargs) FOUND_INMANTA_ENV_FILE=true
 else
   export FOUND_INMANTA_ENV_FILE=false
 fi


### PR DESCRIPTION
# Description

Fixed issue in container's `/usr/bin/load-inmanta-env` file: when the file is empty, the export command would print the environment variables, which messes up the ssh session setup for tools like rsync.  

The easy fix is to ensure that there is always at least one env set

# Self Check:

- [x] Changelog entry
