### PR TITLE
Use Python 3.11 environment in OSS RPMs

### DIFF
--- a/changelogs/unreleased/build-rpms-with-a-py311-venv.yml
+++ b/changelogs/unreleased/build-rpms-with-a-py311-venv.yml
@@ -1,0 +1,8 @@
+---
+description: Added support for Python 3.11
+issue-nr: 6024
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master]
+sections:
+  feature: "{{description}}"

--- a/changelogs/unreleased/build-rpms-with-a-py311-venv.yml
+++ b/changelogs/unreleased/build-rpms-with-a-py311-venv.yml
@@ -1,5 +1,5 @@
 ---
-description: Added support for Python 3.11
+description: The RPMs now install a Python 3.11 environment.
 issue-nr: 6024
 issue-repo: inmanta-core
 change-type: patch

--- a/changelogs/unreleased/build-rpms-with-a-py311-venv.yml
+++ b/changelogs/unreleased/build-rpms-with-a-py311-venv.yml
@@ -5,4 +5,4 @@ issue-repo: inmanta-core
 change-type: patch
 destination-branches: [master]
 sections:
-  feature: "{{description}}"
+  upgrade-note: "{{description}}"

--- a/inmanta.spec
+++ b/inmanta.spec
@@ -62,9 +62,15 @@ BuildRequires:  openssl-devel >= 1:1.1.1
 Requires:       openssl >= 1:1.1.1
 %endif
 
+%if "%{#undotted_python_version}" == "2"
 BuildRequires:  python%{undotted_python_version}-devel
 Requires:       python%{undotted_python_version}
 Requires:       python%{undotted_python_version}-devel
+%else
+BuildRequires:  python%{python_version}-devel
+Requires:       python%{python_version}
+Requires:       python%{python_version}-devel
+%endif
 
 Obsoletes: python3-inmanta
 Obsoletes: python3-inmanta-core
@@ -120,6 +126,9 @@ fi
 # Fix shebang
 find %{venv}/bin/ -type f | xargs sed -i "s|%{buildroot}||g"
 find %{venv} -name RECORD | xargs sed -i "s|%{buildroot}||g"
+
+# Fix path in pyvenv.cfg file
+sed -i "s|%{buildroot}||g" %{venv}/pyvenv.cfg
 
 # Make sure we use the correct python version and don't have dangeling symlink
 ln -sf /usr/bin/python%{python_version} %{venv}/bin/python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ files = [ "requirements.txt" ]
 
 [tool.irt.build.rpm]
 centos_versions = [8, 9]
-python_version = "python3.9"
+python_version = "python3.11"
 
 [tool.irt.build.rpm.enable_repo]
 el8 = []


### PR DESCRIPTION
# Description

The RPMs now come with a Python 3.11 environment.

closes inmanta/inmanta-core#6024

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
