### PR TITLE
dropped docs build exclude_patterns override

### DIFF
--- a/changelogs/unreleased/drop-exclude-patterns-override.yml
+++ b/changelogs/unreleased/drop-exclude-patterns-override.yml
@@ -1,0 +1,4 @@
+description: dropped docs build exclude_patterns override
+change-type: patch
+destination-branches:
+  - master

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,3 @@ with open(core_conf_file, "r") as f:
     code = compile(f.read(), core_conf_file, "exec")
     # share this file's globals namespace (both for reading and for writing)
     exec(code, globals())
-
-# override exclude patterns: don't exclude anything for product docs
-exclude_patterns = []


### PR DESCRIPTION
The `exclude_patterns` in core only contain `adr/*.md`. If we exclude it in core, I think we want to exclude it for the product as well.