### PR TITLE
Include logging config in docker image

### DIFF
--- a/changelogs/unreleased/add-logging-config.yml
+++ b/changelogs/unreleased/add-logging-config.yml
@@ -4,3 +4,5 @@ issue-nr: 527
 issue-repo: inmanta-service-orchestrator
 change-type: patch
 destination-branches: [master]
+sections:
+  upgrade-note: "The orchestrator docker image now writes the Inmanta server logs to both stdout and to /var/log/inmanta/server.log by default."

--- a/changelogs/unreleased/add-logging-config.yml
+++ b/changelogs/unreleased/add-logging-config.yml
@@ -1,0 +1,6 @@
+---
+description: Update the Dockerfile to include logging config
+issue-nr: 527
+issue-repo: inmanta-service-orchestrator
+change-type: patch
+destination-branches: [master]

--- a/docker/native_image/Dockerfile
+++ b/docker/native_image/Dockerfile
@@ -30,7 +30,7 @@ ENV INMANTA_SERVER_ENABLED_EXTENSIONS="ui"
 
 RUN --mount=type=bind,target=/inmanta_build_dir <<EOF
 # Create required directories
-mkdir -p /var/lib/inmanta /var/log/inmanta /usr/share/inmanta/web-console /usr/share/doc/inmanta-oss /etc/inmanta/{inmanta.d,logging}
+mkdir -p /var/lib/inmanta /var/log/inmanta /usr/share/inmanta/web-console /usr/share/doc/inmanta-oss /etc/inmanta/inmanta.d /etc/inmanta/logging
 # Copy files from build directory
 cp /inmanta_build_dir/product/LICENSE /usr/share/doc/inmanta-oss/
 cp /inmanta_build_dir/inmanta-core/misc/inmanta-workon-register.sh /usr/bin/

--- a/docker/native_image/Dockerfile
+++ b/docker/native_image/Dockerfile
@@ -38,7 +38,7 @@ cp /inmanta_build_dir/inmanta-core/misc/inmanta-workon-register.sh /usr/bin/
 cp /inmanta_build_dir/inmanta-core/misc/server_log_container.yml /etc/inmanta/logging/server.yml
 cat <<EOF >/etc/inmanta/inmanta.d/logging.cfg
 [logging]
-server = server.yml
+server = /etc/inmanta/logging/server.yml
 EOF
 # Install packages
 apt-get -y update

--- a/docker/native_image/Dockerfile
+++ b/docker/native_image/Dockerfile
@@ -30,10 +30,16 @@ ENV INMANTA_SERVER_ENABLED_EXTENSIONS="ui"
 
 RUN --mount=type=bind,target=/inmanta_build_dir <<EOF
 # Create required directories
-mkdir -p /var/lib/inmanta /var/log/inmanta /usr/share/inmanta/web-console /usr/share/doc/inmanta-oss
+mkdir -p /var/lib/inmanta /var/log/inmanta /usr/share/inmanta/web-console /usr/share/doc/inmanta-oss /etc/inmanta/{inmanta.d,logging}
 # Copy files from build directory
 cp /inmanta_build_dir/product/LICENSE /usr/share/doc/inmanta-oss/
 cp /inmanta_build_dir/inmanta-core/misc/inmanta-workon-register.sh /usr/bin/
+# Add logging configuration
+cp /inmanta_build_dir/inmanta-core/misc/server_log_container.yml /etc/inmanta/logging/server.yml
+cat <<EOF >/etc/inmanta/inmanta.d/logging.cfg
+[logging]
+server = server.yml
+EOF
 # Install packages
 apt-get -y update
 apt-get -y install git \

--- a/docker/native_image/Dockerfile
+++ b/docker/native_image/Dockerfile
@@ -36,10 +36,10 @@ cp /inmanta_build_dir/product/LICENSE /usr/share/doc/inmanta-oss/
 cp /inmanta_build_dir/inmanta-core/misc/inmanta-workon-register.sh /usr/bin/
 # Add logging configuration
 cp /inmanta_build_dir/inmanta-core/misc/server_log_container.yml /etc/inmanta/logging/server.yml
-cat <<EOF >/etc/inmanta/inmanta.d/logging.cfg
+cat <<EOF2 >/etc/inmanta/inmanta.d/logging.cfg
 [logging]
 server = /etc/inmanta/logging/server.yml
-EOF
+EOF2
 # Install packages
 apt-get -y update
 apt-get -y install git \


### PR DESCRIPTION
# Description

Include logging config in the docker image, so that the server logs are written to stdout and to file.

closes inmanta/inmanta-service-orchestrator#527

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
