### PR TITLE
[TMP] remove python-slugify dependency to make the doc build pass

### DIFF
--- a/changelogs/unreleased/release-2023-02-temporarily-remove-python-slugify-dependency-to-pass-doc-build.yml
+++ b/changelogs/unreleased/release-2023-02-temporarily-remove-python-slugify-dependency-to-pass-doc-build.yml
@@ -1,3 +1,0 @@
-description: Temporarily remove dependency on python-slugify so that the release doc build passes. This commit has to be reverted once the build is successful.
-change-type: patch
-destination-branches: [master]

--- a/changelogs/unreleased/release-2023-02-temporarily-remove-python-slugify-dependency-to-pass-doc-build.yml
+++ b/changelogs/unreleased/release-2023-02-temporarily-remove-python-slugify-dependency-to-pass-doc-build.yml
@@ -1,0 +1,3 @@
+description: Temporarily remove dependency on python-slugify so that the release doc build passes. This commit has to be reverted once the build is successful.
+change-type: patch
+destination-branches: [master]

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,6 @@ pyformance==0.4
 PyJWT==2.6.0
 pyproject_hooks==1.0.0
 python-dateutil==2.8.2
-python-slugify==8.0.0
 PyYAML==6.0
 requests==2.28.2
 ruamel.yaml==0.17.21


### PR DESCRIPTION
# Description

Remove python-slugify dependency to make the doc build pass
This commit must be reverted once the doc build has passed.


# Self Check:

- [ ] Attached issue to pull request
- [ ] Changelog entry
