### PR TITLE
Unconstrain os version docker image

### DIFF
--- a/changelogs/unreleased/unconstrain-os-version-docker-image.yml
+++ b/changelogs/unreleased/unconstrain-os-version-docker-image.yml
@@ -1,0 +1,4 @@
+---
+description: "Don't put a constraint on the os version of the base docker image used to build the orchestrator container."
+change-type: patch
+destination-branches: [master]

--- a/docker/native_image/Dockerfile
+++ b/docker/native_image/Dockerfile
@@ -3,7 +3,7 @@
 # * A checkout of the inmanta-core repository in a directory called inmanta-core.
 # * A checkout of the product repository in a directory called product
 ARG PYTHON_VERSION_INMANTA_VENV
-FROM python:${PYTHON_VERSION_INMANTA_VENV}-bookworm
+FROM python:${PYTHON_VERSION_INMANTA_VENV}
 
 ARG PYTHON_VERSION_INMANTA_VENV
 ARG VERSION


### PR DESCRIPTION
# Description

Don't put a constraint on the os version of the base docker image used to build the orchestrator container.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
