### PR TITLE
Use the health API endpoint in the container health check

### DIFF
--- a/changelogs/unreleased/use-health-endpoint.yml
+++ b/changelogs/unreleased/use-health-endpoint.yml
@@ -1,0 +1,6 @@
+---
+description: "Use the GET /api/v2/health API endpoint in the health check of the docker container"
+change-type: patch
+destination-branches: [master]
+sections:
+  minor-improvement: "{{description}}"

--- a/docker/native_image/Dockerfile
+++ b/docker/native_image/Dockerfile
@@ -102,7 +102,7 @@ WORKDIR /var/lib/inmanta
 
 # Configure a healthcheck which validates that the api is responsive
 HEALTHCHECK --interval=10s --timeout=3s --start-period=5m --start-interval=5s --retries=3 \
-    CMD /opt/inmanta/bin/python -c "from inmanta import config as c, protocol as p; c.Config.load_config(config_dir='/etc/inmanta/inmanta.d'); r = p.SyncClient('client').get_server_status(); assert r.code == 200 and {s['name']: s for s in r.result['data']['slices']}['core.database']['status']['connected'], str(r.result)"
+    CMD /opt/inmanta/bin/python -c "from inmanta import config as c, protocol as p; c.Config.load_config(config_dir='/etc/inmanta/inmanta.d'); r = p.SyncClient('client').health(); assert r.code == 200, str(r.result)"
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/bin/inmanta"]
 CMD ["--log-file", "/var/log/inmanta/server.log", "--log-file-level", "INFO", "--timed-logs", "server", "--db-wait-time", "15"]


### PR DESCRIPTION
# Description

Use the `GET /api/v2/health` API endpoint in the health check of the docker container. This prevents the health check from failing if authentication is enabled on the server.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
