### PR TITLE
Update spec file

### DIFF
--- a/changelogs/unreleased/update-pkg-names-in-spec-file.yml
+++ b/changelogs/unreleased/update-pkg-names-in-spec-file.yml
@@ -1,0 +1,4 @@
+---
+description: Update the inmanta.spec file so that it's in-line with the fact that the name part of an sdist package separates its parts using an underscore instead of a hyphen.
+change-type: patch
+destination-branches: [master]

--- a/inmanta.spec
+++ b/inmanta.spec
@@ -98,7 +98,7 @@ Obsoletes:      python3-inmanta-agent
 %setup -T -D -a 1 -n inmanta-%{sourceversion_egg}
 # Unpack inmanta-core
 mkdir inmanta_core
-tar -xf dependencies/inmanta-core-*.tar.gz --strip-components=1 --directory inmanta_core
+tar -xf dependencies/inmanta_core-*.tar.gz --strip-components=1 --directory inmanta_core
 
 %build
 
@@ -312,3 +312,4 @@ exit
 
 * Mon Jan 18 2021 Arnaud Schoonjans <arnaud.schoonjans@inmanta.com> - 2016.3
 - Initial commit
+


### PR DESCRIPTION
# Description

Setuptools version `setuptools=69.3.1` and higher separates the parts of the name in the dist package name using underscores instead of  hyphens. This PR makes sure that the RPM build can handle the new naming schema.

Reference: https://setuptools.pypa.io/en/stable/history.html#id8

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
