### PR TITLE
Add version constraint on cython build dependency

### DIFF
--- a/changelogs/unreleased/add-version-constraint-cython-build-dep.yml
+++ b/changelogs/unreleased/add-version-constraint-cython-build-dep.yml
@@ -1,0 +1,4 @@
+---
+description: Add version constraint cython<3 on the cython build dependency, because asyncpg is not yet compatible with cython>=3.
+change-type: patch
+destination-branches: [master]

--- a/requirements.setup.txt
+++ b/requirements.setup.txt
@@ -3,7 +3,8 @@
 # 2. pip download --no-build-isolation --check-build-dependencies --no-binary :all: dist/*.tar.gz
 build
 cffi>=1.12; platform_python_implementation != 'PyPy'
-cython
+# asyncpg is not compatible with cython>=3
+cython<3
 flit_core>=3.2.0,<4
 poetry-core>=1
 setuptools


### PR DESCRIPTION
# Description

Add version constraint `cython<3` on the cython build dependency, because asyncpg is not yet compatible with `cython>=3`.

Ticket to remove the version constraint again: https://github.com/inmanta/inmanta-service-orchestrator/issues/398

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
