### PR TITLE
Remove imagemagick and mercurial from the container image

### DIFF
--- a/changelogs/unreleased/remove-imagemagick-mercurial-from-container.yml
+++ b/changelogs/unreleased/remove-imagemagick-mercurial-from-container.yml
@@ -1,0 +1,4 @@
+---
+description: "Remove imagemagick and mercurial (and their orphaned dependencies) from the container. They are inherited from the python base image but not used, and only add attack surface."
+change-type: patch
+destination-branches: [master]

--- a/docker/native_image/Dockerfile
+++ b/docker/native_image/Dockerfile
@@ -58,6 +58,10 @@ apt-get -y install git \
                    cargo \
                    openssl \
                    tini
+# Remove packages that the python base image (buildpack-deps) ships but that we do not use, to
+# reduce the container's attack surface. --auto-remove also drops their now-orphaned dependencies
+# (imagemagick's image libraries: libheif, openexr, libde265, ...).
+apt-get purge -y --auto-remove imagemagick libmagickcore-dev libmagickwand-dev mercurial
 apt-get clean
 # Create venv
 python${PYTHON_VERSION_INMANTA_VENV} -m venv /opt/inmanta


### PR DESCRIPTION
_Claude here, opening this on behalf of Bart._

## What

Removes **imagemagick** and **mercurial** from the product container image.

Neither is installed by our Dockerfile - they come from the `python:<ver>[-trixie]` base image, which is built on `buildpack-deps` and bundles a large set of build tooling/libraries so arbitrary Python C-extensions can compile. We use none of it: there is no ImageMagick binding (`Wand`/`pgmagick`) in the venv, and we don't use mercurial.

The change purges them after our own `apt-get install`; `--auto-remove` also drops their now-orphaned dependencies - imagemagick's image libraries (`libheif`, `openexr`, `libde265`, `libraw`, `libwmf`, `tiff`, `openjpeg2`, `cairo`, `harfbuzz`, `gdk-pixbuf`, `graphite2`, ...).

## Why

Pure attack-surface reduction. On the released `service-orchestrator-9` image, imagemagick alone accounts for **28 CVEs** in a customer scan, and its orphaned image libraries add more. `git` and `gcc` (which we do use) are unaffected - they are manually-installed, and `--auto-remove` only reaps auto-marked orphans.

## Verification

Simulated in the base image (`apt-get purge -s --auto-remove imagemagick libmagickcore-dev libmagickwand-dev mercurial`): **116 packages removed, 0 essentials** (git, gcc, g++, make, libc6, libssl, openssl, ca-certificates, python, libpq5, libffi all retained). No venv dependency needs any of the removed libraries to build or run (checked the full `pip freeze`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
